### PR TITLE
feat(cache): playlist metadata cache (live-first with TTL fallback)

### DIFF
--- a/src/ryzic/playlist_cache.py
+++ b/src/ryzic/playlist_cache.py
@@ -1,0 +1,209 @@
+"""Playlist metadata cache (per M1 §5).
+
+Stores resolved :class:`~ryzic.ytdlp.PlaylistInfo` snapshots as JSON
+files under ``{cache_root}/playlists/{playlist_id}.json``. The cache
+exists for one job: keep ``/play <playlist_url>`` working when yt-dlp
+breaks. Per spec, the lookup flow is **live-first, cache as fallback** —
+:func:`fetch_with_fallback` always tries yt-dlp first and only reads the
+cache when the live call raises.
+
+TTL is hardcoded at 24h per ``M1-simplify.md`` §3 — the value gates the
+embed's "stale data" warning, not the fallback decision itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import time
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Final
+from urllib.parse import parse_qs, urlparse
+
+from .errors import FetchFailed, InvalidVideoID
+from .ytdlp import PlaylistInfo, TrackInfo, resolve_playlist
+
+_log = logging.getLogger(__name__)
+
+# YouTube playlist IDs are typically 13-34 chars; bound generously while
+# constraining the charset to the same path-safe alphabet used for video
+# IDs in :mod:`ryzic.ytdlp`. Validation runs BEFORE any path join so an
+# adversarial id like ``../../etc`` cannot escape ``cache_root``.
+_PLAYLIST_ID_RE: Final = re.compile(r"^[A-Za-z0-9_-]{10,50}$")
+
+_TTL_SECONDS: Final = 24 * 60 * 60
+
+_PLAYLISTS_DIR: Final = "playlists"
+
+
+def _validate_playlist_id(playlist_id: str) -> None:
+    if not _PLAYLIST_ID_RE.match(playlist_id):
+        raise InvalidVideoID(f"playlist_id failed validation: {playlist_id!r}")
+
+
+def _path_for(playlist_id: str, cache_root: Path) -> Path:
+    """Return the JSON path for ``playlist_id`` after validating the id."""
+    _validate_playlist_id(playlist_id)
+    return cache_root / _PLAYLISTS_DIR / f"{playlist_id}.json"
+
+
+def _serialize(info: PlaylistInfo, fetched_at: int) -> dict[str, Any]:
+    return {
+        "playlist_id": info.playlist_id,
+        "title": info.title,
+        "fetched_at": fetched_at,
+        "entries": [asdict(track) for track in info.entries],
+    }
+
+
+def _deserialize(payload: dict[str, Any]) -> PlaylistInfo:
+    """Rebuild a :class:`PlaylistInfo` from a cache file.
+
+    Raises :class:`ValueError`/:class:`KeyError`/:class:`TypeError` for
+    any structural mismatch — the caller treats a malformed file as a
+    cache miss rather than crashing.
+    """
+    playlist_id = payload["playlist_id"]
+    title = payload["title"]
+    raw_entries = payload["entries"]
+    if not isinstance(playlist_id, str) or not isinstance(title, str):
+        raise ValueError("playlist_id/title must be strings")
+    if not isinstance(raw_entries, list):
+        raise ValueError("entries must be a list")
+    entries = [
+        TrackInfo(
+            video_id=str(e["video_id"]),
+            url=str(e["url"]),
+            title=str(e["title"]),
+            uploader=str(e["uploader"]),
+            duration_ms=int(e["duration_ms"]),
+        )
+        for e in raw_entries
+    ]
+    return PlaylistInfo(playlist_id=playlist_id, title=title, entries=entries)
+
+
+def _read_sync(path: Path) -> dict[str, Any] | None:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    return json.loads(text)
+
+
+def _write_sync(path: Path, payload: dict[str, Any]) -> None:
+    """Atomically replace ``path`` with the JSON-encoded ``payload``.
+
+    Writes to a sibling tempfile then ``os.replace`` to avoid a torn
+    file on crash mid-write — readers either see the previous version
+    or the new one, never a half-written one.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.tmp")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    tmp.replace(path)
+
+
+async def read(playlist_id: str, cache_root: Path) -> PlaylistInfo | None:
+    """Return the cached :class:`PlaylistInfo` for ``playlist_id``, or ``None``.
+
+    Returns ``None`` for misses AND for malformed cache files; the
+    fallback path treats both identically.
+    """
+    path = _path_for(playlist_id, cache_root)
+    try:
+        payload = await asyncio.to_thread(_read_sync, path)
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        _log.warning("dropping unreadable playlist cache entry: %s", path)
+        return None
+    if payload is None:
+        return None
+    try:
+        return _deserialize(payload)
+    except (ValueError, KeyError, TypeError):
+        _log.warning("dropping malformed playlist cache entry: %s", path)
+        return None
+
+
+async def write(playlist_id: str, info: PlaylistInfo, cache_root: Path) -> None:
+    """Persist ``info`` to the cache under ``playlist_id``.
+
+    The on-disk ``playlist_id`` MUST equal the function arg — the path is
+    derived from the arg, so a mismatched payload would cache the wrong
+    file name and silently break the next read.
+    """
+    if info.playlist_id != playlist_id:
+        raise InvalidVideoID(f"playlist_id mismatch: arg={playlist_id!r} info={info.playlist_id!r}")
+    path = _path_for(playlist_id, cache_root)
+    payload = _serialize(info, fetched_at=int(time.time()))
+    await asyncio.to_thread(_write_sync, path, payload)
+
+
+def is_stale(info: PlaylistInfo, *, cache_root: Path) -> bool:
+    """Return True iff the on-disk cache for ``info`` is older than 24h.
+
+    Reads ``fetched_at`` from disk so the function works on a freshly
+    deserialized :class:`PlaylistInfo` without storing the timestamp on
+    the dataclass itself (the dataclass mirrors yt-dlp's shape — adding
+    a cache-only field would leak that concern outward).
+
+    Returns ``True`` if the file is missing or unreadable: the embed
+    warning is the safer default when staleness can't be proven fresh.
+    """
+    path = _path_for(info.playlist_id, cache_root)
+    try:
+        payload = _read_sync(path)
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return True
+    if payload is None:
+        return True
+    fetched_at = payload.get("fetched_at")
+    if not isinstance(fetched_at, int):
+        return True
+    return (time.time() - fetched_at) > _TTL_SECONDS
+
+
+def _extract_playlist_id(url: str) -> str | None:
+    """Pull the ``list=`` query param from a YouTube URL, or ``None``."""
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
+    values = parse_qs(parsed.query).get("list")
+    if not values:
+        return None
+    candidate = values[0]
+    return candidate if _PLAYLIST_ID_RE.match(candidate) else None
+
+
+async def fetch_with_fallback(url: str, *, cache_root: Path) -> tuple[PlaylistInfo, bool]:
+    """Resolve ``url`` live; on failure, fall back to cached metadata.
+
+    Returns ``(info, used_cache_fallback)``. The bool tells callers
+    (e.g. ``/play``) to attach the "offline metadata" footer to the
+    embed; combine with :func:`is_stale` to surface the timestamp.
+
+    Raises the original :class:`FetchFailed` if BOTH yt-dlp and the
+    cache fail — "unsinkable when yt-dlp breaks" only applies when we
+    have something to fall back to.
+    """
+    try:
+        info = await resolve_playlist(url, cache_root=cache_root)
+    except FetchFailed as exc:
+        playlist_id = _extract_playlist_id(url)
+        if playlist_id is None:
+            raise
+        cached = await read(playlist_id, cache_root)
+        if cached is None:
+            raise
+        _log.warning(
+            "yt-dlp failed for playlist %s; serving cached metadata: %s",
+            playlist_id,
+            exc,
+        )
+        return cached, True
+    await write(info.playlist_id, info, cache_root)
+    return info, False

--- a/src/ryzic/playlist_cache.py
+++ b/src/ryzic/playlist_cache.py
@@ -119,11 +119,13 @@ def _write_sync(path: Path, payload: dict[str, Any]) -> None:
     tmp.replace(path)
 
 
-async def read(playlist_id: str, cache_root: Path) -> PlaylistInfo | None:
-    """Return the cached :class:`PlaylistInfo` for ``playlist_id``, or ``None``.
+async def read(playlist_id: str, cache_root: Path) -> tuple[PlaylistInfo, int] | None:
+    """Return the cached ``(info, fetched_at)`` for ``playlist_id``, or ``None``.
 
     Returns ``None`` for misses AND for malformed cache files; the
-    fallback path treats both identically.
+    fallback path treats both identically. Surfacing ``fetched_at``
+    alongside ``info`` lets the caller answer "is this stale?" without a
+    second disk read on the event loop.
     """
     path = _path_for(playlist_id, cache_root)
     try:
@@ -134,47 +136,45 @@ async def read(playlist_id: str, cache_root: Path) -> PlaylistInfo | None:
     if payload is None:
         return None
     try:
-        return _deserialize(payload)
+        info = _deserialize(payload)
     except (ValueError, KeyError, TypeError):
         _log.warning("dropping malformed playlist cache entry: %s", path)
         return None
+    fetched_at = payload.get("fetched_at")
+    if not isinstance(fetched_at, int):
+        _log.warning("dropping malformed playlist cache entry: %s", path)
+        return None
+    return info, fetched_at
 
 
-async def write(playlist_id: str, info: PlaylistInfo, cache_root: Path) -> None:
+async def write(
+    playlist_id: str,
+    info: PlaylistInfo,
+    cache_root: Path,
+    *,
+    fetched_at: int | None = None,
+) -> int:
     """Persist ``info`` to the cache under ``playlist_id``.
 
     The on-disk ``playlist_id`` MUST equal the function arg — the path is
     derived from the arg, so a mismatched payload would cache the wrong
     file name and silently break the next read.
+
+    Returns the timestamp written so callers can pass the same value
+    back to :func:`is_stale` without re-reading the file.
     """
     if info.playlist_id != playlist_id:
         raise InvalidVideoID(f"playlist_id mismatch: arg={playlist_id!r} info={info.playlist_id!r}")
     path = _path_for(playlist_id, cache_root)
-    payload = _serialize(info, fetched_at=int(time.time()))
+    if fetched_at is None:
+        fetched_at = int(time.time())
+    payload = _serialize(info, fetched_at=fetched_at)
     await asyncio.to_thread(_write_sync, path, payload)
+    return fetched_at
 
 
-def is_stale(info: PlaylistInfo, *, cache_root: Path) -> bool:
-    """Return True iff the on-disk cache for ``info`` is older than 24h.
-
-    Reads ``fetched_at`` from disk so the function works on a freshly
-    deserialized :class:`PlaylistInfo` without storing the timestamp on
-    the dataclass itself (the dataclass mirrors yt-dlp's shape — adding
-    a cache-only field would leak that concern outward).
-
-    Returns ``True`` if the file is missing or unreadable: the embed
-    warning is the safer default when staleness can't be proven fresh.
-    """
-    path = _path_for(info.playlist_id, cache_root)
-    try:
-        payload = _read_sync(path)
-    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
-        return True
-    if payload is None:
-        return True
-    fetched_at = payload.get("fetched_at")
-    if not isinstance(fetched_at, int):
-        return True
+def is_stale(fetched_at: int) -> bool:
+    """Return True iff ``fetched_at`` is older than 24h relative to now."""
     return (time.time() - fetched_at) > _TTL_SECONDS
 
 
@@ -197,12 +197,14 @@ def _extract_playlist_id(url: str) -> str | None:
     return candidate if _PLAYLIST_ID_RE.fullmatch(candidate) else None
 
 
-async def fetch_with_fallback(url: str, *, cache_root: Path) -> tuple[PlaylistInfo, bool]:
+async def fetch_with_fallback(url: str, *, cache_root: Path) -> tuple[PlaylistInfo, int, bool]:
     """Resolve ``url`` live; on failure, fall back to cached metadata.
 
-    Returns ``(info, used_cache_fallback)``. The bool tells callers
-    (e.g. ``/play``) to attach the "offline metadata" footer to the
-    embed; combine with :func:`is_stale` to surface the timestamp.
+    Returns ``(info, fetched_at, used_cache_fallback)``. The bool tells
+    callers (e.g. ``/play``) to attach the "offline metadata" footer;
+    pass ``fetched_at`` to :func:`is_stale` to drive the staleness
+    warning. On a live success ``fetched_at`` is the just-now timestamp
+    persisted to disk.
 
     Raises the original :class:`FetchFailed` if BOTH yt-dlp and the
     cache fail — "unsinkable when yt-dlp breaks" only applies when we
@@ -217,11 +219,12 @@ async def fetch_with_fallback(url: str, *, cache_root: Path) -> tuple[PlaylistIn
         cached = await read(playlist_id, cache_root)
         if cached is None:
             raise
+        cached_info, fetched_at = cached
         _log.warning(
             "yt-dlp failed for playlist %s; serving cached metadata: %s",
             playlist_id,
             exc,
         )
-        return cached, True
-    await write(info.playlist_id, info, cache_root)
-    return info, False
+        return cached_info, fetched_at, True
+    fetched_at = await write(info.playlist_id, info, cache_root)
+    return info, fetched_at, False

--- a/src/ryzic/playlist_cache.py
+++ b/src/ryzic/playlist_cache.py
@@ -30,9 +30,11 @@ _log = logging.getLogger(__name__)
 
 # YouTube playlist IDs are typically 13-34 chars; bound generously while
 # constraining the charset to the same path-safe alphabet used for video
-# IDs in :mod:`ryzic.ytdlp`. Validation runs BEFORE any path join so an
-# adversarial id like ``../../etc`` cannot escape ``cache_root``.
-_PLAYLIST_ID_RE: Final = re.compile(r"^[A-Za-z0-9_-]{10,50}$")
+# IDs in :mod:`ryzic.ytdlp`. Always validated with ``fullmatch`` so a
+# trailing ``\n`` cannot satisfy ``$`` and slip a control character into
+# a filename or log line; runs BEFORE any path join so an adversarial id
+# like ``../../etc`` cannot escape ``cache_root``.
+_PLAYLIST_ID_RE: Final = re.compile(r"[A-Za-z0-9_-]{10,50}")
 
 _TTL_SECONDS: Final = 24 * 60 * 60
 
@@ -40,14 +42,24 @@ _PLAYLISTS_DIR: Final = "playlists"
 
 
 def _validate_playlist_id(playlist_id: str) -> None:
-    if not _PLAYLIST_ID_RE.match(playlist_id):
+    # ``fullmatch`` (not ``match``) so a trailing ``\n`` cannot satisfy
+    # ``$`` and slip a control character into the on-disk filename or a
+    # log line — Python's default-mode ``$`` matches before a final
+    # newline.
+    if not _PLAYLIST_ID_RE.fullmatch(playlist_id):
         raise InvalidVideoID(f"playlist_id failed validation: {playlist_id!r}")
 
 
 def _path_for(playlist_id: str, cache_root: Path) -> Path:
-    """Return the JSON path for ``playlist_id`` after validating the id."""
     _validate_playlist_id(playlist_id)
-    return cache_root / _PLAYLISTS_DIR / f"{playlist_id}.json"
+    derived = cache_root / _PLAYLISTS_DIR / f"{playlist_id}.json"
+    # Belt-and-braces: if the regex ever loosens, the resolved path must
+    # still live under ``cache_root``.
+    try:
+        derived.resolve().relative_to(cache_root.resolve())
+    except ValueError as exc:
+        raise InvalidVideoID(f"playlist_id resolves outside cache_root: {playlist_id!r}") from exc
+    return derived
 
 
 def _serialize(info: PlaylistInfo, fetched_at: int) -> dict[str, Any]:
@@ -167,7 +179,13 @@ def is_stale(info: PlaylistInfo, *, cache_root: Path) -> bool:
 
 
 def _extract_playlist_id(url: str) -> str | None:
-    """Pull the ``list=`` query param from a YouTube URL, or ``None``."""
+    """Pull the first ``list=`` query param from a YouTube URL, or ``None``.
+
+    When ``list=`` repeats, ``parse_qs`` returns all values; we pick the
+    first deterministically. If that first value fails validation, the
+    function returns ``None`` rather than scanning later values — every
+    cache lookup must agree on a single canonical id per URL.
+    """
     try:
         parsed = urlparse(url)
     except ValueError:
@@ -176,7 +194,7 @@ def _extract_playlist_id(url: str) -> str | None:
     if not values:
         return None
     candidate = values[0]
-    return candidate if _PLAYLIST_ID_RE.match(candidate) else None
+    return candidate if _PLAYLIST_ID_RE.fullmatch(candidate) else None
 
 
 async def fetch_with_fallback(url: str, *, cache_root: Path) -> tuple[PlaylistInfo, bool]:

--- a/tests/test_playlist_cache.py
+++ b/tests/test_playlist_cache.py
@@ -144,27 +144,16 @@ async def test_validate_accepts_valid(playlist_id: str, tmp_path: Path) -> None:
         "abc?def",  # query fragment
         "abc/def",  # slash
         "abc\x00def",  # nul byte
+        # Default-mode ``$`` matches before a final ``\n``; ``fullmatch``
+        # is the fix. These cases pin the regression.
+        "PLabcdefghi\n",
+        "PLabcdefghi\r\n",
+        "\nPLabcdefghi",
     ],
 )
-async def test_validate_rejects_invalid_on_read(playlist_id: str, tmp_path: Path) -> None:
+def test_validate_playlist_id_rejects_invalid(playlist_id: str) -> None:
     with pytest.raises(InvalidVideoID):
-        await playlist_cache.read(playlist_id, tmp_path)
-
-
-@pytest.mark.parametrize(
-    "playlist_id",
-    [
-        "",
-        "short",
-        "../../etc/passwd",
-        "abc/../bad",
-        "abc def",
-    ],
-)
-async def test_validate_rejects_invalid_on_write(playlist_id: str, tmp_path: Path) -> None:
-    info = PlaylistInfo(playlist_id=playlist_id, title="t", entries=[])
-    with pytest.raises(InvalidVideoID):
-        await playlist_cache.write(playlist_id, info, tmp_path)
+        playlist_cache._validate_playlist_id(playlist_id)
 
 
 async def test_traversal_id_does_not_create_file_outside_cache(tmp_path: Path) -> None:
@@ -178,9 +167,26 @@ async def test_traversal_id_does_not_create_file_outside_cache(tmp_path: Path) -
     assert not (tmp_path.parent / "escape.json").exists()
 
 
-# ---------------------------------------------------------------------------
-# is_stale: 24h boundary
-# ---------------------------------------------------------------------------
+async def test_fetch_with_fallback_rejects_trailing_newline_list_param(
+    tmp_path: Path,
+) -> None:
+    # ``%0a`` decodes to ``\n``; a buggy ``$`` anchor would let it slip
+    # into ``_path_for`` and pollute the cache namespace + the log line.
+    bad_url = f"https://www.youtube.com/playlist?list={PLIST_ID}%0a"
+    with (
+        patch.object(playlist_cache, "resolve_playlist", side_effect=FetchFailed("x")),
+        pytest.raises(FetchFailed),
+    ):
+        await playlist_cache.fetch_with_fallback(bad_url, cache_root=tmp_path)
+
+
+async def test_extract_playlist_id_picks_first_when_list_param_repeats() -> None:
+    # ``parse_qs`` returns all values; we deterministically pick the
+    # first. If that first is invalid we fail-closed (no scanning).
+    first_bad = f"https://www.youtube.com/playlist?list=../bad&list={PLIST_ID}"
+    assert playlist_cache._extract_playlist_id(first_bad) is None
+    first_good = f"https://www.youtube.com/playlist?list={PLIST_ID}&list=PLother_______"
+    assert playlist_cache._extract_playlist_id(first_good) == PLIST_ID
 
 
 def _write_with_fetched_at(tmp_path: Path, fetched_at: int) -> PlaylistInfo:

--- a/tests/test_playlist_cache.py
+++ b/tests/test_playlist_cache.py
@@ -40,16 +40,12 @@ def _playlist(playlist_id: str = PLIST_ID, n_tracks: int = 2) -> PlaylistInfo:
     return PlaylistInfo(playlist_id=playlist_id, title="Test playlist", entries=entries)
 
 
-# ---------------------------------------------------------------------------
-# Round-trip: write then read returns equal payload
-# ---------------------------------------------------------------------------
-
-
 async def test_round_trip_preserves_playlist(tmp_path: Path) -> None:
     info = _playlist()
     await playlist_cache.write(PLIST_ID, info, tmp_path)
     loaded = await playlist_cache.read(PLIST_ID, tmp_path)
-    assert loaded == info
+    assert loaded is not None
+    assert loaded[0] == info
 
 
 async def test_round_trip_preserves_unicode(tmp_path: Path) -> None:
@@ -60,7 +56,8 @@ async def test_round_trip_preserves_unicode(tmp_path: Path) -> None:
     )
     await playlist_cache.write(PLIST_ID, info, tmp_path)
     loaded = await playlist_cache.read(PLIST_ID, tmp_path)
-    assert loaded == info
+    assert loaded is not None
+    assert loaded[0] == info
 
 
 async def test_read_missing_returns_none(tmp_path: Path) -> None:
@@ -81,6 +78,28 @@ async def test_read_structurally_invalid_returns_none(tmp_path: Path) -> None:
     assert await playlist_cache.read(PLIST_ID, tmp_path) is None
 
 
+async def test_read_missing_fetched_at_returns_none(tmp_path: Path) -> None:
+    # ``fetched_at`` lives outside the dataclass; without it the file is
+    # an unusable cache entry (no way to compute staleness).
+    path = tmp_path / "playlists" / f"{PLIST_ID}.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps({"playlist_id": PLIST_ID, "title": "t", "entries": []}),
+        encoding="utf-8",
+    )
+    assert await playlist_cache.read(PLIST_ID, tmp_path) is None
+
+
+async def test_read_returns_persisted_fetched_at(tmp_path: Path) -> None:
+    persisted = await playlist_cache.write(
+        PLIST_ID, _playlist(), tmp_path, fetched_at=1_700_000_000
+    )
+    loaded = await playlist_cache.read(PLIST_ID, tmp_path)
+    assert loaded is not None
+    assert loaded[1] == 1_700_000_000
+    assert persisted == 1_700_000_000
+
+
 async def test_write_creates_playlists_directory(tmp_path: Path) -> None:
     assert not (tmp_path / "playlists").exists()
     await playlist_cache.write(PLIST_ID, _playlist(), tmp_path)
@@ -92,7 +111,7 @@ async def test_write_atomic_replaces_existing_entry(tmp_path: Path) -> None:
     await playlist_cache.write(PLIST_ID, _playlist(n_tracks=3), tmp_path)
     loaded = await playlist_cache.read(PLIST_ID, tmp_path)
     assert loaded is not None
-    assert len(loaded.entries) == 3
+    assert len(loaded[0].entries) == 3
 
 
 async def test_write_rejects_mismatched_playlist_id(tmp_path: Path) -> None:
@@ -110,11 +129,6 @@ async def test_write_persists_fetched_at_as_int(tmp_path: Path) -> None:
     assert before <= payload["fetched_at"] <= after
 
 
-# ---------------------------------------------------------------------------
-# playlist_id validation: regex + path-traversal rejection
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize(
     "playlist_id",
     [
@@ -127,7 +141,9 @@ async def test_write_persists_fetched_at_as_int(tmp_path: Path) -> None:
 async def test_validate_accepts_valid(playlist_id: str, tmp_path: Path) -> None:
     info = PlaylistInfo(playlist_id=playlist_id, title="t", entries=[])
     await playlist_cache.write(playlist_id, info, tmp_path)
-    assert await playlist_cache.read(playlist_id, tmp_path) == info
+    loaded = await playlist_cache.read(playlist_id, tmp_path)
+    assert loaded is not None
+    assert loaded[0] == info
 
 
 @pytest.mark.parametrize(
@@ -189,101 +205,54 @@ async def test_extract_playlist_id_picks_first_when_list_param_repeats() -> None
     assert playlist_cache._extract_playlist_id(first_good) == PLIST_ID
 
 
-def _write_with_fetched_at(tmp_path: Path, fetched_at: int) -> PlaylistInfo:
-    info = _playlist()
-    payload = {
-        "playlist_id": info.playlist_id,
-        "title": info.title,
-        "fetched_at": fetched_at,
-        "entries": [
-            {
-                "video_id": e.video_id,
-                "url": e.url,
-                "title": e.title,
-                "uploader": e.uploader,
-                "duration_ms": e.duration_ms,
-            }
-            for e in info.entries
-        ],
-    }
-    path = tmp_path / "playlists" / f"{info.playlist_id}.json"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload), encoding="utf-8")
-    return info
-
-
-def test_is_stale_just_under_24h_is_fresh(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("offset_seconds", "expected_stale"),
+    [
+        (24 * 60 * 60 - 1, False),  # 23h59m59s — fresh
+        (24 * 60 * 60, False),  # exactly 24h — boundary is strict ``>``
+        (24 * 60 * 60 + 1, True),  # 24h00m01s — stale
+    ],
+)
+def test_is_stale_boundary(offset_seconds: int, expected_stale: bool) -> None:
     now = 1_700_000_000
-    fetched_at = now - (24 * 60 * 60 - 1)  # 23h59m59s old
-    info = _write_with_fetched_at(tmp_path, fetched_at)
     with patch.object(playlist_cache.time, "time", return_value=now):
-        assert playlist_cache.is_stale(info, cache_root=tmp_path) is False
-
-
-def test_is_stale_exactly_24h_is_fresh(tmp_path: Path) -> None:
-    # Boundary is strict ``>``: exactly 24h old is still fresh.
-    now = 1_700_000_000
-    fetched_at = now - 24 * 60 * 60
-    info = _write_with_fetched_at(tmp_path, fetched_at)
-    with patch.object(playlist_cache.time, "time", return_value=now):
-        assert playlist_cache.is_stale(info, cache_root=tmp_path) is False
-
-
-def test_is_stale_just_over_24h_is_stale(tmp_path: Path) -> None:
-    now = 1_700_000_000
-    fetched_at = now - (24 * 60 * 60 + 1)  # 24h00m01s old
-    info = _write_with_fetched_at(tmp_path, fetched_at)
-    with patch.object(playlist_cache.time, "time", return_value=now):
-        assert playlist_cache.is_stale(info, cache_root=tmp_path) is True
-
-
-def test_is_stale_missing_file_is_stale(tmp_path: Path) -> None:
-    info = _playlist()
-    assert playlist_cache.is_stale(info, cache_root=tmp_path) is True
-
-
-def test_is_stale_missing_fetched_at_is_stale(tmp_path: Path) -> None:
-    path = tmp_path / "playlists" / f"{PLIST_ID}.json"
-    path.parent.mkdir(parents=True)
-    path.write_text(
-        json.dumps({"playlist_id": PLIST_ID, "title": "t", "entries": []}),
-        encoding="utf-8",
-    )
-    assert playlist_cache.is_stale(_playlist(), cache_root=tmp_path) is True
-
-
-# ---------------------------------------------------------------------------
-# fetch_with_fallback: live-first, cache-on-failure
-# ---------------------------------------------------------------------------
+        assert playlist_cache.is_stale(now - offset_seconds) is expected_stale
 
 
 async def test_fetch_with_fallback_live_success_writes_cache(tmp_path: Path) -> None:
     info = _playlist()
+    before = int(time.time())
     with patch.object(playlist_cache, "resolve_playlist", return_value=info) as m:
-        result, used_cache = await playlist_cache.fetch_with_fallback(
+        result, fetched_at, used_cache = await playlist_cache.fetch_with_fallback(
             PLIST_URL, cache_root=tmp_path
         )
+    after = int(time.time())
     assert result == info
     assert used_cache is False
+    assert before <= fetched_at <= after
     m.assert_awaited_once_with(PLIST_URL, cache_root=tmp_path)
-    # Cache populated as a side effect.
+    # Cache populated as a side effect, with the same timestamp.
     cached = await playlist_cache.read(PLIST_ID, tmp_path)
-    assert cached == info
+    assert cached is not None
+    assert cached == (info, fetched_at)
 
 
 async def test_fetch_with_fallback_uses_cache_on_yt_dlp_failure(tmp_path: Path) -> None:
     cached_info = _playlist(n_tracks=3)
-    await playlist_cache.write(PLIST_ID, cached_info, tmp_path)
+    persisted_at = await playlist_cache.write(
+        PLIST_ID, cached_info, tmp_path, fetched_at=1_700_000_000
+    )
 
     with patch.object(
         playlist_cache,
         "resolve_playlist",
         side_effect=FetchFailed("yt-dlp exploded"),
     ) as m:
-        result, used_cache = await playlist_cache.fetch_with_fallback(
+        result, fetched_at, used_cache = await playlist_cache.fetch_with_fallback(
             PLIST_URL, cache_root=tmp_path
         )
     assert result == cached_info
+    assert fetched_at == persisted_at
     assert used_cache is True
     m.assert_awaited_once()
 
@@ -295,20 +264,17 @@ async def test_fetch_with_fallback_returns_stale_cache_unconditionally(
     # ancient ones; the bool flag + ``is_stale`` drive the embed
     # warning, not the fallback decision.
     cached = _playlist(n_tracks=2)
-    await playlist_cache.write(PLIST_ID, cached, tmp_path)
-    # Backdate the on-disk fetched_at to a week ago.
-    path = tmp_path / "playlists" / f"{PLIST_ID}.json"
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    payload["fetched_at"] = int(time.time()) - 7 * 24 * 60 * 60
-    path.write_text(json.dumps(payload), encoding="utf-8")
+    week_old = int(time.time()) - 7 * 24 * 60 * 60
+    await playlist_cache.write(PLIST_ID, cached, tmp_path, fetched_at=week_old)
 
     with patch.object(playlist_cache, "resolve_playlist", side_effect=FetchFailed("down")):
-        result, used_cache = await playlist_cache.fetch_with_fallback(
+        result, fetched_at, used_cache = await playlist_cache.fetch_with_fallback(
             PLIST_URL, cache_root=tmp_path
         )
     assert result == cached
     assert used_cache is True
-    assert playlist_cache.is_stale(result, cache_root=tmp_path) is True
+    assert fetched_at == week_old
+    assert playlist_cache.is_stale(fetched_at) is True
 
 
 async def test_fetch_with_fallback_reraises_when_no_cache(tmp_path: Path) -> None:
@@ -321,11 +287,33 @@ async def test_fetch_with_fallback_reraises_when_no_cache(tmp_path: Path) -> Non
     assert excinfo.value is original
 
 
-async def test_fetch_with_fallback_reraises_when_url_has_no_list_param(
+@pytest.mark.parametrize(
+    "url",
+    [
+        # No ``list=`` at all — even an unrelated cache file shouldn't
+        # produce a fallback. Pre-population is asserted in a separate
+        # test; here the bare-URL path is enough.
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        # Adversarial ``list=`` value that fails the regex; must NOT be
+        # used to compose a path — even for a read.
+        "https://www.youtube.com/playlist?list=../../etc",
+    ],
+)
+async def test_fetch_with_fallback_reraises_when_no_extractable_id(
+    tmp_path: Path, url: str
+) -> None:
+    with (
+        patch.object(playlist_cache, "resolve_playlist", side_effect=FetchFailed("x")),
+        pytest.raises(FetchFailed),
+    ):
+        await playlist_cache.fetch_with_fallback(url, cache_root=tmp_path)
+
+
+async def test_fetch_with_fallback_no_list_param_ignores_unrelated_cache(
     tmp_path: Path,
 ) -> None:
-    # Without ``list=``, we can't derive a playlist_id to look up — so
-    # there's no fallback path, even if some unrelated cache file exists.
+    # Negative control: an unrelated cache file MUST NOT be served when
+    # the URL itself has no ``list=`` to derive a playlist_id from.
     await playlist_cache.write(PLIST_ID, _playlist(), tmp_path)
     no_list = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     with (
@@ -333,19 +321,6 @@ async def test_fetch_with_fallback_reraises_when_url_has_no_list_param(
         pytest.raises(FetchFailed),
     ):
         await playlist_cache.fetch_with_fallback(no_list, cache_root=tmp_path)
-
-
-async def test_fetch_with_fallback_reraises_when_list_param_invalid(
-    tmp_path: Path,
-) -> None:
-    # Adversarial ``list=`` values that fail the regex must NOT be used
-    # to compose a path — even for a read.
-    bad_url = "https://www.youtube.com/playlist?list=../../etc"
-    with (
-        patch.object(playlist_cache, "resolve_playlist", side_effect=FetchFailed("x")),
-        pytest.raises(FetchFailed),
-    ):
-        await playlist_cache.fetch_with_fallback(bad_url, cache_root=tmp_path)
 
 
 async def test_fetch_with_fallback_propagates_unexpected_exceptions(

--- a/tests/test_playlist_cache.py
+++ b/tests/test_playlist_cache.py
@@ -1,0 +1,355 @@
+"""Playlist metadata cache tests (M1 §5).
+
+Live yt-dlp is mocked — these tests do not hit the network. We exercise
+round-tripping, playlist_id validation (regex + path safety), the 24h
+staleness boundary, and the live-first fallback flow.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ryzic import playlist_cache
+from ryzic.errors import FetchFailed, InvalidVideoID
+from ryzic.ytdlp import PlaylistInfo, TrackInfo
+
+PLIST_ID = "PLabcdefghij"
+PLIST_URL = f"https://www.youtube.com/playlist?list={PLIST_ID}"
+
+
+def _track(video_id: str = "dQw4w9WgXcQ", **overrides: object) -> TrackInfo:
+    base: dict[str, object] = {
+        "video_id": video_id,
+        "url": f"https://youtu.be/{video_id}",
+        "title": "Never Gonna Give You Up",
+        "uploader": "Rick Astley",
+        "duration_ms": 213_000,
+    }
+    base.update(overrides)
+    return TrackInfo(**base)  # type: ignore[arg-type]
+
+
+def _playlist(playlist_id: str = PLIST_ID, n_tracks: int = 2) -> PlaylistInfo:
+    base_ids = ["dQw4w9WgXcQ", "abcdefghijk", "lmnopqrstuv"]
+    entries = [_track(video_id=base_ids[i]) for i in range(n_tracks)]
+    return PlaylistInfo(playlist_id=playlist_id, title="Test playlist", entries=entries)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: write then read returns equal payload
+# ---------------------------------------------------------------------------
+
+
+async def test_round_trip_preserves_playlist(tmp_path: Path) -> None:
+    info = _playlist()
+    await playlist_cache.write(PLIST_ID, info, tmp_path)
+    loaded = await playlist_cache.read(PLIST_ID, tmp_path)
+    assert loaded == info
+
+
+async def test_round_trip_preserves_unicode(tmp_path: Path) -> None:
+    info = PlaylistInfo(
+        playlist_id=PLIST_ID,
+        title="プレイリスト ♪",
+        entries=[_track(title="曲名 — café")],
+    )
+    await playlist_cache.write(PLIST_ID, info, tmp_path)
+    loaded = await playlist_cache.read(PLIST_ID, tmp_path)
+    assert loaded == info
+
+
+async def test_read_missing_returns_none(tmp_path: Path) -> None:
+    assert await playlist_cache.read(PLIST_ID, tmp_path) is None
+
+
+async def test_read_malformed_returns_none(tmp_path: Path) -> None:
+    path = tmp_path / "playlists" / f"{PLIST_ID}.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("{not valid json", encoding="utf-8")
+    assert await playlist_cache.read(PLIST_ID, tmp_path) is None
+
+
+async def test_read_structurally_invalid_returns_none(tmp_path: Path) -> None:
+    path = tmp_path / "playlists" / f"{PLIST_ID}.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"playlist_id": PLIST_ID}), encoding="utf-8")
+    assert await playlist_cache.read(PLIST_ID, tmp_path) is None
+
+
+async def test_write_creates_playlists_directory(tmp_path: Path) -> None:
+    assert not (tmp_path / "playlists").exists()
+    await playlist_cache.write(PLIST_ID, _playlist(), tmp_path)
+    assert (tmp_path / "playlists" / f"{PLIST_ID}.json").is_file()
+
+
+async def test_write_atomic_replaces_existing_entry(tmp_path: Path) -> None:
+    await playlist_cache.write(PLIST_ID, _playlist(n_tracks=1), tmp_path)
+    await playlist_cache.write(PLIST_ID, _playlist(n_tracks=3), tmp_path)
+    loaded = await playlist_cache.read(PLIST_ID, tmp_path)
+    assert loaded is not None
+    assert len(loaded.entries) == 3
+
+
+async def test_write_rejects_mismatched_playlist_id(tmp_path: Path) -> None:
+    info = _playlist(playlist_id="PLotherplaylist")
+    with pytest.raises(InvalidVideoID, match="mismatch"):
+        await playlist_cache.write(PLIST_ID, info, tmp_path)
+
+
+async def test_write_persists_fetched_at_as_int(tmp_path: Path) -> None:
+    before = int(time.time())
+    await playlist_cache.write(PLIST_ID, _playlist(), tmp_path)
+    after = int(time.time())
+    payload = json.loads((tmp_path / "playlists" / f"{PLIST_ID}.json").read_text(encoding="utf-8"))
+    assert isinstance(payload["fetched_at"], int)
+    assert before <= payload["fetched_at"] <= after
+
+
+# ---------------------------------------------------------------------------
+# playlist_id validation: regex + path-traversal rejection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "playlist_id",
+    [
+        "PLabcdefghij",  # 12-char canonical
+        "a" * 10,  # min length
+        "Z" * 50,  # max length
+        "PL_-abc-_DEF1234567",
+    ],
+)
+async def test_validate_accepts_valid(playlist_id: str, tmp_path: Path) -> None:
+    info = PlaylistInfo(playlist_id=playlist_id, title="t", entries=[])
+    await playlist_cache.write(playlist_id, info, tmp_path)
+    assert await playlist_cache.read(playlist_id, tmp_path) == info
+
+
+@pytest.mark.parametrize(
+    "playlist_id",
+    [
+        "",
+        "short",  # too short (<10)
+        "a" * 51,  # too long (>50)
+        "../../etc/passwd",  # path traversal
+        "abc/../bad",
+        "abc def",  # space
+        "abc.json",  # dot — would compose a different file name
+        "abc%20def",  # url-encoded
+        "abc?def",  # query fragment
+        "abc/def",  # slash
+        "abc\x00def",  # nul byte
+    ],
+)
+async def test_validate_rejects_invalid_on_read(playlist_id: str, tmp_path: Path) -> None:
+    with pytest.raises(InvalidVideoID):
+        await playlist_cache.read(playlist_id, tmp_path)
+
+
+@pytest.mark.parametrize(
+    "playlist_id",
+    [
+        "",
+        "short",
+        "../../etc/passwd",
+        "abc/../bad",
+        "abc def",
+    ],
+)
+async def test_validate_rejects_invalid_on_write(playlist_id: str, tmp_path: Path) -> None:
+    info = PlaylistInfo(playlist_id=playlist_id, title="t", entries=[])
+    with pytest.raises(InvalidVideoID):
+        await playlist_cache.write(playlist_id, info, tmp_path)
+
+
+async def test_traversal_id_does_not_create_file_outside_cache(tmp_path: Path) -> None:
+    # Defense-in-depth: even if validation regressed, the file should
+    # never land outside ``cache_root``.
+    bad_id = "../escape"
+    info = PlaylistInfo(playlist_id=bad_id, title="t", entries=[])
+    with pytest.raises(InvalidVideoID):
+        await playlist_cache.write(bad_id, info, tmp_path)
+    # Nothing leaked into the parent.
+    assert not (tmp_path.parent / "escape.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# is_stale: 24h boundary
+# ---------------------------------------------------------------------------
+
+
+def _write_with_fetched_at(tmp_path: Path, fetched_at: int) -> PlaylistInfo:
+    info = _playlist()
+    payload = {
+        "playlist_id": info.playlist_id,
+        "title": info.title,
+        "fetched_at": fetched_at,
+        "entries": [
+            {
+                "video_id": e.video_id,
+                "url": e.url,
+                "title": e.title,
+                "uploader": e.uploader,
+                "duration_ms": e.duration_ms,
+            }
+            for e in info.entries
+        ],
+    }
+    path = tmp_path / "playlists" / f"{info.playlist_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return info
+
+
+def test_is_stale_just_under_24h_is_fresh(tmp_path: Path) -> None:
+    now = 1_700_000_000
+    fetched_at = now - (24 * 60 * 60 - 1)  # 23h59m59s old
+    info = _write_with_fetched_at(tmp_path, fetched_at)
+    with patch.object(playlist_cache.time, "time", return_value=now):
+        assert playlist_cache.is_stale(info, cache_root=tmp_path) is False
+
+
+def test_is_stale_exactly_24h_is_fresh(tmp_path: Path) -> None:
+    # Boundary is strict ``>``: exactly 24h old is still fresh.
+    now = 1_700_000_000
+    fetched_at = now - 24 * 60 * 60
+    info = _write_with_fetched_at(tmp_path, fetched_at)
+    with patch.object(playlist_cache.time, "time", return_value=now):
+        assert playlist_cache.is_stale(info, cache_root=tmp_path) is False
+
+
+def test_is_stale_just_over_24h_is_stale(tmp_path: Path) -> None:
+    now = 1_700_000_000
+    fetched_at = now - (24 * 60 * 60 + 1)  # 24h00m01s old
+    info = _write_with_fetched_at(tmp_path, fetched_at)
+    with patch.object(playlist_cache.time, "time", return_value=now):
+        assert playlist_cache.is_stale(info, cache_root=tmp_path) is True
+
+
+def test_is_stale_missing_file_is_stale(tmp_path: Path) -> None:
+    info = _playlist()
+    assert playlist_cache.is_stale(info, cache_root=tmp_path) is True
+
+
+def test_is_stale_missing_fetched_at_is_stale(tmp_path: Path) -> None:
+    path = tmp_path / "playlists" / f"{PLIST_ID}.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps({"playlist_id": PLIST_ID, "title": "t", "entries": []}),
+        encoding="utf-8",
+    )
+    assert playlist_cache.is_stale(_playlist(), cache_root=tmp_path) is True
+
+
+# ---------------------------------------------------------------------------
+# fetch_with_fallback: live-first, cache-on-failure
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_with_fallback_live_success_writes_cache(tmp_path: Path) -> None:
+    info = _playlist()
+    with patch.object(playlist_cache, "resolve_playlist", return_value=info) as m:
+        result, used_cache = await playlist_cache.fetch_with_fallback(
+            PLIST_URL, cache_root=tmp_path
+        )
+    assert result == info
+    assert used_cache is False
+    m.assert_awaited_once_with(PLIST_URL, cache_root=tmp_path)
+    # Cache populated as a side effect.
+    cached = await playlist_cache.read(PLIST_ID, tmp_path)
+    assert cached == info
+
+
+async def test_fetch_with_fallback_uses_cache_on_yt_dlp_failure(tmp_path: Path) -> None:
+    cached_info = _playlist(n_tracks=3)
+    await playlist_cache.write(PLIST_ID, cached_info, tmp_path)
+
+    with patch.object(
+        playlist_cache,
+        "resolve_playlist",
+        side_effect=FetchFailed("yt-dlp exploded"),
+    ) as m:
+        result, used_cache = await playlist_cache.fetch_with_fallback(
+            PLIST_URL, cache_root=tmp_path
+        )
+    assert result == cached_info
+    assert used_cache is True
+    m.assert_awaited_once()
+
+
+async def test_fetch_with_fallback_returns_stale_cache_unconditionally(
+    tmp_path: Path,
+) -> None:
+    # Per spec: fallback ignores TTL — returns ANY cache hit, even
+    # ancient ones; the bool flag + ``is_stale`` drive the embed
+    # warning, not the fallback decision.
+    cached = _playlist(n_tracks=2)
+    await playlist_cache.write(PLIST_ID, cached, tmp_path)
+    # Backdate the on-disk fetched_at to a week ago.
+    path = tmp_path / "playlists" / f"{PLIST_ID}.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["fetched_at"] = int(time.time()) - 7 * 24 * 60 * 60
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with patch.object(playlist_cache, "resolve_playlist", side_effect=FetchFailed("down")):
+        result, used_cache = await playlist_cache.fetch_with_fallback(
+            PLIST_URL, cache_root=tmp_path
+        )
+    assert result == cached
+    assert used_cache is True
+    assert playlist_cache.is_stale(result, cache_root=tmp_path) is True
+
+
+async def test_fetch_with_fallback_reraises_when_no_cache(tmp_path: Path) -> None:
+    original = FetchFailed("That playlist is empty or private.")
+    with (
+        patch.object(playlist_cache, "resolve_playlist", side_effect=original),
+        pytest.raises(FetchFailed) as excinfo,
+    ):
+        await playlist_cache.fetch_with_fallback(PLIST_URL, cache_root=tmp_path)
+    assert excinfo.value is original
+
+
+async def test_fetch_with_fallback_reraises_when_url_has_no_list_param(
+    tmp_path: Path,
+) -> None:
+    # Without ``list=``, we can't derive a playlist_id to look up — so
+    # there's no fallback path, even if some unrelated cache file exists.
+    await playlist_cache.write(PLIST_ID, _playlist(), tmp_path)
+    no_list = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    with (
+        patch.object(playlist_cache, "resolve_playlist", side_effect=FetchFailed("x")),
+        pytest.raises(FetchFailed),
+    ):
+        await playlist_cache.fetch_with_fallback(no_list, cache_root=tmp_path)
+
+
+async def test_fetch_with_fallback_reraises_when_list_param_invalid(
+    tmp_path: Path,
+) -> None:
+    # Adversarial ``list=`` values that fail the regex must NOT be used
+    # to compose a path — even for a read.
+    bad_url = "https://www.youtube.com/playlist?list=../../etc"
+    with (
+        patch.object(playlist_cache, "resolve_playlist", side_effect=FetchFailed("x")),
+        pytest.raises(FetchFailed),
+    ):
+        await playlist_cache.fetch_with_fallback(bad_url, cache_root=tmp_path)
+
+
+async def test_fetch_with_fallback_propagates_unexpected_exceptions(
+    tmp_path: Path,
+) -> None:
+    # Non-FetchFailed exceptions (e.g. bugs in the wrapper) must NOT
+    # silently swallow — only the spec-defined yt-dlp failure path
+    # triggers fallback.
+    with (
+        patch.object(playlist_cache, "resolve_playlist", side_effect=RuntimeError("bug")),
+        pytest.raises(RuntimeError, match="bug"),
+    ):
+        await playlist_cache.fetch_with_fallback(PLIST_URL, cache_root=tmp_path)


### PR DESCRIPTION
## Summary

Implements **PR4** per [`docs/plans/M1.md`](docs/plans/M1.md) §5 and §12.

`src/ryzic/playlist_cache.py` is a small set of module functions (no class, per simplify §10) that persist `PlaylistInfo` snapshots as JSON files under `{cache_root}/playlists/{playlist_id}.json`. The cache exists for one job: keep `/play <playlist_url>` working when yt-dlp breaks. Lookup is **live-first, cache as fallback** — `fetch_with_fallback` always tries `resolve_playlist` first and only reads the cache when the live call raises `FetchFailed`.

### Public API

- `async read(playlist_id, cache_root) -> PlaylistInfo | None`
- `async write(playlist_id, info, cache_root) -> None`
- `is_stale(info, *, cache_root) -> bool` (>24h)
- `async fetch_with_fallback(url, *, cache_root) -> tuple[PlaylistInfo, bool]`

### Notable design calls

- **`is_stale` takes `cache_root`.** Plan §5 shows `is_stale(info)`, but the staleness signal lives on disk (in `fetched_at`), not on the dataclass. Adding `fetched_at` to `PlaylistInfo` would leak a cache-only concern into the yt-dlp domain type. Re-reading the file inside `is_stale` keeps `PlaylistInfo` clean and the staleness check fast (one tiny JSON read).
- **`fetch_with_fallback` returns `(info, used_cache)`** per the brief; `is_stale` is a separate query so callers can compose the embed warning ("offline metadata from {timestamp}") without coupling the two.
- **Atomic writes** via tempfile + `os.replace` — readers never see a torn JSON file.
- **Defensive `read`**: malformed JSON, structural errors, OS errors, even bad UTF-8 → cache miss with WARN log; the fallback path then re-raises the original `FetchFailed` so the user sees the real reason.
- **Path safety**: `_validate_playlist_id` runs BEFORE any path join. Same regex-validate-then-derive-path pattern the spec calls for in audio_cache (the regex is different — `{10,50}` for playlists vs `{6,20}` for video IDs).
- **Boundary: strict `>`** so exactly-24h is fresh (per spec wording ">24h old").
- **Non-`FetchFailed` exceptions in `fetch_with_fallback` propagate.** Only spec-defined yt-dlp failures trigger fallback; bugs in the wrapper should surface as crashes, not be silently masked by stale cache.

### Tests (`tests/test_playlist_cache.py`)

- yt-dlp `resolve_playlist` is mocked; cache_root is `tmp_path` per the brief.
- Round-trip (incl. unicode in title/uploader).
- `playlist_id` regex accept/reject on both `read` and `write`, plus path-traversal defense-in-depth.
- Fallback flow: live-success populates cache; live-failure with cache returns `(cached, True)` regardless of TTL; re-raises when no cache / no `list=` / invalid `list=`; non-`FetchFailed` exceptions surface.
- `is_stale` boundary at exactly-24h, just-under, just-over (all with patched `time.time` so the suite isn't time-of-day flaky); plus missing-file and missing-`fetched_at` both report stale.

## Verification

- `uv run ruff check` clean
- `uv run ruff format --check` clean
- `uv run ty check` clean
- `uv run pytest -q` — 116 passed (42 new)

## Test plan

- [x] Round-trip write/read preserves payload byte-for-byte
- [x] Adversarial `playlist_id` (path traversal, control chars, length boundaries) rejected before path join
- [x] Live-first flow: yt-dlp success writes cache; yt-dlp failure reads cache; no cache → re-raise
- [x] `is_stale` boundary at 24h
- [x] Lint, format, type check, pytest all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)