### PR TITLE
docs: README + SEMVER + manual smoke tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,11 @@ Thanks for taking the time. This file documents the workflow we expect for chang
 
 ## Commits
 
-ryzic uses [Conventional Commits](https://www.conventionalcommits.org/). The commit type drives the version bump that [release-please](https://github.com/googleapis/release-please) cuts:
+ryzic uses [Conventional Commits](https://www.conventionalcommits.org/). The commit type drives the version bump that [release-please](https://github.com/googleapis/release-please) cuts. Pre-1.0, the mapping is intentionally conservative — see [SEMVER.md](SEMVER.md) for rationale:
 
 - `fix:` → patch release.
-- `feat:` → minor release.
-- `feat!:` (or any commit with a `BREAKING CHANGE:` footer) → minor release pre-1.0, major release post-1.0. See [SEMVER.md](SEMVER.md).
+- `feat:` → patch release pre-1.0, minor release post-1.0.
+- `feat!:` (or any commit with a `BREAKING CHANGE:` footer) → minor release pre-1.0, major release post-1.0.
 - `chore:`, `docs:`, `test:`, `refactor:`, `ci:` → no release.
 
 Squash your branch into a single Conventional Commit at merge time, or keep individual commits each conventional — either is fine, as long as the final history on `main` is parseable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing to ryzic
+
+Thanks for taking the time. This file documents the workflow we expect for changes that land on `main`.
+
+## Commits
+
+ryzic uses [Conventional Commits](https://www.conventionalcommits.org/). The commit type drives the version bump that [release-please](https://github.com/googleapis/release-please) cuts:
+
+- `fix:` → patch release.
+- `feat:` → minor release.
+- `feat!:` (or any commit with a `BREAKING CHANGE:` footer) → minor release pre-1.0, major release post-1.0. See [SEMVER.md](SEMVER.md).
+- `chore:`, `docs:`, `test:`, `refactor:`, `ci:` → no release.
+
+Squash your branch into a single Conventional Commit at merge time, or keep individual commits each conventional — either is fine, as long as the final history on `main` is parseable.
+
+## Pull requests
+
+1. Open an issue first for non-trivial changes — saves both sides time if the design needs a discussion.
+2. Branch off `main`. Push to a feature branch (we don't accept pushes directly to `main`).
+3. Make sure CI is green: `uv run ruff check && uv run ruff format --check && uv run ty check && uv run pytest -q`.
+4. Open a PR. Keep the PR focused — one logical change per PR is much easier to review than a kitchen sink.
+5. PRs need at least one approving review before merge. Don't self-merge.
+
+Before-merge gates (run as separate review passes on substantial PRs):
+
+- `/review` — correctness + design.
+- `/security-review` — input handling, supply chain, secrets exposure.
+- `/simplify` — KISS / DRY / SRP / SOLID housekeeping.
+
+## Where the design lives
+
+The M1 plan and per-PR review notes live under [docs/plans/](docs/plans/). `M1.md` is the source of truth for behavior, env vars, and module layout; the `PR{n}-review.md` / `PR{n}-security-review.md` / `PR{n}-simplify.md` files capture review output for each implementation PR. Reference them when proposing follow-ups so reviewers have context.
+
+## What we won't merge
+
+- Anything that enables YouTube cookies or a credentialed-fetch path without a security review and a clear opt-in. See [README.md § Self-hoster considerations](README.md#self-hoster-considerations).
+- Secrets in commits (tokens, `.env`, signing keys). `.gitignore` lists the obvious patterns; if you find yourself fighting it, stop and ask.
+- New runtime dependencies without a justification in the PR body.
+
+## Manual smoke tests
+
+[docs/manual-smoke-tests.md](docs/manual-smoke-tests.md) is the checklist run before each release. PRs that touch the playback path should at minimum re-run the **Core playback** section locally and call out the result in the PR description.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,131 @@
+# ryzic
+
+[![CI](https://github.com/VeryLongOrgNameSuchWow/ryzic/actions/workflows/ci.yml/badge.svg)](https://github.com/VeryLongOrgNameSuchWow/ryzic/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Python 3.13+](https://img.shields.io/badge/python-3.13%2B-blue.svg)](https://www.python.org/downloads/)
+
+A self-hostable Discord music bot. Plays YouTube audio in voice channels via [Lavalink](https://lavalink.dev/), with a local LRU cache so frequently-played tracks survive yt-dlp breakage. One bot per server you run yourself; no public hosting, no telemetry, no premium tier.
+
+## Features
+
+- Six slash commands: `/play`, `/skip`, `/queue`, `/pause`, `/resume`, `/leave`.
+- Per-guild queue with paged display.
+- LRU audio cache backed by SQLite — re-playing a track skips the network round-trip and survives transient yt-dlp regressions.
+- Auto-leave after 5 minutes idle in voice (sensible Discord etiquette).
+- One-command deploy via `docker compose`.
+- No privileged Discord intents required.
+
+## Requirements
+
+- Docker 24+ with `docker compose` v2 (the newer `compose.yaml` shape).
+- A Discord account that can create applications.
+- A voice channel you can invite the bot into.
+
+## Setup
+
+### 1. Create the Discord application
+
+1. Open the [Discord Developer Portal](https://discord.com/developers/applications) and create a new application.
+2. In **Bot** → **Token**, click **Reset Token** and copy it. You'll paste this into `.env` in step 4.
+3. **Privileged Gateway Intents — leave them all OFF.** ryzic does not need Server Members, Message Content, or Presence. If you turned them on, turn them off.
+4. In **OAuth2** → **URL Generator**:
+   - Scopes: `bot`, `applications.commands`.
+   - Bot Permissions: `Connect`, `Speak`, `Send Messages`, `Embed Links`, `Use Slash Commands`.
+   - **Do not pick Administrator.** A music bot has no business with admin rights — it's a security smell and many server owners refuse such invites.
+5. Open the generated URL and invite the bot to your server.
+
+### 2. Clone and configure
+
+```bash
+git clone https://github.com/VeryLongOrgNameSuchWow/ryzic.git
+cd ryzic
+cp .env.example .env
+```
+
+Edit `.env` and paste the token into `DISCORD_BOT_TOKEN=`.
+
+(Optional — strongly recommended during first-run testing.) Add a comma-separated list of guild IDs to register slash commands instantly. Without it Discord propagates new commands globally, which can take up to an hour:
+
+```bash
+RYZIC_GUILD_IDS=123456789012345678
+```
+
+### 3. Bring it up
+
+```bash
+docker compose up -d
+```
+
+The first boot pulls the Lavalink image and downloads the `youtube-source` plugin (~30s). Tail the logs to confirm both services are healthy:
+
+```bash
+docker compose logs -f
+```
+
+### 4. Try it
+
+Join a voice channel, then in any text channel the bot can see:
+
+```
+/play https://www.youtube.com/watch?v=dQw4w9WgXcQ
+```
+
+You should hear audio within a couple of seconds.
+
+### Troubleshooting
+
+- **Slash commands don't appear.** Discord caches global commands for ~1h. Set `RYZIC_GUILD_IDS` to the test guild's ID and `docker compose restart ryzic` for instant registration.
+- **"Audio service is down."** Check `docker compose logs lavalink`. The bot expects Lavalink at `lavalink:2333` inside the compose network — if you've changed `LAVALINK_HOST` or `LAVALINK_PORT`, both services need to agree.
+- **No audio plays despite "Queued".** ryzic only joins your voice channel — make sure you joined first, and that the bot has `Connect` and `Speak` on it.
+- **`Failed to load: ...`** Some videos are age-restricted, region-locked, or private. ryzic surfaces a friendly variant of yt-dlp's error; the cause is upstream.
+- **You changed `RYZIC_CACHE_DIR`.** Update it in **both** the `ryzic` and `lavalink` services' volume mounts in `compose.yaml`. They share the cache directory and Lavalink reads files via the same absolute path that ryzic writes.
+
+## Configuration
+
+All configuration is via environment variables (read from `.env` by `docker compose`).
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `DISCORD_BOT_TOKEN` | yes | — | Bot token from the Discord Developer Portal. |
+| `LAVALINK_PASSWORD` | no | `youshallnotpass` | Must match `lavalink/application.yml`. Change both together. |
+| `LAVALINK_HOST` | no | `lavalink` | Set automatically by `compose.yaml`. Override only when running ryzic outside compose. |
+| `LAVALINK_PORT` | no | `2333` | |
+| `RYZIC_CACHE_DIR` | no | `/var/cache/ryzic` (compose) / `./.cache` (local) | Audio + playlist cache directory. **Both services must mount the same path.** |
+| `RYZIC_CACHE_MAX_GB` | no | `5` | LRU eviction kicks in once cached audio exceeds this size (GiB). |
+| `RYZIC_LOG_LEVEL` | no | `INFO` | One of `DEBUG`, `INFO`, `WARNING`, `ERROR`. |
+| `RYZIC_GUILD_IDS` | no | unset | Comma-separated guild IDs for instant slash-command registration. Unset = global registration (up to 1h propagation). |
+
+## Self-hoster considerations
+
+- **YouTube cookies are deliberately disabled.** Enabling them lets a deployment fetch age-restricted/private content under your account, which is a security and account-safety risk. There is no env var to enable them in M1; if you need them, fork and review the change carefully first.
+- **The cache directory holds copyrighted material.** What you cache and how long you keep it is your responsibility. Default eviction is by least-recently-used at the `RYZIC_CACHE_MAX_GB` threshold.
+- **No rate limiting in this release.** Anyone in your server who can run slash commands can fill your queue or your disk. If you don't trust everyone, restrict command access via Discord's built-in **Server Settings** → **Integrations** permissions before exposing the bot widely.
+- **Single-instance only.** The audio cache, playlist cache, and per-guild state assume exactly one ryzic process per cache directory. Don't run two replicas against the same volume.
+
+## Development
+
+You don't need Docker to hack on the code — only to run a real Lavalink (which the integration tests spin up themselves via testcontainers).
+
+```bash
+uv sync
+uv run pytest -q
+uv run python -m ryzic    # requires DISCORD_BOT_TOKEN + a reachable Lavalink
+```
+
+Code style is enforced by `ruff` and `ty`:
+
+```bash
+uv run ruff check
+uv run ruff format --check
+uv run ty check
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the PR workflow and [docs/manual-smoke-tests.md](docs/manual-smoke-tests.md) for the end-to-end checklist run before each release.
+
+## Versioning
+
+ryzic is pre-1.0; minor bumps may include breaking changes. See [SEMVER.md](SEMVER.md) for the full policy and what counts as breaking once we reach v1.0.
+
+## License
+
+[MIT](LICENSE).

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A self-hostable Discord music bot. Plays YouTube audio in voice channels via [La
 3. **Privileged Gateway Intents — leave them all OFF.** ryzic does not need Server Members, Message Content, or Presence. If you turned them on, turn them off.
 4. In **OAuth2** → **URL Generator**:
    - Scopes: `bot`, `applications.commands`.
-   - Bot Permissions: `Connect`, `Speak`, `Send Messages`, `Embed Links`, `Use Slash Commands`.
+   - Bot Permissions: `Connect`, `Speak`, `Send Messages`, `Embed Links`.
    - **Do not pick Administrator.** A music bot has no business with admin rights — it's a security smell and many server owners refuse such invites.
 5. Open the generated URL and invite the bot to your server.
 
@@ -78,7 +78,7 @@ You should hear audio within a couple of seconds.
 - **"Audio service is down."** Check `docker compose logs lavalink`. The bot expects Lavalink at `lavalink:2333` inside the compose network — if you've changed `LAVALINK_HOST` or `LAVALINK_PORT`, both services need to agree.
 - **No audio plays despite "Queued".** ryzic only joins your voice channel — make sure you joined first, and that the bot has `Connect` and `Speak` on it.
 - **`Failed to load: ...`** Some videos are age-restricted, region-locked, or private. ryzic surfaces a friendly variant of yt-dlp's error; the cause is upstream.
-- **You changed `RYZIC_CACHE_DIR`.** Update it in **both** the `ryzic` and `lavalink` services' volume mounts in `compose.yaml`. They share the cache directory and Lavalink reads files via the same absolute path that ryzic writes.
+- **You changed `RYZIC_CACHE_DIR`.** Prefer changing only the host-side path of the bind mount (top-level `volumes:` block) and leaving the in-container path alone. If you must change the in-container path, update the env value **and** both `volumes:` mount targets (ryzic and lavalink), and keep the lavalink mount `:ro`. A mismatch here means ryzic writes files Lavalink can't find.
 
 ## Configuration
 
@@ -92,7 +92,7 @@ All configuration is via environment variables (read from `.env` by `docker comp
 | `LAVALINK_PORT` | no | `2333` | |
 | `RYZIC_CACHE_DIR` | no | `/var/cache/ryzic` (compose) / `./.cache` (local) | Audio + playlist cache directory. **Both services must mount the same path.** |
 | `RYZIC_CACHE_MAX_GB` | no | `5` | LRU eviction kicks in once cached audio exceeds this size (GiB). |
-| `RYZIC_LOG_LEVEL` | no | `INFO` | One of `DEBUG`, `INFO`, `WARNING`, `ERROR`. |
+| `RYZIC_LOG_LEVEL` | no | `INFO` | One of `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. |
 | `RYZIC_GUILD_IDS` | no | unset | Comma-separated guild IDs for instant slash-command registration. Unset = global registration (up to 1h propagation). |
 
 ## Self-hoster considerations
@@ -112,15 +112,7 @@ uv run pytest -q
 uv run python -m ryzic    # requires DISCORD_BOT_TOKEN + a reachable Lavalink
 ```
 
-Code style is enforced by `ruff` and `ty`:
-
-```bash
-uv run ruff check
-uv run ruff format --check
-uv run ty check
-```
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the PR workflow and [docs/manual-smoke-tests.md](docs/manual-smoke-tests.md) for the end-to-end checklist run before each release.
+Run the same lint/type/test suite CI runs before opening a PR — see [CONTRIBUTING.md § Pull requests](CONTRIBUTING.md#pull-requests) for the canonical command. [docs/manual-smoke-tests.md](docs/manual-smoke-tests.md) is the end-to-end checklist run before each release.
 
 ## Versioning
 

--- a/SEMVER.md
+++ b/SEMVER.md
@@ -4,11 +4,17 @@ ryzic follows [Semantic Versioning 2.0.0](https://semver.org/) with the pre-1.0 
 
 ## Pre-1.0 (`0.x.y`)
 
-While the major version is `0`, **minor bumps may contain breaking changes**. release-please is configured with `bump-minor-pre-major: true`, so a `feat!:` commit produces a `0.MINOR+1.0` release rather than a major bump.
+While the major version is `0`, **minor bumps may contain breaking changes**. release-please is configured with `bump-minor-pre-major: true` and `bump-patch-for-minor-pre-major: true`, so the pre-1.0 commit-to-bump mapping is intentionally conservative:
 
-If stability matters to you before v1.0, **pin to an exact version** (`ryzic==0.4.2`, `ghcr.io/.../ryzic:0.4.2`) and read [CHANGELOG.md](CHANGELOG.md) before upgrading. The CHANGELOG calls out breaking changes with a `BREAKING CHANGE:` footer.
+- `fix:` → patch (`0.x.Y+1`)
+- `feat:` → patch (`0.x.Y+1`)
+- `feat!:` / `BREAKING CHANGE:` → minor (`0.MINOR+1.0`) rather than a major bump
 
-Patch versions (`0.x.Y+1`) remain non-breaking even pre-1.0.
+Holding `feat:` to a patch keeps `0.x` cheap to iterate on while reserving minor bumps for the loud "this might break you" signal pre-1.0. Post-1.0 the standard SemVer mapping applies (`feat:` → minor, `feat!:` → major).
+
+If stability matters to you before v1.0, **pin to an exact version** (`ryzic==0.4.2`) and read [CHANGELOG.md](CHANGELOG.md) before upgrading. The CHANGELOG calls out breaking changes with a `BREAKING CHANGE:` footer.
+
+Patch versions remain non-breaking even pre-1.0.
 
 ## v1.0+ stable surfaces
 
@@ -20,6 +26,7 @@ When ryzic reaches v1.0, the following surfaces become covered by SemVer guarant
 - **Default behaviors observable from a Discord client.** The auto-leave timeout, queue cap, and per-track duration cap are documented defaults; changing them in a way that surprises a self-hoster running a stable upgrade is breaking.
 - **`compose.yaml` rolling-upgrade compatibility.** A `docker compose pull && docker compose up -d` against an unchanged user-supplied `.env` should continue to work across patch and minor versions.
 - **On-disk cache format.** The SQLite schema and audio file layout under `RYZIC_CACHE_DIR` are stable; ryzic will migrate old caches in place rather than ignore them.
+- **Minimum Python and Docker versions.** Raising either is breaking — operators may not have a newer interpreter or engine available.
 
 The following are **explicitly not stable** and may change in any release:
 
@@ -32,19 +39,3 @@ The following are **explicitly not stable** and may change in any release:
 When we plan to remove or rename a stable surface, we deprecate it for **at least one full minor version** before removing. Deprecated env vars continue to work and emit a `WARNING` log; deprecated commands keep working but their description prefixes with `[deprecated]`.
 
 A removal that wasn't preceded by a deprecation cycle is itself a bug — please file an issue.
-
-## Major-bump triggers
-
-Any of the following requires a major version bump (post-1.0):
-
-- Removing or renaming a slash command.
-- Renaming or repurposing an environment variable.
-- Breaking the on-disk cache format in a way that loses data on upgrade.
-- Breaking `compose.yaml` rolling upgrades (e.g. requiring a new manual `.env` value with no default, or a compose schema change that user-edited copies can't tolerate).
-- Raising the minimum Python or Docker version.
-
-Routine changes that do **not** require a major bump:
-
-- Adding a new slash command, env var, or optional parameter (with a sensible default).
-- Bumping the pinned Lavalink server image within its 4.x line.
-- Internal refactors visible only to importers of `src/ryzic/`.

--- a/SEMVER.md
+++ b/SEMVER.md
@@ -1,0 +1,50 @@
+# Versioning policy
+
+ryzic follows [Semantic Versioning 2.0.0](https://semver.org/) with the pre-1.0 caveats spelled out below. Releases are cut by [release-please](https://github.com/googleapis/release-please) from Conventional Commits on `main`.
+
+## Pre-1.0 (`0.x.y`)
+
+While the major version is `0`, **minor bumps may contain breaking changes**. release-please is configured with `bump-minor-pre-major: true`, so a `feat!:` commit produces a `0.MINOR+1.0` release rather than a major bump.
+
+If stability matters to you before v1.0, **pin to an exact version** (`ryzic==0.4.2`, `ghcr.io/.../ryzic:0.4.2`) and read [CHANGELOG.md](CHANGELOG.md) before upgrading. The CHANGELOG calls out breaking changes with a `BREAKING CHANGE:` footer.
+
+Patch versions (`0.x.Y+1`) remain non-breaking even pre-1.0.
+
+## v1.0+ stable surfaces
+
+When ryzic reaches v1.0, the following surfaces become covered by SemVer guarantees. Breaking changes to any of them require a major version bump.
+
+- **Slash command names.** `/play`, `/skip`, `/queue`, `/pause`, `/resume`, `/leave` and any commands added later won't be renamed without a major bump.
+- **Slash command parameter shapes.** Names, types, optionality, and ordering of parameters are stable.
+- **Environment variable names and meanings.** Renaming `RYZIC_CACHE_DIR` or changing the units of `RYZIC_CACHE_MAX_GB` is breaking. Adding new optional env vars with sensible defaults is not.
+- **Default behaviors observable from a Discord client.** The auto-leave timeout, queue cap, and per-track duration cap are documented defaults; changing them in a way that surprises a self-hoster running a stable upgrade is breaking.
+- **`compose.yaml` rolling-upgrade compatibility.** A `docker compose pull && docker compose up -d` against an unchanged user-supplied `.env` should continue to work across patch and minor versions.
+- **On-disk cache format.** The SQLite schema and audio file layout under `RYZIC_CACHE_DIR` are stable; ryzic will migrate old caches in place rather than ignore them.
+
+The following are **explicitly not stable** and may change in any release:
+
+- Internal Python APIs (anything under `src/ryzic/` consumed by import). ryzic is an application, not a library; we don't promise downstream importers anything.
+- Lavalink protocol details, plugin pins (`youtube-source` version), and `lavalink/application.yml` shape — these track upstream Lavalink and may move with it.
+- Log message wording, log level of any specific event, embed text and exact wording of error messages. Don't grep logs in CI; don't pattern-match embed text from another bot.
+
+## Deprecation policy (post-1.0)
+
+When we plan to remove or rename a stable surface, we deprecate it for **at least one full minor version** before removing. Deprecated env vars continue to work and emit a `WARNING` log; deprecated commands keep working but their description prefixes with `[deprecated]`.
+
+A removal that wasn't preceded by a deprecation cycle is itself a bug — please file an issue.
+
+## Major-bump triggers
+
+Any of the following requires a major version bump (post-1.0):
+
+- Removing or renaming a slash command.
+- Renaming or repurposing an environment variable.
+- Breaking the on-disk cache format in a way that loses data on upgrade.
+- Breaking `compose.yaml` rolling upgrades (e.g. requiring a new manual `.env` value with no default, or a compose schema change that user-edited copies can't tolerate).
+- Raising the minimum Python or Docker version.
+
+Routine changes that do **not** require a major bump:
+
+- Adding a new slash command, env var, or optional parameter (with a sensible default).
+- Bumping the pinned Lavalink server image within its 4.x line.
+- Internal refactors visible only to importers of `src/ryzic/`.

--- a/docs/manual-smoke-tests.md
+++ b/docs/manual-smoke-tests.md
@@ -6,7 +6,7 @@ Prerequisites:
 
 - A test Discord server you own.
 - A clean clone with `.env` populated per [README.md](../README.md).
-- Two voice channels in the test server, plus one stage channel (for stage rejection).
+- Two voice channels in the test server, plus one stage channel (for stage rejection — requires Server Settings → Enable Community).
 - A second Discord account (or a friend) is helpful but not required.
 
 Reset state between runs with `docker compose down -v && docker compose up -d` if you want a cold cache.
@@ -34,27 +34,26 @@ Reset state between runs with `docker compose down -v && docker compose up -d` i
 ## Cache behavior
 
 - [ ] `/play` the same video twice in a row: the second play does **not** re-download (visible in `docker compose logs ryzic` as a cache-hit log; no yt-dlp activity).
-- [ ] Cache survives `docker compose restart ryzic`: re-`/play` the same video after restart still hits cache (no yt-dlp re-download).
-- [ ] LRU eviction triggers at the configured size: set `RYZIC_CACHE_MAX_GB=1` in `.env`, `docker compose up -d`, queue several long tracks (live concerts work), and confirm via `du -sh` on the cache volume that the directory stays under the cap and the oldest tracks are gone.
+- [ ] Two `/play` calls for the same URL within ~1s yield exactly one yt-dlp download (verify in `docker compose logs ryzic` — only one "downloading" log line per video). Both interactions report success.
+- [ ] Cache survives `docker compose restart ryzic`: re-`/play` the same video after restart still hits cache (no yt-dlp re-download). The queue itself is empty post-restart (per-guild state is in-memory by design).
+- [ ] LRU eviction triggers at the configured size: set `RYZIC_CACHE_MAX_GB=1` in `.env`, `docker compose up -d`, queue several long tracks (live concerts work), and confirm via `du -sh` on the cache volume that the directory stays under the cap and the oldest tracks are gone. **Restore `RYZIC_CACHE_MAX_GB` to your previous value afterwards.**
 - [ ] The currently-playing file is **never** evicted even when the cap is exceeded (queue a long track on a tight cap and confirm playback continues without error).
 
 ## Error handling
 
-- [ ] `/play https://youtube.com.evil.com/watch?v=x` is rejected by the URL validator with `Only YouTube URLs are supported.`
+- [ ] `/play https://youtube.com.invalid/watch?v=x` is rejected by the URL validator with `Only YouTube URLs are supported.`
 - [ ] `/play <livestream_url>` is rejected with the livestream-not-supported message before any download starts.
 - [ ] `/play <private_video_url>` surfaces `That video is private.`
 - [ ] `/play <age_restricted_url>` surfaces `That video is age-restricted and can't be played.`
-- [ ] Simulated yt-dlp breakage (`docker compose exec ryzic pip install 'yt-dlp==0.0.1'` against a hot container, then `/play <track_with_cached_metadata>` for a track NOT in audio cache, and `/play <playlist>` for a playlist with cached metadata) yields friendly errors and the cached-playlist warning footer respectively. Restore with `docker compose restart ryzic`.
+- [ ] Simulated yt-dlp breakage: run `docker compose exec ryzic python -m pip install 'yt-dlp==2021.1.15'` against a hot container (a real-but-stale release that fails against current YouTube), then `/play <track_with_cached_metadata>` for a track NOT in audio cache, and `/play <playlist>` for a playlist with cached metadata. Both should yield friendly errors and the cached-playlist warning footer respectively. **Restore with `docker compose down && docker compose up -d --force-recreate`** — `restart` does **not** undo `pip install`, the broken package persists in the container layer.
 
 ## Discord-side rejections
 
-- [ ] `/play` from a stage channel is rejected with `Stage channels aren't supported.`
+- [ ] `/play` from a stage channel is rejected with `Stage channels aren't supported. Use a regular voice channel.`
 - [ ] `/play` from a DM never reaches the bot (Discord hides the command).
 - [ ] `/skip`, `/pause`, `/resume`, `/leave` from a user not in the bot's voice channel return the `Join <#channel>` ephemeral.
 
-## Restart behavior
-
-- [ ] `docker compose restart ryzic` mid-queue: cached audio files are retained on disk; the queue itself is empty (per-guild state is in-memory by design).
+Coverage and unit-test acceptance criteria (plan §11.9 / §11.10) are enforced in CI, not here.
 
 ## Sign-off
 

--- a/docs/manual-smoke-tests.md
+++ b/docs/manual-smoke-tests.md
@@ -1,0 +1,64 @@
+# Manual smoke tests
+
+End-to-end verification run against a real Discord server + a real voice channel before each release. Automated tests cover units and a Lavalink container; this checklist covers everything that requires a live Discord gateway and human ears.
+
+Prerequisites:
+
+- A test Discord server you own.
+- A clean clone with `.env` populated per [README.md](../README.md).
+- Two voice channels in the test server, plus one stage channel (for stage rejection).
+- A second Discord account (or a friend) is helpful but not required.
+
+Reset state between runs with `docker compose down -v && docker compose up -d` if you want a cold cache.
+
+## Bring-up
+
+- [ ] `docker compose up -d` brings both services up; `docker compose ps` shows `lavalink` as healthy and `ryzic` as running within ~60s.
+- [ ] `docker compose logs ryzic` shows `Logged in as <bot> (<id>)` and a node-connected line.
+- [ ] `/ping` responds (sanity check that slash commands registered).
+
+## Core playback
+
+- [ ] `/play <youtube_track_url>` (e.g. `https://www.youtube.com/watch?v=dQw4w9WgXcQ`) plays audio in your voice channel within ~3s.
+- [ ] `/play <youtube_playlist_url>` queues every track in the playlist; the embed reports the correct count and total duration.
+- [ ] `/queue` shows the currently-playing track with `mm:ss / mm:ss` progress and the next entries (paged at 10).
+- [ ] `/skip` advances to the next track immediately; the embed names the skipped title.
+- [ ] `/pause` halts playback; `/resume` resumes from the same position (no audible jump).
+- [ ] `/leave` disconnects the bot and clears the queue; `/queue` afterwards reports empty.
+
+## Auto-leave
+
+- [ ] After the final track in a queue ends, the bot stays connected briefly, then disconnects after ~5 minutes of idle and posts `Idle for 5 minutes — disconnecting.` in the channel where `/play` was last used.
+- [ ] `/play` during the idle window cancels the timer; the bot does not disconnect.
+
+## Cache behavior
+
+- [ ] `/play` the same video twice in a row: the second play does **not** re-download (visible in `docker compose logs ryzic` as a cache-hit log; no yt-dlp activity).
+- [ ] Cache survives `docker compose restart ryzic`: re-`/play` the same video after restart still hits cache (no yt-dlp re-download).
+- [ ] LRU eviction triggers at the configured size: set `RYZIC_CACHE_MAX_GB=1` in `.env`, `docker compose up -d`, queue several long tracks (live concerts work), and confirm via `du -sh` on the cache volume that the directory stays under the cap and the oldest tracks are gone.
+- [ ] The currently-playing file is **never** evicted even when the cap is exceeded (queue a long track on a tight cap and confirm playback continues without error).
+
+## Error handling
+
+- [ ] `/play https://youtube.com.evil.com/watch?v=x` is rejected by the URL validator with `Only YouTube URLs are supported.`
+- [ ] `/play <livestream_url>` is rejected with the livestream-not-supported message before any download starts.
+- [ ] `/play <private_video_url>` surfaces `That video is private.`
+- [ ] `/play <age_restricted_url>` surfaces `That video is age-restricted and can't be played.`
+- [ ] Simulated yt-dlp breakage (`docker compose exec ryzic pip install 'yt-dlp==0.0.1'` against a hot container, then `/play <track_with_cached_metadata>` for a track NOT in audio cache, and `/play <playlist>` for a playlist with cached metadata) yields friendly errors and the cached-playlist warning footer respectively. Restore with `docker compose restart ryzic`.
+
+## Discord-side rejections
+
+- [ ] `/play` from a stage channel is rejected with `Stage channels aren't supported.`
+- [ ] `/play` from a DM never reaches the bot (Discord hides the command).
+- [ ] `/skip`, `/pause`, `/resume`, `/leave` from a user not in the bot's voice channel return the `Join <#channel>` ephemeral.
+
+## Restart behavior
+
+- [ ] `docker compose restart ryzic` mid-queue: cached audio files are retained on disk; the queue itself is empty (per-guild state is in-memory by design).
+
+## Sign-off
+
+- [ ] All boxes ticked.
+- [ ] Release version: `___________`
+- [ ] Tester: `___________`
+- [ ] Date: `___________`


### PR DESCRIPTION
## Summary

Implements PR9 from `docs/plans/M1.md` §12 — the docs deliverable that lands after PR7. Per spec: docs only, no source code touched.

- **`README.md`** — rewrites the empty file with badges (CI, license, Python 3.13+), feature list, Discord-side setup walkthrough (no privileged intents, no Administrator permission, exact OAuth scopes/permissions per plan §10), `.env` + docker compose bring-up, troubleshooting, full env-var reference table for all eight vars, self-hoster considerations (cookies deliberately off, cache holds copyrighted content, no rate limiting in M1, single-instance), local development quickstart. 131 lines, well under the ~250-line cap.
- **`SEMVER.md`** — pre-1.0 stance (minor bumps may break, matches `bump-minor-pre-major: true` in release-please config); v1.0+ stable surfaces (command names + parameter shapes, env var names + meanings, defaults, compose rolling-upgrade compatibility, on-disk cache format); explicitly-not-stable surfaces (internal Python APIs, Lavalink protocol, log/embed wording); deprecation policy (one minor version warning before removal); major-bump trigger list.
- **`docs/manual-smoke-tests.md`** — checklist covering bring-up, all six commands, auto-leave (5 min), cache behavior (hit / restart-survival / LRU eviction / in-use protection), error handling (URL allowlist, livestream rejection, friendly yt-dlp errors, yt-dlp-broken playlist fallback), Discord-side rejections (stage / DM / wrong-voice-channel), restart behavior, sign-off block. Mirrors plan §11 acceptance criteria.
- **`CONTRIBUTING.md`** — Conventional Commits + bump mapping, PR workflow with the four CI gates, the review/security-review/simplify gates, where the design lives (`docs/plans/`), what we won't merge (cookies, secrets, unjustified deps).

## Decisions and notes

- **Docs assume the full M1 surface exists** per the brief. PR6a (`/play`) and PR6b (the other five commands) ship in parallel; the README copy reflects post-merge state, which is correct because docs go to `main` after all command PRs land.
- **Repo-relative badge URLs** point to `VeryLongOrgNameSuchWow/ryzic`. Used the existing CI workflow (`ci.yml`) for the status badge and `img.shields.io` static badges for license + Python (no external account needed).
- **CONTRIBUTING was tractable** within the brief's "if room" budget, so I included it. README references it.
- **`CHANGELOG.md` link in SEMVER** points at a file release-please will create on the first release; left as-is per the brief ("don't add CHANGELOG.md by hand").
- **Default `RYZIC_CACHE_DIR` shown as compose-default first, local fallback second** — matches what self-hosters following the README will actually see.
- **No reference to internal docs** (kanbantool, agent worktrees) per brief.

## Verification

```
uv run ruff check          # All checks passed!
uv run ruff format --check # 21 files already formatted
uv run ty check            # All checks passed!
uv run pytest -q           # 175 passed, 1 deselected
```

Markdown rendered locally; tables, code fences, headings, and inter-doc links all visually inspected.

## Test plan

- [ ] Reviewer reads README cold (skipping M1.md) and confirms the setup steps are sufficient to bring the bot up.
- [ ] Reviewer confirms env-var table matches `src/ryzic/config.py` defaults.
- [ ] Reviewer confirms SEMVER policy is consistent with `release-please-config.json` (`bump-minor-pre-major: true`).
- [ ] Reviewer confirms manual smoke checklist covers plan §11 acceptance criteria.