### PR TITLE
chore(github): archive PR review records + issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: Bug report
+description: Something is broken or behaves unexpectedly
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-broke
+    attributes:
+      label: What broke
+      description: A short description of the unexpected behavior.
+      placeholder: "/play hangs after 'Loading...' instead of starting playback."
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: Numbered steps to reproduce. Include the URL, command, or interaction sequence.
+      placeholder: |
+        1. /play https://www.youtube.com/watch?v=...
+        2. Wait 30s.
+        3. Bot reports nothing; queue is empty.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: input
+    id: ryzic-version
+    attributes:
+      label: ryzic version
+      description: Run `git describe --tags` in your clone, or note the docker image tag.
+      placeholder: "v0.1.0 / commit 0234b91"
+    validations:
+      required: true
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment
+      options:
+        - docker compose
+        - bare metal (uv run python -m ryzic)
+        - other
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Output from `docker compose logs ryzic` (and `lavalink` if relevant). Redact tokens before pasting.
+      render: shell
+  - type: checkboxes
+    id: checked
+    attributes:
+      label: Confirmations
+      options:
+        - label: I redacted any tokens, secrets, or PII before pasting logs.
+          required: true
+        - label: I checked existing issues for duplicates.
+          required: true

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,23 @@
+name: Chore / refactor
+description: Tooling, dependency, refactor, or housekeeping that doesn't change user-visible behavior
+labels: ["type:chore"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What to do
+      description: Concrete change. Files touched, deps added/removed, behavior preserved.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: What does this enable? Reduce maintenance burden? Unblock something?
+    validations:
+      required: true
+  - type: input
+    id: loc-delta
+    attributes:
+      label: Estimated LOC delta
+      placeholder: "−40 src + −15 tests = −55 net"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Setup help
+    url: https://github.com/VeryLongOrgNameSuchWow/ryzic#setup
+    about: README has the full self-hoster setup walkthrough.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature request
+description: Propose a new command, behavior, or capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you want
+      description: One paragraph. What changes about the bot from a user's perspective?
+      placeholder: "Add a /shuffle command that randomizes the current queue order."
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why
+      description: What problem does this solve? Who asked for it?
+    validations:
+      required: true
+  - type: textarea
+    id: ux-sketch
+    attributes:
+      label: UX sketch
+      description: Concrete success and error messages, edge cases, command parameters.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you think about? Why this one?
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - One small command
+        - New subsystem
+        - Workflow/process change
+        - Other
+    validations:
+      required: true

--- a/docs/plans/PR1-review.md
+++ b/docs/plans/PR1-review.md
@@ -1,0 +1,68 @@
+# PR #1 Review — `feat: project skeleton, /ping bot, release-please, CI, dependabot`
+
+**Branch:** `feat/skeleton-and-entrypoint` → `main`
+**Scope per plan:** `docs/plans/M1.md` §12 PR2 (skeleton + entrypoint + `/ping` smoke + tooling).
+**Diff:** +1140 LOC across 16 files (~445 LOC excluding `uv.lock`).
+**Local verification:** `uv lock --check`, `ruff check`, `ruff format --check`, `ty check`, `pytest -q` — all green (10 tests pass).
+
+---
+
+## Findings
+
+### LOW-1 — Redundant `extra-files` block in `release-please-config.json`
+
+- **Severity:** LOW
+- **Where:** `release-please-config.json:11-17`
+- **Why it matters:** `release-type: python` already updates `[project].version` in `pyproject.toml` automatically (per release-please docs and the CLI helptext). The explicit `extra-files` TOML/JSONPath updater duplicates that — it isn't broken (idempotent on the same field), but it's noise that future maintainers may copy as if it were necessary.
+- **Fix:** Drop the `extra-files` block entirely; the Python release-type handles `pyproject.toml` natively. If you want to belt-and-braces, leave a comment explaining the duplication is intentional defense-in-depth.
+
+### LOW-2 — `RYZIC_LOG_LEVEL` typo path raises a raw `ValueError`, not `ConfigError`
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/bot.py:59-62` (and indirectly `src/ryzic/config.py:73`)
+- **Why it matters:** `config.load()` accepts any string for `log_level` and `.upper()`s it. `logging.basicConfig(level="NONSENSE")` then raises `ValueError: Unknown level: 'NONSENSE'` from inside `bot.main`, after the "starting" log line and after `bot = hikari.GatewayBot(...)`. The plan's §10 explicitly documents `DEBUG, INFO, WARNING, ERROR` as the valid set, and the rest of `config.py` is careful to surface `ConfigError` for every bad input. This one slips through.
+- **Fix:** Either validate in `config.load` (`if log_level not in {"DEBUG","INFO","WARNING","ERROR","CRITICAL"}: raise ConfigError(...)`) or wrap the `basicConfig` call in a try/except that re-raises as `ConfigError`. The first option keeps fail-fast policy consistent.
+
+### LOW-3 — `LAVALINK_PORT` and `RYZIC_CACHE_MAX_GB` accept zero/negative values
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/config.py:55-62, 69, 72`
+- **Why it matters:** `_parse_int` only checks "is it an int". `LAVALINK_PORT=-1` or `RYZIC_CACHE_MAX_GB=0` parse cleanly and surface as confusing failures further downstream (lavalink connection error / immediate eviction of every cached file in PR3b). Consistent with the plan's "fail fast on bad config" intent to catch obvious nonsense at load time.
+- **Fix:** Add a `min_value: int = 1` (or similar) parameter to `_parse_int`, or layer a small validator in `Config.__post_init__`. Five extra lines.
+
+### LOW-4 — `_parse_guild_ids` shadows loop variable inside the `for` clause
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/config.py:44-46`
+- **Why it matters:** `for chunk in raw.split(","):` then `chunk = chunk.strip()` reassigns the loop variable. Ruff B007 is off so no warning fires, but reassigning a `for` target is a known smell — at minimum it confuses tooling that tracks variable provenance. Trivial readability nit.
+- **Fix:** Either `for raw_chunk in raw.split(","):` then `chunk = raw_chunk.strip()`, or simply `chunks = (c.strip() for c in raw.split(","))` and iterate over that.
+
+### LOW-5 — `class Ping` is defined inside `_build_client` rather than at module scope
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/bot.py:41-50`
+- **Why it matters:** Defining the command class inside a function works (closure over `started_at` is convenient) but it's idiomatically unusual — every lightbulb v3 doc example puts command classes at module scope and uses `client.di` / a constant for shared state. It also means `Ping` is invisible to introspection and `lightbulb`-aware tooling won't find it. Since the command is removed in PR6b per `M1-simplify.md` §7, the cost of "fixing" it is higher than the cost of leaving it. Flagging only because the PR description's "Decisions made" section doesn't mention it as a deliberate choice.
+- **Fix:** None required for PR1. If you wanted to make it textbook v3, register `started_at` in `client.di` and define `Ping` at module scope with `started_at: float` injected via `@lightbulb.invoke`. But that's gold-plating a command that's about to be deleted.
+
+### INFO — Things that are genuinely solid (worth saying)
+
+- **`config.py`** is exemplary: fail-fast `_require`, typed `_parse_int` / `_parse_guild_ids` with named-error messages, frozen dataclass, defaults match the plan §10 table line-for-line. The error messages name the offending var and point at `.env.example`. No comments narrating WHAT — only the module docstring explains WHY.
+- **lightbulb v3 idioms** are correct: `client_from_app(...)` with `default_enabled_guilds` (sequence, empty = global), `bot.subscribe(StartingEvent, client.start)` + `StoppingEvent → client.stop`, `@client.register` over `class Ping(lightbulb.SlashCommand, name=..., description=...)` with `@lightbulb.invoke`. All verified against `/tandemdude/hikari-lightbulb` 3.2.x docs. No v2 idioms slipping in.
+- **Intents** are exactly `GUILDS | GUILD_VOICE_STATES` per plan §7 — no privileged intents, no presence/messages/members.
+- **Tests** cover the helpers that have logic (`_format_uptime` boundary cases at <1m, m+s, h+m+s, multi-day) and the config validation paths (missing required, bad guild ID, bad int, defaults round-trip). 10 tests for ~170 LOC of source is a healthy ratio for a skeleton PR.
+- **CI workflow** is tight: concurrency group cancels superseded runs, `uv sync --frozen` enforces lockfile discipline, all four gates (`ruff check`, `ruff format --check`, `ty check`, `pytest`) run separately so failures are diagnosable. The `setup-uv@v8.1.0` pin is justified in the commit message (no floating major tag exists yet) and dependabot will heal it.
+- **Dependabot config** correctly excludes `yt-dlp` from the python-minor-and-patch group with a precise inline comment explaining why (frequent YouTube-fix releases per plan).
+- **Conventional commits**: all five commits are correctly formatted (`feat(bot):`, `ci:`, `ci:`, `chore(deps):`, `ci:`). The split is reviewable — entrypoint, CI, release-please, dependabot, then the setup-uv pin fix as its own commit. Will squash cleanly.
+- **`.env.example`** documents every var in the plan's table, no actual secrets, clear comments distinguishing required vs optional and explaining the compose vs local override rationale.
+- **`pyproject.toml`** matches plan §1 exactly: hikari, hikari-lightbulb v3, lavalink (Devoxin's `Lavalink.py` per uv.lock — confirmed `lavalink==5.11.0` from PyPI), yt-dlp, python-dotenv, aiosqlite. Dev group: ruff, ty, pytest, pytest-asyncio with `asyncio_mode = "auto"`. Version pinned at `0.0.0` so release-please owns it.
+- **`.gitignore`** already covers `.env`, `.cache/`, sqlite ancillaries, and the `.claude/` worktree directory. No edits needed.
+- **`errors.py`** sites `FetchFailed` and `InvalidVideoID` upfront to avoid the circular-import hazard the plan calls out. Two classes, no premature additions.
+- **release-please manifest** correctly seeded at `0.0.0`; first merge will produce `v0.1.0` (or whatever the conventional-commit history dictates).
+
+---
+
+## Overall verdict
+
+**ship as-is** — all five findings are LOW-severity and could equally be fixed in this PR or rolled into a follow-up. None block PR2 dependents (PR3a/PR5).
+
+**One-line summary:** Solid foundation PR — lightbulb v3 idioms verified correct, config validation is rigorous, CI/release-please/dependabot configured to spec; only nits are a redundant release-please block, three small input-validation gaps in `config.py`, and a stylistic command-class-inside-function choice for the about-to-be-deleted `/ping`.

--- a/docs/plans/PR1-security-review.md
+++ b/docs/plans/PR1-security-review.md
@@ -1,0 +1,197 @@
+# PR #1 — Security Review
+
+**PR**: `feat: project skeleton, /ping bot, release-please, CI, dependabot`
+**Branch**: `feat/skeleton-and-entrypoint` → `main`
+**Repo**: `VeryLongOrgNameSuchWow/ryzic`
+**Commits reviewed**: `feb5a84`, `b70808c`, `0004bf3`, `d7bc4dc`, `9e71aa9` (and `.gitignore` carried in from `0104cdc`).
+
+Scope: secrets handling, `.gitignore`, CI workflow security, dependency security, logging hygiene, `pyproject.toml` / `uv.lock`, repository-level config, release-please permissions.
+
+---
+
+## Findings
+
+### 1. No committed secrets — clean
+
+**Severity**: (informational — no finding)
+**What**: Every tracked file under the PR was scanned for credential strings (`token`, `secret`, `password`, common API-key prefixes, Discord token regex `[A-Za-z0-9_-]{24,28}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,38}`). Nothing real surfaced.
+**Where**: All tracked files; specifically:
+- `.env.example` — `DISCORD_BOT_TOKEN=` is empty (placeholder); `LAVALINK_PASSWORD=youshallnotpass` is the public upstream Lavalink default, not a secret.
+- `tests/test_imports.py` — uses `"fake-token"` literal as monkeypatched value.
+- `src/ryzic/config.py` — defaults `LAVALINK_PASSWORD` to `"youshallnotpass"` (Lavalink upstream default).
+- `src/ryzic/bot.py` — only uses `cfg.discord_bot_token` as a hikari arg; never logs it.
+- `.github/workflows/release-please.yml` — uses `${{ secrets.GITHUB_TOKEN }}`, the GHA-provided per-job token, not a static value.
+- No `.env` in git history (`git log --all -- .env` is empty).
+
+Verdict: clean.
+
+---
+
+### 2. CI workflow action pinning — appropriate
+
+**Severity**: LOW (informational; current pinning is acceptable per stated policy)
+**What**: All three actions used are from trusted publishers (per the audit policy "tolerable for trusted publishers (actions/*, astral-sh/*); third-party should be SHA-pinned"). No third-party actions.
+**Where**:
+- `.github/workflows/ci.yml:22` — `actions/checkout@v6` (floating major, GitHub-owned, trusted)
+- `.github/workflows/ci.yml:25` — `astral-sh/setup-uv@v8.1.0` (exact tag, Astral, trusted; deliberately tighter than necessary per commit `9e71aa9`)
+- `.github/workflows/release-please.yml:15` — `googleapis/release-please-action@v5` (floating major, Google-owned, trusted)
+**Why it matters**: Floating tags allow a compromised maintainer or repo to push a malicious release that gets picked up on the next workflow run. Tradeoff: SHA pinning gives stronger supply-chain guarantees but loses automatic security patches and creates dependabot churn for trivial bumps.
+**Fix**: No action required for M1. If you ever want maximum hardening later, run `gh api repos/{owner}/{repo}/git/ref/tags/{tag} --jq .object.sha` and pin to commit SHAs (with the readable tag in a `# v6.x` trailing comment). Dependabot already covers `github-actions` weekly so SHA bumps would be automated.
+
+---
+
+### 3. CI workflow `permissions:` block — correct (least-privilege)
+
+**Severity**: (informational — no finding)
+**What**: `ci.yml` declares `permissions: contents: read` at the top level, narrowing the default `GITHUB_TOKEN` scope from the org/repo default (which can be write) down to just read. The release workflow declares `contents: write` + `pull-requests: write`, exactly what release-please needs and nothing more.
+**Where**: `.github/workflows/ci.yml:8-9`, `.github/workflows/release-please.yml:7-9`.
+Verdict: clean.
+
+---
+
+### 4. `pull_request_target` / untrusted code execution
+
+**Severity**: (informational — no finding)
+**What**: Audited for any workflow triggered by `pull_request_target` that checks out fork code. None present. CI uses plain `pull_request` (which checks out the PR head in an unprivileged context with the read-only `contents: read` token).
+Verdict: clean.
+
+---
+
+### 5. release-please `GITHUB_TOKEN` scoping — correct
+
+**Severity**: (informational — no finding)
+**What**: Per `googleapis/release-please-action` docs, the action requires `contents: write` (to create release branches, tags, and GitHub Releases) and `pull-requests: write` (to open the release PR). The workflow grants exactly those two — nothing extra (no `actions: write`, no `id-token: write`, no `packages: write`, etc.). Token is the per-job ephemeral `GITHUB_TOKEN`, not a long-lived PAT or App token.
+**Where**: `.github/workflows/release-please.yml:7-9, 19`.
+Verdict: minimum viable scope. Clean.
+
+---
+
+### 6. `.gitignore` — hardening opportunity
+
+**Severity**: LOW
+**What**: `.gitignore` covers the must-haves (`.env`, `.cache/`) and project-specific artifacts (sqlite WAL/SHM/journal, `.venv`, `.claude/` worktrees). It does NOT preemptively exclude common credential file patterns: `*.pem`, `*.key`, `*.crt`, `*.p12`, `id_rsa*`, `id_ed25519*`, `.envrc`, `secrets/`, `*.kdbx`, `*.gpg`. Given the recent near-miss on `.env`, broadening this is cheap insurance against the next foot-gun.
+**Where**: `/home/user/Projects/ryzic/.gitignore` (carried in from initial commit `0104cdc`, unchanged in this PR).
+**Why it matters**: A contributor running `gh auth setup-git`, generating a key for testing, or dropping a service-account JSON into the repo root would have nothing protecting them. Broad patterns cost nothing and harden against the entire class of mistake.
+**Fix**: Append to `.gitignore`:
+
+```gitignore
+# Generic credential / key files — defense-in-depth
+*.pem
+*.key
+*.crt
+*.p12
+*.pfx
+id_rsa
+id_rsa.pub
+id_ed25519
+id_ed25519.pub
+.envrc
+.env.*
+!.env.example
+secrets/
+*.kdbx
+*.gpg
+```
+
+The `!.env.example` exception keeps the placeholder file tracked. (Consider opening as a follow-up issue rather than blocking this PR — `.env` and `.cache/` are already covered, which were the specifically-required entries.)
+
+---
+
+### 7. `Config` dataclass has no `__repr__` redaction
+
+**Severity**: LOW
+**What**: `config.Config` is a frozen dataclass holding `discord_bot_token: str` and `lavalink_password: str`. Default dataclass `__repr__` will print these in plaintext. If any future code does `_log.debug("loaded %s", cfg)` or `repr(cfg)` (e.g. in an exception handler, debug REPL, or third-party error reporter), the bot token leaks into logs.
+**Where**: `/home/user/Projects/ryzic/src/ryzic/config.py:18-27`.
+**Why it matters**: The point of failing fast on startup is to keep secrets in memory and never on the wire. A redacted `__repr__` is a one-liner that closes off an entire class of accidental leak. Right now `bot.py` doesn't log the cfg object, but PR3a/PR4 implementers may add `_log.exception` blocks or use `Sentry`/structlog and accidentally serialize it.
+**Fix**: Either (a) override `__repr__` to mask the two sensitive fields, or (b) use `dataclasses.field(repr=False)` for `discord_bot_token` and `lavalink_password`. Option (b) is one line per field and is the idiomatic fix:
+
+```python
+@dataclass(frozen=True)
+class Config:
+    discord_bot_token: str = field(repr=False)
+    ...
+    lavalink_password: str = field(repr=False)
+    ...
+```
+
+(Will need `from dataclasses import dataclass, field`.) This is hardening, not a present-day bug — flag as a follow-up rather than a merge blocker.
+
+---
+
+### 8. Dependency security — no known CVEs at versions resolved
+
+**Severity**: (informational — no finding)
+**What**: Resolved versions in `uv.lock` (cross-checked vs cutoff Jan 2026):
+- `aiohttp 3.13.5` — well past CVE-2024-42367 (path traversal, fixed 3.10.5) and CVE-2024-52303 (memory leak, fixed 3.10.11).
+- `yt-dlp 2026.3.17` — current rolling release per the `>=2026.3.17` floor.
+- `python-dotenv 1.2.2`, `aiosqlite 0.22.1`, `hikari 2.5.0`, `hikari-lightbulb 3.2.4`, `lavalink 5.11.0` — all current minor/patch lines, no outstanding advisories I'm aware of.
+- Dev: `pytest 9.0.3`, `pytest-asyncio 1.3.0`, `ruff 0.15.12`, `ty 0.0.34` — fine.
+- Transitive `confspec 0.0.5` and `linkd 0.3.0` are tandemdude's (lightbulb maintainer) own utility crates pulled by hikari-lightbulb; expected.
+
+All packages source from `https://pypi.org/simple` (verified by `grep "^source = " uv.lock` — every entry uses the PyPI registry, no Git URLs, no path overrides, no custom indices).
+Verdict: clean.
+
+---
+
+### 9. Logging hygiene — config-loading path safe
+
+**Severity**: (informational — no finding)
+**What**: Only one log line in the codebase: `_log.info("ryzic starting; log level=%s", cfg.log_level)` at `src/ryzic/bot.py:63`. `cfg.log_level` is a non-secret string. No `print(cfg)`, no `_log.debug(cfg)`, no exception handler that re-raises with the env contents. `dotenv.load_dotenv()` itself does not log file contents.
+**Where**: `/home/user/Projects/ryzic/src/ryzic/bot.py:63`.
+Verdict: clean. (See finding #7 for the forward-looking risk.)
+
+---
+
+### 10. `pyproject.toml` and `uv.lock` — no sketchy sources
+
+**Severity**: (informational — no finding)
+**What**: `pyproject.toml` declares all deps via PEP 508 specifiers with no extras pulling from non-PyPI indices, no `[tool.uv.sources]` overrides, no `[[tool.uv.index]]` pointing anywhere besides PyPI default. `uv.lock` `revision = 3` confirms lockfile integrity is enforced. `--frozen` flag in CI (`uv sync --frozen`) ensures no implicit upgrades during build.
+**Where**: `/home/user/Projects/ryzic/pyproject.toml`, `/home/user/Projects/ryzic/uv.lock`, `.github/workflows/ci.yml:33`.
+Verdict: clean.
+
+---
+
+### 11. Repository-level: CODEOWNERS, branch protection, dependabot
+
+**Severity**: LOW (CODEOWNERS — out of scope per PR plan; branch protection — gated on free-tier upgrade)
+**What**:
+- No `.github/CODEOWNERS` file. For a single-maintainer FOSS project this is fine; once external contributors arrive a CODEOWNERS pointing every path at `@riohno` would auto-tag review requests.
+- Branch protection on `main` cannot be configured: repo is private + free tier (`gh api repos/.../branches/main/protection` returns 403 "Upgrade to GitHub Pro or make this repository public"). The PR description explicitly notes "we'll add CI-required-green after this lands" — tracked, in-scope-for-later.
+- `.github/dependabot.yml` is well-formed: `pip` weekly with minor/patch grouping (excluding `yt-dlp` so its frequent releases each get their own PR, deliberate per the comment); `github-actions` weekly. `open-pull-requests-limit: 10` is sensible. Both ecosystems labeled appropriately. No secret-bearing config.
+**Where**: `/home/user/Projects/ryzic/.github/dependabot.yml`.
+**Fix**: None blocking. Once the repo goes public (or upgrades to Pro), enable branch protection: require PR review, require CI green, require `feat/`/`chore/`/`fix/` linear history if you care, dismiss stale approvals on push. Consider a one-line CODEOWNERS (`* @riohno`) before the first external contributor.
+
+---
+
+## Summary table
+
+| # | Finding | Severity |
+|---|---|---|
+| 1 | No committed secrets | clean |
+| 2 | CI action pinning (trusted publishers, mixed pin styles) | LOW (informational) |
+| 3 | CI `permissions:` blocks (least-privilege) | clean |
+| 4 | No `pull_request_target` exposure | clean |
+| 5 | release-please `GITHUB_TOKEN` scope (minimum viable) | clean |
+| 6 | `.gitignore` lacks generic credential patterns | LOW |
+| 7 | `Config` dataclass has no `__repr__` redaction | LOW |
+| 8 | No known CVEs in resolved dep versions | clean |
+| 9 | Logging hygiene (only safe log line) | clean |
+| 10 | `pyproject.toml`/`uv.lock` from PyPI only | clean |
+| 11 | No CODEOWNERS / branch protection (gated externally) | LOW |
+
+**HIGH-severity findings: 0**
+**MEDIUM-severity findings: 0**
+**LOW-severity findings: 3** (`.gitignore` hardening, `Config.__repr__` redaction, repo-level governance)
+
+---
+
+## Security verdict
+
+**clean** — no merge-blocking issues.
+
+The three LOW-severity items are hardening opportunities worth opening as follow-up issues, not gates on this PR:
+- `.gitignore` broadening (defense-in-depth against the next near-miss; lift after merge as a one-line PR)
+- `Config` `__repr__` redaction (closes off accidental token leak via future debug logging; do before PR4 lands real secrets-in-flight)
+- CODEOWNERS + branch-protection follow-up (already noted in the PR description)
+
+Foundation PR is genuinely solid on the supply-chain and secrets axes — least-privilege workflow tokens, PyPI-only dep registry, no committed creds, lockfile-frozen CI, no `pull_request_target` foot-guns.

--- a/docs/plans/PR1-simplify.md
+++ b/docs/plans/PR1-simplify.md
@@ -1,0 +1,126 @@
+# PR #1 Simplification Pass — `feat: project skeleton, /ping bot, release-please, CI, dependabot`
+
+**Branch:** `feat/skeleton-and-entrypoint` -> `main`
+**Diff reviewed:** +1140 LOC across 16 files (~445 LOC excluding `uv.lock`).
+**Companion docs:** `docs/plans/M1-simplify.md` (already-decided plan-level cuts), `docs/plans/PR1-review.md` (correctness review).
+
+This pass looks only for code that's *more elaborate than its M1 surface justifies*. It does **not** re-litigate decisions already locked in `M1-simplify.md` (e.g. flat module layout, `errors.py` central placement, dropping pre-commit, dropping `RYZIC_PLAYLIST_CACHE_TTL_HOURS`).
+
+Honest framing: this PR is mostly tight. Of the M1-simplify rules I tried to apply, only **two** found real fat. The rest of the file is a "keep as-is" recommendation.
+
+---
+
+## Findings
+
+### S-1 — Drop `_format_uptime` and the `(uptime: ...)` suffix on `/ping`
+
+**What to cut/collapse:** The `/ping` command body is `await ctx.respond(f"Pong (uptime: {uptime})")`. Replace with `await ctx.respond("Pong")`. Delete the `_format_uptime` helper and the `started_at: float` parameter that exists only to feed it. Delete the four `test_format_uptime_*` tests.
+
+**Where:**
+- `src/ryzic/bot.py:17-30` (`_format_uptime`)
+- `src/ryzic/bot.py:34, 49, 65, 71` (`started_at` plumbing)
+- `tests/test_imports.py:17-30` (four uptime tests)
+
+**Why it's safe:** `/ping` is explicitly a smoke command that gets removed in PR6b (per `M1-simplify.md` §7 — "removes `/lltest` here, it's obsolete once `/play` exists" — same reasoning applies to `/ping`). The smoke goal is "did the bot register a slash command and respond" — `"Pong"` answers that perfectly. Adding uptime turns a smoke into a feature; nothing downstream needs it. Test scaffolding richer than the surface it tests (rule #9): four boundary-condition tests for a 14-line helper that lives one PR.
+
+The `started_at = time.monotonic()` capture in `main()`, the parameter through `_build_client`, the closure capture inside the inner class, and the import of `time` all collapse with this.
+
+**Estimated LOC saved:** ~30 LOC (14 src + 14 tests + import + plumbing).
+
+---
+
+### S-2 — Drop the `extra-files` block in `release-please-config.json`
+
+**What to cut/collapse:** Remove the `"extra-files": [...]` array (lines 11-17) entirely.
+
+**Where:** `release-please-config.json:11-17`.
+
+**Why it's safe:** `"release-type": "python"` already updates `[project].version` in `pyproject.toml` natively — that's the single thing the explicit updater is configured to update. Configuration knobs not earned by use cases (rule #3): this is duplicating built-in behavior. Already flagged independently in `PR1-review.md` LOW-1 from the correctness side; from the simplification side it's the same cut for the same reason.
+
+**Estimated LOC saved:** ~7 LOC (the `extra-files` array body).
+
+---
+
+### S-3 — Optional: collapse `_build_client` into `main`
+
+**What to cut/collapse:** Inline the `_build_client(...)` body into `main()` directly. Or, if S-1 lands and the `Ping` command is also at module scope (it would no longer need `started_at`), `_build_client` reduces to two lines and inlines naturally.
+
+**Where:** `src/ryzic/bot.py:33-52, 71`.
+
+**Why it's safe:** `_build_client` is called exactly once, takes three params, and returns one value — it's a function-shaped paragraph break, not an abstraction. After S-1 lands the body is essentially `client = lightbulb.client_from_app(bot, default_enabled_guilds=cfg.guild_ids); ...register Ping...; return client` and the helper costs more than it saves. Modules that could be inlined / functions used in one place (rule #2 applied to function granularity).
+
+I'm calling this **optional** because `main()` post-inline still reads cleanly at ~25 lines, and pulling out the `Ping` registration to module scope (the lightbulb-idiomatic shape per `PR1-review.md` LOW-5) is a separate refactor that should land together. If S-1 doesn't land, leave `_build_client` as-is.
+
+**Estimated LOC saved:** ~5 LOC (signature, return, blank lines).
+
+---
+
+### S-4 — Optional: collapse the CI Python matrix
+
+**What to cut/collapse:** Replace `strategy: matrix: python-version: ["3.13"]` and `${{ matrix.python-version }}` interpolation with a literal `3.13`.
+
+**Where:** `.github/workflows/ci.yml:18-20, 29-30`.
+
+**Why it's safe:** A 1-element matrix is matrix scaffolding without matrix value. `requires-python = ">=3.13"` and `.python-version` already pin the version single-source; CI doesn't gain anything from the matrix shape until a second version exists. Premature abstraction (rule #5) — "for future X" where X is "we add 3.14 later," and adding the matrix back is a one-PR change at that point.
+
+I'm calling this **optional** because (a) the bloat is genuinely tiny — ~4 LOC, (b) some teams prefer to keep matrix scaffolding so version sweeps are mechanical, and (c) leaving it doesn't create any active maintenance burden. Leans cut, defensible to keep.
+
+**Estimated LOC saved:** ~4 LOC.
+
+---
+
+## Things I considered cutting and decided not to
+
+### `errors.py` (`FetchFailed`, `InvalidVideoID`)
+**Keep.** No callers in this PR — looks textbook "for future X" (rule #5). But `M1-simplify.md` §"Things I considered cutting" already weighed this and kept it for a real reason: cross-module catches between `commands/play.py` and `ytdlp.py` would create a circular-import path if the exceptions lived next to either raiser. Re-cutting now would mean immediately re-introducing the file in PR3 with no net win. 14 LOC of upfront discipline is the right trade.
+
+### `config.py`'s validation rigor (`_require`, `_parse_int`, `_parse_guild_ids`)
+**Keep.** This *looks* like defensive code at internal boundaries (rule #6) but env vars are a system edge — they cross from the OS into the process. Validate-at-the-edge is the textbook KISS choice; the alternative is `os.environ["DISCORD_BOT_TOKEN"]` raising `KeyError` from inside a slash-command handler an hour into a session. The five validation tests (`test_config_*`) earn their keep — they pin the fail-fast contract.
+
+### `config.py` module docstring (5 lines)
+**Keep.** It explains *why* validation happens at startup (process-level fail-fast vs. handler-level surprise) — exactly the WHY-not-WHAT comment style the project standards endorse.
+
+### `_parse_int` helper (used twice)
+**Keep.** Two callers + the rule "three similar lines is better than a premature abstraction" technically suggests inlining. But each call site would then duplicate the try/except + ConfigError construction (~5 lines each), so inlining grows the file. The helper pays for itself on 2 callers because the duplicated block is non-trivial.
+
+### `lightbulb` `Ping` class defined inside `_build_client`
+**Keep for this PR.** `PR1-review.md` LOW-5 already covered this and called it "gold-plating a command that's about to be deleted." Same conclusion here from the simplification side: the class disappears in PR6b along with `/ping`, so promoting it to module scope plus `client.di` injection would add machinery for a temporary command. If S-1 lands, `started_at` goes away and the closure motivation evaporates — but the class-inside-function shape is still defensible for a one-PR-lifespan command.
+
+### `__main__.py` (3 lines)
+**Keep.** `python -m ryzic` is a stable contract; the alternative is "`uv run ryzic` only" which loses the standard module-runner UX. 3 lines is the minimum.
+
+### `dependabot.yml` config (27 lines)
+**Keep.** Two ecosystems (pip, github-actions), one grouping rule with a single `yt-dlp` exclusion — every line is doing work. The inline comment explaining *why* `yt-dlp` is ungrouped (frequent YouTube-fix releases) is exactly the WHY-comment standard. No bloat.
+
+### `.env.example` (25 lines, 6 documented vars)
+**Keep.** Every var documented matches a field in `Config`. Comments distinguish required vs. optional and explain the compose-vs-local override case. No commented-out stub vars, no "future X" placeholders.
+
+### `pyproject.toml` ruff rule selection (`E,W,F,I,B,UP,SIM,RUF`)
+**Keep.** Eight rule families is on the lean end of "useful default set" — none of these are exotic. No selection-explosion smell.
+
+### `release-please.yml` workflow (19 lines)
+**Keep** (after S-2 cuts the `extra-files` block in the *config*). The workflow itself is the minimum viable release-please setup: trigger, perms, action call. Nothing to trim.
+
+### Multiple separate CI steps for ruff-check / ruff-format / ty / pytest
+**Keep.** `PR1-review.md` already noted this is good practice — separate steps mean failures are diagnosable from the GitHub Actions UI without scrolling logs. Combining them into one `make ci` would save 4 lines of YAML at the cost of debuggability.
+
+### `.gitignore` (24 lines)
+**Keep.** Every block is justified (Python build artifacts, venv, `.env` with the "NEVER commit" comment per project memory, `.cache/`, sqlite ancillaries, the `.claude/` worktree dir). The agent-worktree comment is the WHY type. No bloat.
+
+### `tests/__init__.py` (empty)
+**Keep.** Empty marker for pytest discovery — that's its whole job. Nothing to cut.
+
+---
+
+## Top 3 wins
+
+1. **Drop `_format_uptime` + uptime-suffix on `/ping` (S-1)** — ~30 LOC. Largest single cut; removes test scaffolding richer than its surface, removes a feature not earned by the smoke use-case, simplifies the `/ping` registration path.
+2. **Drop `extra-files` in `release-please-config.json` (S-2)** — ~7 LOC. Pure dead config; release-type:python already does this. Same finding as PR1-review LOW-1, viewed from the simplification axis.
+3. **Optional inline of `_build_client` into `main` (S-3)** — ~5 LOC. Function used in exactly one place; particularly natural after S-1 lands. Defensible to skip.
+
+## Total LOC the PR could lose
+
+- **Solid wins (S-1 + S-2): ~37 LOC** (out of ~445 hand-written, or ~8%).
+- **Including optional cuts (S-1 + S-2 + S-3 + S-4): ~46 LOC.**
+
+This is a tight PR. The remaining ~400 LOC are doing real work — config validation tests, CI workflow, dependabot config, and the lightbulb skeleton are all at or near minimum viable.

--- a/docs/plans/PR2-review.md
+++ b/docs/plans/PR2-review.md
@@ -1,0 +1,103 @@
+# PR #2 Review — `feat(ytdlp): wrapper + URL validator + tests`
+
+**Branch:** `feat/ytdlp-and-url-validator` → `main`
+**Scope per plan:** `docs/plans/M1.md` §6 and §12 PR3a (yt-dlp wrapper, URL validator, tests; no Discord deps).
+**Diff:** +774 LOC across 4 files (`url_validator.py` 30, `ytdlp.py` 278, `test_url_validator.py` 80, `test_ytdlp.py` 386).
+**Local verification:** `uv run ruff check`, `uv run ruff format --check`, `uv run ty check`, `uv run pytest -q` — all green (77 tests pass). Coverage on the new modules: `url_validator.py` 100%, `ytdlp.py` 99% (sole missing line is `_sync_extract`'s sanitize-info return; covered indirectly via the `YoutubeDL` patch test).
+
+---
+
+## Findings
+
+### MEDIUM-1 — Friendly error mapping returns category codes, not the user-facing strings the plan specifies
+
+- **Severity:** MEDIUM
+- **Where:** `src/ryzic/ytdlp.py:50-54, 117-128`
+- **Why it matters:** `_FRIENDLY_ERROR_PATTERNS` maps known yt-dlp fragments to bare category strings (`"age-restricted"`, `"private video"`, `"region-blocked or unavailable"`) and `_raise_from_download_error` raises `FetchFailed(friendly or detail)`. The plan §3 specifies the user-facing rendering: `"That video is age-restricted and can't be played."`, `"That video is private."`, `"That video is not available in this region."`. Plan §6 says the wrapper raises `FetchFailed(str)` "with first line of `DownloadError`" and the `/play` command does the friendly rendering ("the `/play` command remaps known patterns to friendlier wording" — verbatim from this PR's own module docstring at line 18-19). The PR splits the difference: it does an intermediate categorization that matches neither contract, forcing `/play` to know the category-code vocabulary and re-translate it to a sentence. Two layers of mapping where the plan calls for one.
+- **Fix:** Pick one of (a) raise `FetchFailed(detail)` (the unmodified first line) and let `/play` substring-match `"Sign in to confirm your age"` etc. itself — that's what §6 actually specifies, and it keeps the `/play` mapping table self-contained at the call site. Or (b) raise `FetchFailed("That video is age-restricted and can't be played.")` directly here and have `/play` display verbatim. Option (a) is closer to the plan and keeps `ytdlp.py` ignorant of UX strings; option (b) is fine if you want one source of truth. The current shape is the worst of both — the test at `test_ytdlp.py:172-185` even encodes the category vocabulary as the contract. Pick a layer.
+
+### MEDIUM-2 — `logger=_log` bypasses `no_warnings=True` on yt-dlp warnings
+
+- **Severity:** MEDIUM
+- **Where:** `src/ryzic/ytdlp.py:104`
+- **Why it matters:** Plan §6 lists `"logger": _quiet_logger` — placeholder name implies a logger that drops/quiets messages. The implementation passes the module logger `_log = logging.getLogger(__name__)`. yt-dlp's `report_warning` (verified in `yt_dlp/YoutubeDL.py`) checks `params.get('logger')` *before* `params.get('no_warnings')` — so when a logger is set, **warnings unconditionally hit `logger.warning(message)` regardless of `no_warnings=True`**. That means every yt-dlp WARNING (the "this site is broken" notice, format-fallback warnings, throttling notices, etc.) shows up in the bot's WARNING-level logs, even though the opts dict explicitly says `no_warnings=True`. The intent of the plan was the opposite — silence yt-dlp output and only surface errors. Same path applies to `to_screen` (becomes `logger.debug` — bypasses `quiet=True`), but that's at DEBUG so cosmetic.
+- **Fix:** Either don't pass a `logger` at all (then `quiet=True, no_warnings=True` work as advertised), or define a minimal "quiet" logger that drops `WARNING` and below and only forwards `ERROR` (matches the plan's `_quiet_logger` placeholder name). One-liner:
+  ```python
+  class _QuietLogger:
+      def debug(self, msg): pass
+      def info(self, msg): pass
+      def warning(self, msg): pass
+      def error(self, msg): _log.error("yt-dlp: %s", msg)
+  ```
+
+### LOW-1 — `download()` builds opts that include `paths.home` which is silently ignored
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/ytdlp.py:93, 273`
+- **Why it matters:** `_base_opts` sets `paths={"home": str(cache_root / "tmp")}`. `download()` then sets `outtmpl = str(resolved_dest)` — an absolute path. yt-dlp's `prepare_filename` (verified in source) emits a warning and ignores `paths` whenever `outtmpl` is absolute — that warning is currently swallowed by `quiet=True` (or routed via the logger per MEDIUM-2). Net effect: `paths.home` is dead config for `download()`. It's also dead for `resolve_track`/`resolve_playlist` since `extract_info(..., download=False)` doesn't write files. The line earns its keep nowhere in this PR — partial-file orchestration is owned by `audio_cache.py` in PR3b per plan §4. Not a correctness bug; just config that doesn't do what its presence implies.
+- **Fix:** Two reasonable options. (a) Drop `paths` from `_base_opts` and let the cache layer (PR3b) add it when relevant — keeps each module's opts honest. (b) Leave it as a defensive default for any code path that *does* use a relative `outtmpl` (none currently). I'd lean (a); the dead key adds a future maintenance reading-cost.
+
+### LOW-2 — `_extract` only catches `DownloadError`; sibling `YoutubeDLError` subclasses fall to "internal error"
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/ytdlp.py:208-215`
+- **Why it matters:** `yt_dlp.utils` exposes ~18 exception classes inheriting from `YoutubeDLError` directly (not `DownloadError`): `ExtractorError`, `GeoRestrictedError`, `UnavailableVideoError`, `RejectedVideoReached`, `UnsupportedError`, `UserNotLive`, `ContentTooShortError`, etc. In normal `extract_info` flow, yt-dlp catches `ExtractorError` internally and re-raises as `DownloadError` via `report_error` — confirmed in `yt_dlp/YoutubeDL.py`. So in practice every user-facing failure becomes a `DownloadError` and the current handler works. But the assumption is implicit and brittle to yt-dlp version drift; a release that bypasses the wrap (or a future code path that calls `process_ie_result` more directly) would surface as `"internal error: GeoRestrictedError"` rather than the friendly mapping. The wider catch costs one line.
+- **Fix:** Catch `yt_dlp.utils.YoutubeDLError` (the parent of `DownloadError`) instead. The first-line / friendly-mapping logic still works since both expose `str(exc)`. Defensive widening, no behavior change for current yt-dlp versions.
+
+### LOW-3 — `_reject_livestream_filter` and `_check_not_livestream` have nearly-identical bodies
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/ytdlp.py:135-144`
+- **Why it matters:** `_check_not_livestream` raises `FetchFailed("livestream")` if `_is_livestream(info)` is true; `_reject_livestream_filter` returns the string `"livestream"` (yt-dlp's match-filter contract: returning a non-None reason aborts). Two functions, both wrapping the same one-line predicate. The duplication is explicitly motivated as defense-in-depth (lines 276-278 say so). Fine. But `_reject_livestream_filter`'s `incomplete: bool = False` parameter is unused and exists only because yt-dlp may pass it as a kwarg (per `_match_entry` in yt-dlp source: `match_filter(info_dict, incomplete=incomplete)` with a `TypeError` fallback to `match_filter(info_dict)`). The kwarg exists, but the comment doesn't say so — a reader has to grep yt-dlp to figure out why an unused parameter is there. Trivial — call out the WHY.
+- **Fix:** Either drop `incomplete=False` (yt-dlp's `TypeError` fallback handles old-style filters too — verified in source) and let the function take `info` only, or add a one-line comment explaining yt-dlp's contract. Both cost ~zero; the former is one fewer parameter.
+
+### LOW-4 — `assert isinstance(ALLOWED_HOSTS, frozenset)` test is a tautology
+
+- **Severity:** LOW
+- **Where:** `tests/test_url_validator.py:79-80`
+- **Why it matters:** The test asserts that the literal `frozenset(...)` constructor returned a `frozenset`. That's not testable behavior — it's a Python language guarantee. The intent is "this set must be immutable so middleware can't poison the allowlist at runtime", but the test as written would only fail if someone *changed the source* to `set(...)` — at which point ruff/ty/grep would also flag it. Test scaffolding richer than the surface (PR1-simplify rule #9, applied to tests).
+- **Fix:** Drop the test, or replace with a concrete behavioral assertion (`with pytest.raises(AttributeError): ALLOWED_HOSTS.add("evil.com")`). The latter at least exercises the immutability surface that the comment implies.
+
+### LOW-5 — Module docstring narrates the public surface in prose; redundant with the dataclass/function signatures
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/ytdlp.py:1-21`
+- **Why it matters:** The 21-line docstring opens with "Module functions only — no class. ..." and then enumerates `resolve_track`, `resolve_playlist`, `download`, `validate_video_id` with one-line summaries — duplicating what a reader gets by glancing at the four `def` lines below. The first paragraph (async wrapper, `to_thread`, embedded API, no subprocess/shell) is the WHY worth keeping; the bulleted public surface is WHAT-narration that the type signatures already convey. Project standards: WHY only when non-obvious.
+- **Fix:** Trim to the first paragraph (lines 1-7) plus the closing two sentences about errors/logging (lines 17-21). Drop lines 8-16. ~10 LOC saved without information loss.
+
+### LOW-6 — `# type: ignore[no-any-return]` on `sanitize_info` deserves a one-line WHY
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/ytdlp.py:194`
+- **Why it matters:** `# type: ignore` directives without a comment are project smell — future maintainers can't tell whether this is "the upstream stub is wrong" or "I gave up". `yt_dlp` doesn't ship a `py.typed` marker, so all return types are `Any`; the ignore is silencing ty's "function declared to return `dict[str, Any]` but the call expression's type is unknown". One short trailing comment saves the next reader a 3-minute investigation.
+- **Fix:** `return ydl.sanitize_info(info)  # type: ignore[no-any-return]  # yt-dlp ships no type stubs` — or similar.
+
+### LOW-7 — `paths={"home": str(cache_root / "tmp")}` does not pre-create the `tmp/` directory
+
+- **Severity:** LOW (out-of-scope-leaning)
+- **Where:** `src/ryzic/ytdlp.py:93`
+- **Why it matters:** If `cache_root` exists but `cache_root / "tmp"` does not, `download()` will fail at write time. yt-dlp's `paths.home` is a configuration hint, not a directory-creator. In practice PR3b's audio_cache will create `tmp/` at startup, so this isn't a defect *given the orchestration plan*. Flagging only because if anyone calls `download()` standalone (as the unit tests do) without a pre-existing `tmp/` dir, they'd get a confusing FS error. The existing tests dodge it because they patch `_sync_extract` and never let yt-dlp touch disk.
+- **Fix:** None required for this PR — formalize the precondition in the docstring of `download()` ("`cache_root / 'tmp'` must exist") so PR3b reviewers don't miss it. Or `cache_root.joinpath("tmp").mkdir(parents=True, exist_ok=True)` in `download()` — three lines, idempotent.
+
+### INFO — Things that are genuinely solid (worth saying)
+
+- **`url_validator.py`** is exemplary: 30 LOC, one function, one `frozenset`, and a module docstring whose entire payload is the WHY (regex-based validators happily match `youtube.com.evil.com`). Test coverage hits every allowlisted host individually, the precise HIGH-1 regression, HTTP downgrade, three exotic schemes, two other-platform negatives, malformed/empty inputs, the IPv6 `ValueError` swallow, and the userinfo-smuggle case (`https://youtube.com@evil.com/...`). Case-insensitivity test exists and passes (urlparse lowercases hostnames). The implementation correctly compares `parsed.hostname` (post-userinfo) rather than `parsed.netloc` (which would include `user@host`).
+- **`ytdlp.py` security posture** is tight: `cookiefile=None` with the verbatim comment ("DO NOT enable... requires its own security review before flipping"); `geo_bypass=False`; `max_filesize=500_000_000`; `playlist_items="1-1000"`; `concurrent_fragment_downloads=1`; `restrictfilenames=True`; embedded API only (no subprocess, no shell). All seven security-critical assertions covered by `test_base_opts_security_critical_settings`. Defense-in-depth livestream check (post-extract `_check_not_livestream` PLUS `match_filter=_reject_livestream_filter`) is the right pattern — the filter aborts before bytes hit disk, the post-check covers the resolve_track path that has no filter.
+- **Async correctness**: every yt-dlp call goes through `asyncio.to_thread(_sync_extract, ...)` in `_extract`. There are no sync-blocking yt-dlp calls in the public surface. `_extract` is the single chokepoint, which means future call sites can't accidentally bypass the threading.
+- **Path safety**: `validate_video_id` enforces `^[A-Za-z0-9_-]{6,20}$` BEFORE any path construction (called from `_track_from_info`, `_entry_from_flat`). `download()` independently enforces `dest.resolve().relative_to(cache_root.resolve())` and raises `InvalidVideoID` on escape — sandbox check happens before yt-dlp is invoked (`m.assert_not_called()` test confirms). Two layers of validation; appropriate for the file-write boundary.
+- **Error normalization is a strict layered chain**: `_extract` re-raises `FetchFailed` (so internal raises propagate cleanly), translates `DownloadError` via `_raise_from_download_error`, and wraps everything else with `_log.exception` + `FetchFailed("internal error: ClassName")`. The final-fallback log uses `_log.exception` so the full trace lands in the logs while only the class name reaches the user — exactly the contract §6 specifies.
+- **`extract_flat` correctness**: `resolve_playlist` overrides both `extract_flat=True` and `noplaylist=False` on a per-call basis (lines 238-239); the base opts default to `noplaylist=True, extract_flat=False` for `resolve_track` and `download`. The opts dict isn't shared mutable state (each `_base_opts` call returns a fresh dict — covered by `test_base_opts_does_not_leak_global_state`).
+- **`_entry_from_flat` skip-and-continue policy**: invalid IDs / missing IDs / non-dict entries are dropped silently and the playlist still resolves (covered by `test_resolve_playlist_skips_invalid_entries` with four bad-entry shapes). This matches plan §3 ("Playlist partial-failure: ... `{X} tracks could not be loaded` footer line") — partial failure is a data point for the embed, not an abort condition.
+- **Test depth**: 77 tests, 99-100% coverage on new modules, all yt-dlp interactions mocked (no network). Every edge case in the M1 spec has a corresponding test (HIGH-1 regression, HTTP downgrade, livestream active+upcoming+was_live, three friendly mappings, unknown-error first-line passthrough, internal-error wrapping with caplog assertion, sandbox-escape rejection without invoking yt-dlp, all security-critical opts).
+- **Frozen dataclasses** for `TrackInfo` and `PlaylistInfo` — value semantics, no accidental mutation, hashable. Good fit for cache-key contexts in PR3b/PR4.
+- **No premature abstractions**: no `YtdlpClient` class, no plugin/strategy pattern for error mapping, no `Protocol` for the loggers. Module functions throughout, per `M1-simplify.md` §10. The two error-mapping helpers (`_first_line`, `_map_friendly`) are small, single-purpose, and called once each — borderline-inlineable but break out usefully for the pure-function unit tests at `test_first_line_extracts_first_non_empty`.
+- **Conventional commit**: single commit `feat(ytdlp): wrapper + URL validator + tests` with a precise body; co-author tag present. Will squash-merge cleanly.
+- **No Discord coupling**: confirmed via `grep -r hikari\\|lightbulb src/ryzic/url_validator.py src/ryzic/ytdlp.py` — zero hits. Per plan §12 PR3a constraint.
+
+---
+
+## Overall verdict
+
+**minor revisions** — none of the findings block downstream PRs (PR3b can build on `TrackInfo`/`PlaylistInfo` as-is and the path-safety contract is sound), but MEDIUM-1 (friendly-error layer mismatch with plan) and MEDIUM-2 (`logger` bypass of `no_warnings`) are both worth fixing in this PR rather than deferring. MEDIUM-1 in particular will create awkward duplication when `/play` gets implemented in PR6a — better to pick the layer now while the surface is fresh. The LOW items are 5–10 LOC of polish each, can be batched into a single follow-up commit on this branch or rolled forward.
+
+**One-line summary:** Tight, security-conscious yt-dlp wrapper with exemplary URL validator and 99% test coverage; main issue is the friendly-error layer doing one-and-a-half mappings (returns category codes, not first-lines or finished sentences) — pick one or the other before `/play` lands.

--- a/docs/plans/PR2-security-review.md
+++ b/docs/plans/PR2-security-review.md
@@ -1,0 +1,229 @@
+# PR #2 — Security Review
+
+**PR**: `feat(ytdlp): wrapper + URL validator + tests`
+**Branch**: `feat/ytdlp-and-url-validator` → `main`
+**Repo**: `VeryLongOrgNameSuchWow/ryzic`
+**Commit reviewed**: `092c6a1`
+**Files in scope** (PR diff only):
+- `src/ryzic/url_validator.py` (new, 30 lines)
+- `src/ryzic/ytdlp.py` (new, 278 lines)
+- `tests/test_url_validator.py` (new, 80 lines)
+- `tests/test_ytdlp.py` (new, 386 lines)
+
+No dependency or build-system changes (`pyproject.toml`/`uv.lock` unchanged). `yt-dlp>=2026.3.17` was already declared in PR #1.
+
+This review covers the eight security focus areas from the brief: URL-validator correctness, yt-dlp invocation safety, path traversal, livestream DoS, error-message leakage, resource exhaustion, test isolation, and dependency surface.
+
+---
+
+## Findings
+
+### 1. URL validator — correctness
+
+**Severity**: (informational — no finding)
+**What**: `is_supported_url` uses `urlparse(url).hostname` against a hardcoded `frozenset` allowlist and requires `scheme == "https"`. I exercised every attack vector listed in the brief plus several extras (CRLF/TAB stripping per RFC 3986 normalisation, Cyrillic homoglyphs, NUL bytes, embedded credentials with port, raw IPv6 brackets, path-only URLs, etc.). Every hostile input is rejected; every allowlisted host is accepted (case-insensitively, courtesy of `urlparse` lowercasing).
+
+Sampled cases I ran outside the test suite:
+
+| Input | Result | Outcome |
+| --- | --- | --- |
+| `https://youtube.com.evil.com/x` | hostname=`youtube.com.evil.com` | rejected |
+| `https://youtube.com@evil.com/x` | hostname=`evil.com` | rejected (userinfo split) |
+| `https://www.youtube.com\@evil.com/x` | hostname=`evil.com` | rejected |
+| `https://xn--youtube-com.evil.com/x` | hostname=`xn--youtube-com.evil.com` | rejected |
+| `https://yоutube.com/x` (Cyrillic 'о') | hostname=`yоutube.com` (no IDNA fold) | rejected |
+| `https://youtube.com\x00.evil.com/x` | hostname=`youtube.com\x00.evil.com` | rejected |
+| `http://youtube.com/x` | scheme=`http` | rejected (downgrade) |
+| `https://[::1` | `urlparse` raises `ValueError` | rejected (caught) |
+| `https://youtube.com/\r\nHost: evil.com` | CRLF stripped by `urlparse` → hostname=`youtube.com` | accepted (no smuggling vector — CRLF never reaches yt-dlp) |
+| `https://youtube.com.` (trailing dot FQDN) | hostname=`youtube.com.` | rejected (UX nit, see #2) |
+
+`ALLOWED_HOSTS` is a `frozenset` (asserted in `test_allowed_hosts_is_immutable`). The `ValueError` swallow on malformed IPv6 is explicit and tested. **Verdict: clean.**
+
+---
+
+### 2. URL validator — trailing-dot FQDN rejected
+
+**Severity**: LOW (UX nit, not a security risk)
+**What**: `https://youtube.com./watch?v=...` (trailing-dot rooted FQDN — DNS-equivalent to `youtube.com`) is rejected because the hostname `youtube.com.` is not in `ALLOWED_HOSTS`.
+**Where**: `src/ryzic/url_validator.py:13-21`.
+**Why it matters**: Some link-paste workflows produce trailing-dot URLs. Users will see "URL not supported" for what is in fact a valid YouTube link. Not exploitable.
+**Fix** (optional): strip a single trailing `.` before the lookup, e.g. `host = (parsed.hostname or "").removesuffix(".")`. Or accept the nit — likelihood is low.
+
+---
+
+### 3. yt-dlp plugin auto-loading is enabled by default
+
+**Severity**: MEDIUM (defense-in-depth gap)
+**What**: yt-dlp ≥ 2025 auto-loads plugins on every `YoutubeDL(...)` instantiation, scanning user/system config dirs (`~/.config/yt-dlp/plugins/`, `/etc/yt-dlp/plugins/`, `~/.yt-dlp-plugins/`) and **every entry in `sys.path`** for namespace packages named `yt_dlp_plugins`. The default is `plugin_dirs = ['default']`. Our `_base_opts` does not set `plugin_dirs: []` and the codebase does not export `YTDLP_NO_PLUGINS=1`. I verified live: `from yt_dlp.plugins import plugin_dirs; print(plugin_dirs.value)` → `['default']`.
+**Where**: `src/ryzic/ytdlp.py:79-105` (`_base_opts`); also missing from any module-level setup.
+**Why it matters**: For self-hosters, this means any local package that ships a `yt_dlp_plugins` subpackage (intentionally or by typo-squat in a future `pip install`) gets executed inside the bot process, with full access to the Discord token and the cache filesystem. Exploiting it requires either local write access or a malicious dependency in the env — both are bigger problems on their own — but disabling plugins is a free belt-and-braces hardening that aligns with M1 §6's "embedded API; no subprocess; no shell" posture. The plan does not enumerate this risk; it should.
+**Fix**: Add `plugin_dirs: []` to `_base_opts`, or set `os.environ["YTDLP_NO_PLUGINS"] = "1"` once at module import. Add a `test_base_opts_disables_plugins` assertion. Optionally pair with `allowed_extractors=["youtube", "youtube:tab", "youtube:playlist"]` (see #4).
+
+---
+
+### 4. `allowed_extractors` not constrained
+
+**Severity**: LOW (defense-in-depth gap)
+**What**: yt-dlp's `allowed_extractors` defaults to `['default']`, which permits all bundled extractors including `Generic` (which probes arbitrary HTML for `<video>` tags / m3u8 / etc.). Our hostname allowlist already pins URLs to YouTube domains, so in normal flow only the YouTube extractor matches — but if the YouTube extractor ever reorders its URL match precedence below `Generic`, or if a YouTube URL with an unusual shape falls through to `Generic`, an attacker-controlled YouTube redirect could be processed by an unintended extractor.
+**Where**: `src/ryzic/ytdlp.py:79-105`.
+**Why it matters**: Belt-and-braces. The hostname allowlist is the primary defense; this would be a second wall.
+**Fix**: Add `"allowed_extractors": ["youtube", "youtube:tab", "youtube:playlist", "youtube:search"]` (verify exact extractor IDs you need at integration time). Add a test that `youtube` is in the list and `Generic` is not.
+
+---
+
+### 5. yt-dlp invocation surface — embedded API only, options frozen, sandboxed
+
+**Severity**: (informational — no finding)
+**What**: All yt-dlp work goes through `with YoutubeDL(opts) as ydl: ydl.extract_info(...)` dispatched via `asyncio.to_thread`. No `subprocess`, no shell, no `os.system`, no `Popen`. `_base_opts` returns a fresh dict per call (`test_base_opts_does_not_leak_global_state` confirms). All security-critical options are tested (`test_base_opts_security_critical_settings`):
+
+| Option | Setting | Tested |
+| --- | --- | --- |
+| `cookiefile` | `None` (with security comment forbidding enablement) | yes |
+| `geo_bypass` | `False` | yes |
+| `max_filesize` | `500_000_000` (500 MB cap) | yes |
+| `playlist_items` | `"1-1000"` (cap) | yes |
+| `concurrent_fragment_downloads` | `1` | yes |
+| `restrictfilenames` | `True` | yes |
+| `paths.home` | `cache_root/tmp` (sandboxed) | yes |
+| `format` | Lavaplayer-friendly codec allowlist | yes |
+| `noplaylist` / `extract_flat` | `True` / `False` (overridden in `resolve_playlist`) | yes |
+
+Argv injection is N/A by construction (no argv). `cookiesfrombrowser` is not set (defaults to None), but is *not* mentioned in the cookies comment — see #6. yt-dlp does not pickle untrusted input. The comment at lines 99-103 documents that flipping `cookiefile` requires its own security review. **Verdict: clean.**
+
+---
+
+### 6. Cookies comment mentions `cookiefile` only, not `cookiesfrombrowser`
+
+**Severity**: LOW (documentation gap)
+**What**: yt-dlp also accepts `cookiesfrombrowser=("chrome", profile, container, domain)` which reads cookies from a local browser profile. Our `_base_opts` does not set it (defaults to None, safe), but the security comment in `src/ryzic/ytdlp.py:99-103` only mentions `cookiefile`. A future contributor reading the comment might enable `cookiesfrombrowser` thinking they were sidestepping the prohibition.
+**Where**: `src/ryzic/ytdlp.py:99-103`.
+**Fix**: Extend the comment to "cookies (`cookiefile` AND `cookiesfrombrowser`) are deliberately disabled". Optionally add `"cookiesfrombrowser": None` explicitly and assert it in `test_base_opts_security_critical_settings`.
+
+---
+
+### 7. Path traversal — `download` sandbox enforced
+
+**Severity**: (informational — no finding)
+**What**: `download(url, dest, *, cache_root)` resolves `dest` via `Path.resolve()` (which canonicalises symlinks and `..`), then calls `resolved_dest.relative_to(resolved_root)`. On `ValueError`, raises `InvalidVideoID` BEFORE any yt-dlp call. The absolute resolved dest is then passed as `outtmpl`. Tests cover the escape-via-absolute-path case and the `..`-traversal case (`test_download_rejects_dest_outside_cache_root`, `test_download_rejects_traversal_dest`), and verify yt-dlp is never invoked on rejection (`m.assert_not_called()`).
+
+`outtmpl` is interpreted by yt-dlp as a Python `%`-format template, but since the resolved dest path is built from a regex-validated `video_id` (`^[A-Za-z0-9_-]{6,20}$`, charset excludes `%`, `(`, `)`, `s`), no template substitution can occur. yt-dlp's `_outtmpl_expandpath` calls `os.path.expandvars` / `expanduser`, but `Path.resolve()` already eliminates `~` and the validated charset excludes `$`.
+
+When `outtmpl` is absolute, yt-dlp explicitly ignores `paths` (verified in `YoutubeDL.prepare_filename` line 1537-1538), so the `paths.home = cache_root/tmp` setting is moot for the final filename — it serves only as the directory yt-dlp would have used had outtmpl been relative. Intermediate (`.partial`/`.part`) files are written next to the absolute outtmpl, which still resolves under `cache_root`. **Verdict: clean.**
+
+`validate_video_id` is exposed for the cache layer's pre-construction use, with a dedicated test set (8 valid + 9 invalid including `../../etc/passwd`, `abc/../etc`, URL-encoded). **Verdict: clean.**
+
+---
+
+### 8. Symlink TOCTOU on cache directory
+
+**Severity**: LOW (different threat model)
+**What**: `dest.resolve()` resolves symlinks at check time. If the cache directory has another local user or process with write access, that party could replace `cache_root/audio/dQ` with a symlink to `/etc/` between the `relative_to` check and yt-dlp's actual `open()` call. yt-dlp's `open()` follows symlinks.
+**Where**: `src/ryzic/ytdlp.py:265-273`.
+**Why it matters**: Requires a co-resident attacker with write access to the cache directory — outside the brief's threat model (untrusted Discord user-supplied URLs). Worth noting in the M2 cache-subsystem PR rather than blocking PR #2.
+**Fix** (defer to M2): if you want to guard against this, open the dest with `os.open(dest, O_NOFOLLOW | O_CREAT | O_EXCL, 0o600)` and pass the fd to yt-dlp via a custom downloader — but yt-dlp's downloader accepts paths, not fds, so this is non-trivial. Easier mitigation: ensure cache directory permissions are 0o700 owned by the bot's UID, which is the docker-compose / deploy-doc concern.
+
+---
+
+### 9. Livestream DoS — defended at three layers
+
+**Severity**: (informational — no finding)
+**What**: `download()` sets `match_filter=_reject_livestream_filter` BEFORE invoking yt-dlp. yt-dlp calls the filter inside `_match_entry` both with `incomplete=True` (early, before formats are resolved) and `incomplete=False` (later, with full info). The filter checks both `info["is_live"]` and `info["live_status"] in {"is_live", "is_upcoming"}`, returning a non-None abort reason that yt-dlp surfaces as a `RejectedVideoReached` (mapped to `FetchFailed("livestream")` via the friendly-error layer).
+
+After `_extract` returns, `download()` *also* calls `_check_not_livestream(info)` as defense-in-depth (line 277-278, comment explicit). `resolve_track` calls `_check_not_livestream` post-extraction too. `_LIVE_STATUSES = {"is_live", "is_upcoming"}` correctly excludes `was_live` and `post_live` (which are downloadable VODs); `test_resolve_track_accepts_recorded_was_live` confirms.
+
+YouTube extractor populates `live_status` as a top-level key during initial extraction (verified in `yt_dlp/extractor/youtube/_video.py`), so `incomplete=True` already has the data. No window where bytes hit disk before the check. **Verdict: clean.**
+
+---
+
+### 10. Error message leakage — first-line-only, but not stripped of paths/backticks
+
+**Severity**: LOW (downstream consumer responsibility per M1 §6 item 10, but worth flagging here)
+**What**: `_first_line(str(exc))` returns only the first non-empty line of yt-dlp's `DownloadError`, which limits multi-line traceback / stack info leakage (tested by `test_resolve_track_unknown_download_error_passes_first_line`). However, the first line itself can contain absolute filesystem paths (yt-dlp errors like `ERROR: unable to write to /home/.../cache/audio/dQ/x.m4a`) and backticks. The wrapper does not scrub these.
+
+`_map_friendly` covers three known patterns (age-restricted / private / unavailable) and emits hardcoded user-presentable strings; for any other yt-dlp error, the raw first line is propagated as `FetchFailed(detail)`. Internal exceptions (anything other than `DownloadError`) are wrapped as `FetchFailed(f"internal error: {exc.__class__.__name__}")` (no message text) with full traceback logged at ERROR — that's well-handled.
+
+The `RuntimeError("kaboom")` path is tested (`test_resolve_track_internal_error_logged_and_wrapped`). Crucially, `caplog` confirms `"kaboom"` appears in logs but the test asserts `match="internal error"` for the user-visible message — exception message is not surfaced. Good.
+
+**Where**: `src/ryzic/ytdlp.py:108-128`.
+**Why it matters**: M1 §6 item 10 explicitly says "strip backticks from yt-dlp error strings BEFORE wrapping in inline code". That responsibility lives in the as-yet-unwritten embed builder. If the embed builder consumes `FetchFailed.args[0]` raw, an unsanitised yt-dlp first line could break out of an inline code span (`` `…` ``) or leak the host's `cache_root` path to Discord users. This is a future-PR concern, not a PR #2 bug, **but** the wrapper could provide a sanitised string preemptively (`re.sub(r"[`\\]", "", first_line)` and a length cap) to make consumer code safe-by-default.
+**Fix**: consider sanitising in `_first_line`/`_raise_from_download_error`: collapse runs of whitespace, strip backticks, cap at ~200 chars, replace any absolute path that begins with `cache_root` or `/home/` with `<path>`. This is genuinely defensive — the embed-builder author may forget. Or leave as-is and ensure the embed-builder PR's review explicitly covers it.
+
+---
+
+### 11. Resource exhaustion — bounded everywhere
+
+**Severity**: (informational — no finding)
+**What**:
+- **Per-track size**: `max_filesize=500_000_000` (500 MB).
+- **Playlist length**: `playlist_items="1-1000"`.
+- **Memory on flat playlist**: `extract_flat=True` returns minimal entries (id/title/url/duration); 1000 such entries is ≪ 1 MB of dict.
+- **Subprocess via post-processors**: `_base_opts` declares no `postprocessors` key, so neither `FFmpegExtractAudio`, `FFmpegMerger`, nor `Exec` postprocessor runs by default. Audio-only formats (`bestaudio[ext=...]`) generally don't trigger merging.
+- **External downloaders**: not configured; default native HTTP downloader runs in-process.
+- **Plugins**: see #3 (separate finding).
+- **Concurrent fragments**: `concurrent_fragment_downloads=1` (also a sqlite write-contention guard per M1 §4).
+
+ffmpeg subprocess CAN still be spawned by yt-dlp's automatic merger if a single audio format isn't available and yt-dlp falls back to muxing video+audio (unlikely for `bestaudio[ext=m4a]/...`). If that happens, the cmd is constructed from format URLs and the absolute `outtmpl` (path traversal already blocked); ffmpeg-as-subprocess is itself a hardening concern (sandboxing the ffmpeg binary) but out of M1's scope. **Verdict: clean for the scope of PR #2.**
+
+---
+
+### 12. Tests do not hit the network
+
+**Severity**: (informational — no finding)
+**What**: `test_ytdlp.py` mocks `_sync_extract` and (where it must exercise the inner layer) `YoutubeDL` itself via `unittest.mock.patch`. The test file has no imports of `requests`/`httpx`/`urllib.request`/`socket`. Confirmed by grep across `tests/` and `src/`. `test_url_validator.py` tests pure-function string validation. **Verdict: clean.**
+
+---
+
+### 13. Dependency surface — no changes
+
+**Severity**: (informational — no finding)
+**What**: `pyproject.toml` and `uv.lock` are unchanged in this PR (`git diff main..HEAD` is empty for both). `yt-dlp>=2026.3.17` was already a declared dep in PR #1. The wrapper imports only from `yt_dlp` (`YoutubeDL`, `yt_dlp.utils.DownloadError`) and stdlib (`asyncio`, `logging`, `re`, `dataclasses`, `pathlib`, `typing`, `urllib.parse`). Tests import only stdlib + `pytest` + `yt_dlp.utils.DownloadError`.
+
+Pinned yt-dlp version live in this venv: `2026.03.17`. Floor pin only, per M1 §6 item 8 ("rely on uv lock"); follow-up issue for renovate/dependabot is already noted in the plan. **Verdict: clean.**
+
+---
+
+### 14. Validator not enforced inside the wrapper (defense-in-depth gap)
+
+**Severity**: LOW
+**What**: `resolve_track`, `resolve_playlist`, and `download` all accept arbitrary URL strings and pass them straight to yt-dlp. The plan deliberately puts URL validation in the `/play` command call site ("BEFORE yt-dlp sees the URL", M1 §6 item 3). If a future code path forgets to call `is_supported_url` first, the wrapper will happily resolve a non-allowlisted host.
+**Where**: `src/ryzic/ytdlp.py:218, 230, 257`.
+**Why it matters**: One missed call site at the consumer becomes a privilege bypass. The wrapper has the validator one import away.
+**Fix**: at the top of `resolve_track`, `resolve_playlist`, and `download`, `from .url_validator import is_supported_url; if not is_supported_url(url): raise FetchFailed("unsupported URL")`. Add a test per function asserting non-YouTube URLs are rejected without invoking yt-dlp. Cost: 3 lines + 3 tests; payoff: closes the entire class of "callsite forgot to validate" bugs.
+
+---
+
+### 15. `entry["url"]` from playlist entries is trusted, not re-validated
+
+**Severity**: LOW (related to #14)
+**What**: `_entry_from_flat` reads `entry.get("url")` from yt-dlp's flat playlist response and uses it as `TrackInfo.url`. A malicious playlist could (in principle) list arbitrary URLs as its entries' webpage URLs. The downstream `/play` consumer would then call `resolve_track(track.url)` per entry.
+**Where**: `src/ryzic/ytdlp.py:181`.
+**Why it matters**: If `resolve_track` doesn't re-run `is_supported_url` (see #14), yt-dlp would resolve whatever the playlist author chose. The fallback `f"https://youtu.be/{video_id}"` is safe because `video_id` is regex-validated.
+**Fix**: subsumed by #14 — if `resolve_track` enforces `is_supported_url`, this is closed.
+
+---
+
+### 16. Test naming nit — friendly-error test message assertion
+
+**Severity**: LOW (test fragility)
+**What**: `test_resolve_track_unknown_download_error_passes_first_line` asserts `"ERROR" in msg`. This works because the test's `raw` string starts with `"ERROR: yt-dlp something went wrong"`. If yt-dlp ever changes its error prefix (no longer "ERROR:"), the test would still pass on this synthetic input but mask a real downstream change. Minor.
+**Where**: `tests/test_ytdlp.py:188-198`.
+**Fix** (optional): assert against the exact first-line string `"ERROR: yt-dlp something went wrong"`, or drop the substring check entirely (the multi-line stripping is what's being tested, and that's already covered by the absence of "second line"/"third").
+
+---
+
+## Summary
+
+| Severity | Count |
+| --- | ---: |
+| HIGH (merge-blocking) | 0 |
+| MEDIUM (fix soon) | 1 |
+| LOW (nit) | 6 |
+
+The single MEDIUM is **#3 (yt-dlp plugin auto-loading)** — a one-line hardening (`plugin_dirs: []`) that closes a defense-in-depth gap not enumerated in M1 §6. Worth fixing in this PR or as an immediate follow-up before the wrapper is wired into `/play`. The LOWs are all defense-in-depth or polish; none are exploitable from a Discord-user-supplied URL given the current call surface.
+
+The brief's primary attack vectors — URL-allowlist bypass via `youtube.com.evil.com` / userinfo / IDN / control characters / scheme downgrade; argv injection; path traversal via `outtmpl` or `dest`; livestream DoS — are all defended, well-tested (67 tests, all passing in 0.10 s, mocked-network), and reflect the M1 plan's stated security model.
+
+## Verdict
+
+**fixes recommended** — not merge-blocking. Address #3 (MEDIUM) in this PR or as the next immediate commit on the branch; #6, #10, #14 should land before PR #3 (`/play` integration); #2, #4, #8, #15, #16 are optional polish.

--- a/docs/plans/PR2-simplify.md
+++ b/docs/plans/PR2-simplify.md
@@ -1,0 +1,243 @@
+# PR #2 Simplification Pass — `feat(ytdlp): wrapper + URL validator + tests`
+
+**Branch:** `feat/ytdlp-and-url-validator` -> `main`
+**Diff reviewed:** +774 LOC across 4 files (250 LOC src, 524 LOC tests).
+**Companion docs:** `docs/plans/M1-simplify.md` (already-decided plan-level cuts), `docs/plans/M1.md` §6 (PR3a spec).
+
+This pass looks only for code that's *more elaborate than its M1 §6 surface justifies*. It does **not** re-litigate decisions already locked in `M1-simplify.md` (flat module layout, `errors.py` central placement, no `YtDlpService` class). It does not critique correctness or security — those are other agents' lanes.
+
+Honest framing: the source module is mostly tight, but it has one clear pattern of over-decomposition (a chain of single-call helpers around the `DownloadError` translation path). The test file is rich; ~80 LOC could come out without losing assertion coverage.
+
+---
+
+## Findings
+
+### S-1 — Collapse the `_first_line` -> `_map_friendly` -> `_raise_from_download_error` chain into the one `except DownloadError` block
+
+**What to cut/collapse:** Three single-call helpers (`_first_line`, `_map_friendly`, `_raise_from_download_error`) spread across 21 LOC, each used exactly once from the `except DownloadError` block in `_extract`. Inline the whole chain:
+
+```python
+except DownloadError as exc:
+    detail = next(
+        (s for s in (line.strip() for line in str(exc).splitlines()) if s),
+        str(exc).strip(),
+    )
+    friendly = next((f for n, f in _FRIENDLY_ERROR_PATTERNS if n in detail), None)
+    raise FetchFailed(friendly or detail) from exc
+```
+
+That eliminates the awkward `raise AssertionError("unreachable")  # pragma: no cover` line that `_raise_from_download_error` forces (rule 6 — defensive at internal boundary, present only because static analysis can't see through the helper).
+
+**Where:**
+- `src/ryzic/ytdlp.py:108-128` (`_first_line`, `_map_friendly`, `_raise_from_download_error`)
+- `src/ryzic/ytdlp.py:208-212` (the unreachable-assert workaround in `_extract`)
+- `tests/test_ytdlp.py:365-376` (the `test_first_line_extracts_first_non_empty` parametrized block)
+
+**Why it's safe:** Every helper here is called from exactly one place. The "rule of three" mandates 3+ similar usages before extracting a helper; these are at one usage each. Inlining keeps the error-translation logic in one place where it actually fires (`_extract`), removes one source of "where does control flow when `_raise_from_download_error` returns?" confusion, and lets the type checker see that the `except DownloadError` block raises unconditionally — no `AssertionError("unreachable")` workaround needed.
+
+The `_first_line` test goes away — its behaviour is already covered by `test_resolve_track_unknown_download_error_passes_first_line` and `test_resolve_track_maps_known_errors`, which exercise it through the public API. Internal-helper micro-tests (rule 11) duplicate the public-surface coverage.
+
+If a future caller needs `_first_line` again (the M1 plan does not anticipate one), reintroduce it then.
+
+**Estimated LOC saved:** ~30 LOC (21 src + 12 tests, minus ~3 LOC inlined back into `_extract`).
+
+---
+
+### S-2 — Drop the `_check_not_livestream` helper; keep `_is_livestream` and inline the raise
+
+**What to cut/collapse:** `_check_not_livestream` (3 LOC) is a wrapper that exists only to combine `_is_livestream(info)` + `raise FetchFailed("livestream")`. It's called twice — once in `resolve_track`, once in `download` (the "defense-in-depth" post-check; see S-3). Inline both call sites:
+
+```python
+if _is_livestream(info):
+    raise FetchFailed("livestream")
+```
+
+That's two lines vs. the helper-call's one. The win isn't LOC; it's removing one indirection layer from a hot read path. `_is_livestream` (the actual predicate) stays — it's used by `_reject_livestream_filter` too, so it earns the rule-of-three threshold.
+
+**Where:** `src/ryzic/ytdlp.py:135-137` (the helper); `src/ryzic/ytdlp.py:226, 278` (call sites).
+
+**Why it's safe:** Two-line raise idioms are a Python staple; wrapping them costs more in indirection than they save in LOC. Helpers/wrappers around yt-dlp logic that just thin-pass arguments (rule 1) — this one isn't quite thin-pass, but it's a glorified two-statement combo.
+
+If S-3 lands (cutting one of the two callers), `_check_not_livestream` becomes a pure single-call helper and S-2 becomes a near-zero-thought inline.
+
+**Estimated LOC saved:** ~3 LOC.
+
+---
+
+### S-3 — Pick one livestream guard for `download()`: `match_filter` OR post-extract check, not both
+
+**What to cut/collapse:** `download()` currently sets `opts["match_filter"] = _reject_livestream_filter` AND calls `_check_not_livestream(info)` after. The author's own comment admits this is duplication: *"Defense-in-depth: `match_filter` should have aborted, but a post-check costs nothing and keeps the contract explicit."*
+
+Pick one. **Recommended: drop the `match_filter` callback and keep the post-check.** Reasoning:
+
+- The post-check uses the exact same `_is_livestream(info)` predicate as `resolve_track`, so the contract is symmetric: "all info dicts handed to a public function are livestream-checked at the same point." One mental model.
+- `match_filter` is yt-dlp library indirection — when `_reject_livestream_filter` returns `"livestream"`, yt-dlp wraps it in a `RejectedVideoReached` -> `DownloadError` -> we then translate that back via `_raise_from_download_error`. Three layers of bouncing for what the post-check does in one. Test `test_download_rejects_livestream` covers exactly this path with the post-check alone.
+- The "before bytes hit disk" justification is thin: `extract_info(download=True)` runs metadata extraction first and only starts writing after `match_filter` clears. The post-check sees the same info dict at the same point in time — there is no race.
+
+That removes `_reject_livestream_filter` (5 LOC) and the test `test_reject_livestream_filter_*` pair (8 LOC).
+
+**Where:**
+- `src/ryzic/ytdlp.py:140-144` (`_reject_livestream_filter`)
+- `src/ryzic/ytdlp.py:274` (`opts["match_filter"] = ...`)
+- `src/ryzic/ytdlp.py:276-278` (the "Defense-in-depth" comment + check stays — but the comment loses the "match_filter should have aborted" framing)
+- `tests/test_ytdlp.py:311` (the `assert opts["match_filter"] is ...` assertion)
+- `tests/test_ytdlp.py:379-386` (both `test_reject_livestream_filter_*` tests)
+
+**Why it's safe:** Defense-in-depth at internal boundaries is rule-6 territory: validate at system edges, not at every function call between trusted parties. Both checks here run against an info dict yt-dlp produced from the URL we already validated upstream. There is no system boundary between the match_filter callback and the post-check — both fire inside the same `_extract` call. Picking the simpler one is the right move.
+
+This is also the single biggest "feels like duplication" item in the file.
+
+**Estimated LOC saved:** ~14 LOC (5 src helper + 1 src wiring + 8 tests).
+
+---
+
+### S-4 — Inline `_coerce_duration_ms`
+
+**What to cut/collapse:** `_coerce_duration_ms` is 4 lines (signature + docstring + 2 body lines), called twice. Inline as `int(float(raw or 0) * 1000)` at both call sites:
+
+```python
+duration_ms=int(float(info.get("duration") or 0) * 1000),
+```
+
+**Where:** `src/ryzic/ytdlp.py:147-151` (the helper); `:164, :184` (call sites).
+
+**Why it's safe:** Two callers + a one-line body falls below the rule-of-three abstraction threshold. The inlined expression is short enough to read at a glance, and the meaning ("seconds to ms with a None-safe default") is obvious without naming it.
+
+The `raw or 0` collapses the explicit `is None` branch — `0` and `0.0` map to `0 ms` either way, and yt-dlp doesn't surface other falsy non-None values for `duration` (no booleans, no strings).
+
+Marginal call. Defensible to keep if you'd rather have the named helper for grep-ability. Leans cut.
+
+**Estimated LOC saved:** ~3 LOC.
+
+---
+
+### S-5 — Drop `test_base_opts_does_not_leak_global_state`
+
+**What to cut/collapse:** `tests/test_ytdlp.py:353-357` asserts that `_base_opts(tmp_path)` returns a fresh dict each call by mutating one and verifying the other is untouched.
+
+**Where:** `tests/test_ytdlp.py:353-357`.
+
+**Why it's safe:** This tests Python language semantics (a function returning a dict literal returns a new dict each call), not a behavioural contract of `_base_opts`. The function's body is one `return {...}` literal — there is no global state to leak. The only way this test would fail is if someone refactored `_base_opts` to return a module-level constant — at which point the security-critical-settings test would still pass and several other tests would break in clearer ways (e.g. `test_download_invokes_extract_with_outtmpl` mutates `opts["outtmpl"]`).
+
+Test scaffolding richer than the surface it tests (rule 11) — an implementation-detail test for a behaviour the language already guarantees.
+
+**Estimated LOC saved:** ~6 LOC (function + decorator + blank line above).
+
+---
+
+### S-6 — Parametrize the three `resolve_track` livestream tests
+
+**What to cut/collapse:** `test_resolve_track_rejects_active_livestream`, `test_resolve_track_rejects_upcoming_livestream`, and `test_resolve_track_accepts_recorded_was_live` are three near-identical 6-LOC functions distinguished only by their `info` payload and pass/fail expectation. Collapse into a single parametrized test:
+
+```python
+@pytest.mark.parametrize(
+    ("live_status", "is_live", "rejects"),
+    [
+        ("is_live", True, True),
+        ("is_upcoming", False, True),
+        ("was_live", False, False),  # downloadable VOD
+    ],
+)
+async def test_resolve_track_livestream_handling(
+    tmp_path: Path, live_status: str, is_live: bool, rejects: bool
+) -> None:
+    info = _track_info(is_live=is_live, live_status=live_status)
+    with patch.object(ytdlp, "_sync_extract", return_value=info):
+        if rejects:
+            with pytest.raises(FetchFailed, match="livestream"):
+                await ytdlp.resolve_track(TRACK_URL, cache_root=tmp_path)
+        else:
+            track = await ytdlp.resolve_track(TRACK_URL, cache_root=tmp_path)
+            assert track.video_id == YTID
+```
+
+**Where:** `tests/test_ytdlp.py:112-136` (three tests, 25 LOC including blank lines).
+
+**Why it's safe:** Per the user's PR brief item 11 ("Any tests that could be parameterised?") — yes, these. The three tests share the entire scaffold (mock setup, cache_root plumbing, exception-context shape) and differ only in two fields and the expected outcome. Parametrization makes the data-driven nature of the case matrix visible at a glance: "here are the three cases, here's what we do with each."
+
+Mild downside: the test now branches on a bool, which is a small smell. If you find that distasteful, an alternative split is one parametrized test for the rejection cases (active + upcoming) and a separate single test for the `was_live` accept case — still 12 LOC under the current 25.
+
+**Estimated LOC saved:** ~12 LOC.
+
+---
+
+### S-7 — Convert `_FRIENDLY_ERROR_PATTERNS` to a dict literal
+
+**What to cut/collapse:** The patterns are stored as `tuple[tuple[str, str], ...]`. The substring iteration `for needle, friendly in _FRIENDLY_ERROR_PATTERNS` works just as well over `dict.items()`:
+
+```python
+_FRIENDLY_ERRORS: Final[dict[str, str]] = {
+    "Sign in to confirm your age": "age-restricted",
+    "Private video": "private video",
+    "Video unavailable": "region-blocked or unavailable",
+}
+```
+
+The `Final` type changes from `Final[tuple[tuple[str, str], ...]]` to `Final[dict[str, str]]` — shorter and more idiomatic.
+
+**Where:** `src/ryzic/ytdlp.py:46-54` (and the iteration site, which moves into the inlined block from S-1).
+
+**Why it's safe:** Rule 2 — error mapping that could be a dict literal. The tuple-of-tuples shape costs a type annotation that's twice as long for no semantic gain. Order-of-iteration doesn't matter (the comment on line 49 even calls this out: *"Order doesn't matter — each pattern is unique enough to discriminate."*) — a dict's insertion-ordered iteration matches what the tuple does. If two patterns ever overlap, the comment becomes a lie either way.
+
+Pure mechanical cleanup; pair with S-1 since both touch the same lines.
+
+**Estimated LOC saved:** ~0 LOC (same line count, slightly shorter type annotation).
+
+---
+
+## Things I considered cutting and decided not to
+
+### `validate_video_id` exposed publicly (PR brief item 7)
+**Keep public.** PR brief asked: "exposed publicly when it's only used internally?" Answer: it's NOT only internal. M1 §4 *"Path safety"* explicitly says video IDs are validated *before path construction* — that happens in the audio cache layer (PR3b, separate module). Keeping `validate_video_id` public lets the cache layer pre-validate an ID before constructing a `Path`, exactly as the M1 plan calls out. The module docstring already explains this. Recutting now means re-introducing in PR3b with no net win.
+
+### `_entry_from_flat` returns-None-on-invalid pattern (PR brief item 10)
+**Keep.** PR brief asked: "clean or muddled?" My read: clean. The function is a filter-shaped predicate-and-construct: "given a possibly-bad entry, hand back a `TrackInfo` or skip it." The alternative — raising and try/except'ing in the comprehension — is uglier and slower. The call site `[t for t in (_entry_from_flat(e) for e in raw if isinstance(e, dict)) if t is not None]` is dense but each filter has a distinct job (skip non-dicts, then skip unusable entries). Per M1 §3 the playlist embed surfaces partial-failure counts rather than aborting — None-on-skip directly supports that.
+
+The one nit: the inner `isinstance(e, dict)` filter could move *into* `_entry_from_flat` (cast `entry: Any` on the signature), reducing the comprehension to `[t for t in map(_entry_from_flat, raw) if t is not None]`. Mild simplification at the call site, mild loss of type safety on the helper. I'd leave it.
+
+### `TrackInfo` / `PlaylistInfo` as frozen dataclasses (PR brief item 5)
+**Keep.** PR brief asked: "could be a tuple? could be None?" Both have real shape: `TrackInfo` has 5 named fields with mixed types (str, str, str, str, int), `PlaylistInfo` has 3 including a list of `TrackInfo`. A `NamedTuple` would also work but doesn't beat `@dataclass(frozen=True)` for readability or mutation safety. A bare tuple loses the field names that callers (cache layer, embed builders, queue) will access by name. None of these would simplify.
+
+### `_track_from_info` vs `_entry_from_flat` (similar but separate)
+**Keep separate.** They look duplicative but the differences are real and load-bearing: `_track_from_info` raises on missing/invalid id (full extraction MUST yield an id); `_entry_from_flat` returns None (partial-failure tolerance per M1 §3); they prefer different URL fields (`webpage_url` vs `url`), and `_entry_from_flat` synthesizes a fallback URL from the id. Folding them into one function with a `raise_on_error: bool` flag would replace clean two-purpose helpers with a parameterized abstraction (rule 4 — flag arguments are anti-patterns when they switch behaviour). Three similar lines is better than a premature abstraction; ten similar lines with three real branches is *also* better than one parameterized helper.
+
+### `validate_video_id` separate-function form (vs. inlining the regex)
+**Keep.** Used in `_track_from_info`, `_entry_from_flat`, exposed publicly for the cache layer, and tested directly. Three call sites = above the rule-of-three threshold. The named function also documents the contract better than `_VIDEO_ID_RE.match(...)` at every call.
+
+### `_sync_extract` and `_extract` as separate functions
+**Keep both.** `_sync_extract` is the work the worker thread does; `_extract` is the async-and-error-normalize wrapper. Splitting them means the thread runs only the yt-dlp call (correct — no asyncio code in the worker), and the async layer can wrap exceptions cleanly. Inlining `_sync_extract` into `_extract` would put the `with YoutubeDL(...) as ydl: ...` block inside an `asyncio.to_thread(lambda: ...)` lambda — uglier and harder to mock.
+
+### `url_validator.py` (entire file)
+**Keep as-is.** 30 LOC including the docstring; one allowlist + one function. Module docstring explains *why* (regex check rejected upstream — review HIGH-1). `frozenset` is the right type. `is_supported_url` is one line. No fat to trim.
+
+### `test_url_validator.py` (entire file)
+**Keep as-is.** 80 LOC, fully parametrized, three groups (accepted, rejected, malformed) plus four edge-case singletons (urlparse `ValueError`, userinfo smuggling, case-insensitivity, frozenset immutability). Each singleton documents a non-obvious property that a parametrized list would obscure with a one-line case ID. The `test_allowed_hosts_is_immutable` could arguably go (tests language semantics), but it's three lines and pins a security contract — keep.
+
+### `test_base_opts_security_critical_settings`
+**Keep.** Pins every security-critical default in §6 against accidental change. Rule 11 might suggest "rich tests for a config dict" but every assertion here is a documented HIGH-priority security item — `cookiefile=None` (item 13), `geo_bypass=False`, `max_filesize` (item 5), `concurrent_fragment_downloads` (item 4 race), the codec allowlist (review §6 LOAD_FAILED). One test, one assertion per security concern, perfectly proportioned.
+
+### Comments narrating WHAT (rule 9)
+**Mostly absent.** I scanned every comment in the diff and they're all WHY-style — the cookies-disabled comment (security item 13), the format-priority comment (Lavaplayer codec constraint), the partial-failure comment (M1 §3 reference), etc. The one borderline case is the docstring on `_first_line` ("Return the first non-empty line ... defensively trimmed") which narrates WHAT — but S-1 deletes this helper anyway, so moot.
+
+### `extract_flat` opts-override pattern in `resolve_playlist`
+**Keep.** Three lines mutating the dict from `_base_opts(...)` — `opts["noplaylist"] = False; opts["extract_flat"] = True`. Could be `_base_opts(cache_root) | {"noplaylist": False, "extract_flat": True}`. Same LOC, same readability. Status quo is fine.
+
+### `resolve_track` / `resolve_playlist` / `download` as three module-level functions
+**Keep.** The M1-simplify decision (§10) explicitly rejected a `YtDlpService` class. Three functions are the right shape. None of them thin-pass to `_extract`; each has its own setup (opts mutation, dest sandbox check) and post-processing.
+
+---
+
+## Top 3 wins
+
+1. **S-1: Collapse the error-translation helper chain (~30 LOC)** — Three single-call helpers + their unreachable-assert workaround + a parametrized test for one of them, all replaced by ~3 lines inside `except DownloadError`. Largest single cut; the inlined version is more readable because the entire DownloadError translation path lives in one place.
+2. **S-3: Pick one livestream guard for `download()` (~14 LOC)** — Drops `match_filter` callback + its tests, keeps the post-check. Removes the file's only acknowledged "defense-in-depth at an internal boundary" smell.
+3. **S-6: Parametrize the three livestream-handling `resolve_track` tests (~12 LOC)** — Three near-identical tests collapse into one parametrized case matrix that makes the live/upcoming/was_live decision table visible at a glance.
+
+## Total LOC the PR could lose
+
+- **Solid wins (S-1, S-2, S-3, S-5, S-6, S-7): ~65 LOC** (out of 774 total, or ~8%).
+- **Including S-4 optional: ~68 LOC.**
+
+Source side: ~28 LOC trimmed from `ytdlp.py` (250 -> ~222). Test side: ~38 LOC trimmed (524 -> ~486), still well above the security-critical assertions.
+
+Headline: this PR is mostly tight, but the `DownloadError` translation chain and the `download()` defense-in-depth pair are the two real fat patterns. The rest of the cuts are sub-15-LOC trims around them. The URL validator and its tests are pristine — no recommendations there.

--- a/docs/plans/PR3-review.md
+++ b/docs/plans/PR3-review.md
@@ -1,0 +1,152 @@
+# PR #3 Review — `feat(audio): lavalink.py wire-up + voice bridge`
+
+**Branch:** `feat/lavalink-wireup` → `main`
+**Scope per plan:** `docs/plans/M1.md` §7 (lavalink.py wire-up + voice bridge — known hazard zone) and §12 PR5.
+**Diff:** +837/-2 LOC across 5 files (`bot.py` +20, `commands/__init__.py` +1, `commands/lltest.py` +60, `lavalink_glue.py` +457, `tests/test_lavalink_bridge.py` +299).
+**Local verification:** `uv run ruff check`, `uv run ty check`, `uv run pytest -q` — all green (30 tests, ~0.4s).
+
+---
+
+## Findings
+
+### MEDIUM-1 — `LavalinkNotReadyError` is wrapped by linkd; downstream catches will not see it
+
+- **Severity:** MEDIUM
+- **Where:** `src/ryzic/lavalink_glue.py:421-435` (factory + DI wiring); the implementer's report claims "the DI factory raises `LavalinkNotReadyError` if resolved before bootstrap" and that PR6a's `/play` "should catch and respond `Audio service is down…`".
+- **Why it matters:** linkd's container resolution wraps every factory exception in `DependencyNotSatisfiableException` — see `.venv/lib/python3.13/site-packages/linkd/container.py:259-268`:
+  ```python
+  except Exception as e:
+      raise exceptions.DependencyNotSatisfiableException(
+          f"could not create dependency {dependency_id!r} - factory raised exception"
+      ) from e
+  ```
+  So a `/play` handler that does `lavalink_client: lavalink.Client = lightbulb.di.INJECTED` (the natural DI surface) will see `DependencyNotSatisfiableException` with `LavalinkNotReadyError` only in `__cause__`. The plan-mandated friendly path (plan §3: `"Audio service is down. Try again in a minute."`) requires either catching `DependencyNotSatisfiableException` (couples `/play` to the DI library's exception type, defeating the abstraction) OR walking `e.__cause__` (brittle). The PR commits the implementer to a contract that the runtime won't honor.
+  Note: `/lltest` sidesteps this entirely by calling `lavalink_glue.get_lavalink_client()` directly and checking for `None` — that pattern works. The DI factory in its current form is mostly dead surface that PR6a will discover is wrong.
+- **Fix:** Pick one of (a) drop the DI factory entirely and have PR6a use `lavalink_glue.get_lavalink_client()` (returns `Optional[Client]`) — that's the pattern `/lltest` already uses and it composes cleanly with the "service is down" branch; the DI registration is one of those premature flexibilities that PR6a will pay for. Or (b) keep the factory but **document explicitly** in the docstring that callers must catch `DependencyNotSatisfiableException` and inspect `__cause__`, and add a test pinning that contract so PR6a doesn't get blindsided. (a) is closer to KISS and keeps `/play` honest about the actual lifecycle. The factory + `LavalinkNotReadyError` pair as it stands is two layers of indirection for a bool check.
+
+### MEDIUM-2 — Voice-state listener gates the handshake-ready signal behind `_ll_client is None`
+
+- **Severity:** MEDIUM
+- **Where:** `src/ryzic/lavalink_glue.py:358-374`
+- **Why it matters:** `_on_voice_state_update` returns early if `_ll_client is None`. The `_voice_ready_event(guild_id).set()` block lives **after** that early return. Practical implication: if a `VoiceStateUpdateEvent` for our own user arrives during the bootstrap window — e.g., a residual state from a previous session that hikari delivers right after `ShardReadyEvent` — the event will not be marked ready. In normal `/play` flow this is benign (PR6a's `/play` requires the lavalink client up before it gets to the handshake-wait), but the docstring on `_on_voice_state_update` doesn't reflect that the handshake-ready bookkeeping shares fate with lavalink dispatch. It's an invisible coupling: someone reading "voice handshake race fix" elsewhere in the codebase will assume the event is set on every bot-self join, and the bug will only surface under reconnect timing.
+- **Fix:** Move the handshake-ready bookkeeping above the `_ll_client is None` short-circuit (or split into two separate listeners — bridge-forwarder and handshake-tracker — so each has a single responsibility per SRP). Two listener functions wired separately is the cleaner shape: it also makes `_on_voice_server_update` / `_on_voice_state_update` / `_on_voice_state_handshake` independently testable.
+
+### MEDIUM-3 — `_on_voice_state_update` short-circuit is not tested
+
+- **Severity:** MEDIUM
+- **Where:** `tests/test_lavalink_bridge.py` — only `test_voice_server_listener_short_circuits_when_client_missing` exists; the symmetric state-listener test is missing.
+- **Why it matters:** Both listeners contain the same `if _ll_client is None: return` guard. Coverage of one but not the other is the kind of asymmetry that lets a future refactor regress one half silently. The PR description's test plan claims "listener short-circuit when client not yet bootstrapped" without qualifier — it's only half implemented.
+- **Fix:** Add a parallel `test_voice_state_listener_short_circuits_when_client_missing` mirroring the server one. Five lines.
+
+### LOW-1 — `_make_starter` factory adds indirection without earning it
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/bot.py:39-48, 69`
+- **Why it matters:** The implementer's report explains the indirection as "lambda fails inspect.iscoroutinefunction check". That's true for lambdas, but `_make_starter` returns an `async def` regular function — `bot.subscribe(StartingEvent, async_def_handler)` accepts it directly (verified in `.venv/lib/python3.13/site-packages/hikari/impl/event_manager_base.py:441-449`, which calls `inspect.iscoroutinefunction(callback)`). The factory closure exists only to capture `client` — a top-level `async def _on_starting(event, client=client)` or, more simply, a top-level coroutine that takes `client` from a module-level closure / partial would be the same shape with less ceremony. Net effect: 10 lines + a `Callable[[hikari.StartingEvent], Coroutine[None, None, None]]` type signature + `TYPE_CHECKING` import for what could be five lines inline:
+  ```python
+  async def _on_starting(_: hikari.StartingEvent) -> None:
+      await client.load_extensions("ryzic.commands.lltest")
+      await client.start()
+  bot.subscribe(hikari.StartingEvent, _on_starting)
+  ```
+  defined inside `main()` after `client` is created. Captures `client` via lexical scope. The factory pattern is a leftover from a class-based design that didn't survive simplification.
+- **Fix:** Inline the closure into `main()`. Drop `_make_starter`, drop `Callable`/`Coroutine` from `TYPE_CHECKING`. Reads better, no behavior change.
+
+### LOW-2 — `_auto_leave` swallows `CancelledError` instead of re-raising
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/lavalink_glue.py:120-124`
+- **Why it matters:** Standard asyncio idiom is to re-raise `CancelledError` after cleanup so the task is marked `cancelled()` rather than completed. Returning normally from the cancel handler means `task.cancelled()` returns False after cancellation — and indeed the test at `tests/test_lavalink_bridge.py:282` had to weaken the assertion to `first_task.cancelled() or first_task.cancelling()` to cope. The `cancelling()` half passes for the wrong reason (it's truthy because the cancellation was *requested*, not because the task acknowledged it). Functionally harmless here because no caller waits on the task to settle, but it's a smell that makes the test less informative and complicates future refactors that might `gather()` these tasks.
+- **Fix:**
+  ```python
+  async def _auto_leave(bot: hikari.GatewayBot, guild_id: int) -> None:
+      try:
+          await asyncio.sleep(AUTO_LEAVE_SECONDS)
+      except asyncio.CancelledError:
+          raise
+      ...
+  ```
+  Or just drop the `try/except` entirely — `asyncio.sleep` re-raises by default; the explicit handler is doing nothing useful. Tighten `test_auto_leave_replaces_existing_timer` to assert `first_task.cancelled()` (await it briefly first to let the cancellation land).
+
+### LOW-3 — `wait` happens-before-`set` ordering is not tested
+
+- **Severity:** LOW
+- **Where:** `tests/test_lavalink_bridge.py:196-237`
+- **Why it matters:** The handshake-race fix is the load-bearing piece of the PR. Existing tests cover (a) join-then-wait (event already set), (b) wait-then-timeout (no join). The interesting case for a race fix is **wait first, then join sets event** — that's what `/play` will actually do (call `bot.update_voice_state` then `await wait_for_voice_ready`). The current tests don't pin that ordering. A regression where `_voice_ready_event` is created twice (e.g., a future change replaces the dict lookup with `_voice_ready_events.setdefault(guild_id, asyncio.Event())` called at both sides racing) would not be caught.
+- **Fix:** Add a test along the lines of:
+  ```python
+  async def test_wait_for_voice_ready_resolves_when_join_arrives_after_wait_starts() -> None:
+      lavalink_glue._set_lavalink_client_for_test(...)
+      wait_task = asyncio.create_task(lavalink_glue.wait_for_voice_ready(111, timeout=1.0))
+      await asyncio.sleep(0)  # let wait start
+      await lavalink_glue._on_voice_state_update(_make_voice_state_event(user_id=42, bot_user_id=42, channel_id=999))
+      assert await wait_task is True
+  ```
+
+### LOW-4 — `voice_update_handler` is awaited from listener body; long lavalink ops will block listener throughput
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/lavalink_glue.py:352-361`
+- **Why it matters:** hikari dispatches listeners as `asyncio.create_task` per-listener (so multiple listeners run concurrently for the same event), but inside a single listener the body runs sequentially. `voice_update_handler` issues a REST call to lavalink (`update_player`), which blocks the listener until that round-trip completes. In practice it's fast; in a degraded-network scenario with the lavalink server unreachable, every voice event for every guild blocks until the per-request timeout. lavalink.py doesn't expose `update_player` as fire-and-forget. Not a bug — noting because the implementer's claim "listeners short-circuit when client not yet bootstrapped" doesn't extend to "and never block on a slow lavalink." Future-incident watchlist.
+- **Fix:** None required for M1. Document in the watchlist.
+
+### LOW-5 — `EventHandler.on_track_exception` formats `event.cause` (a stack trace) into the user-facing notice
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/lavalink_glue.py:227`
+- **Why it matters:** `event.message` is `Optional[str]` (a short cause description). `event.cause` is the JVM stack-trace string from Lavalink — multi-line, often hundreds of chars. The fallback `event.message or event.cause` will dump a stack trace into the channel when `message` is null (which lavalink does emit for some failures). Discord will still send it but it's UX noise. PR6a will likely move this to an embed builder; the inline version is for the throwaway window so it's low-impact.
+- **Fix:** Cap to first line or first 120 chars: `(event.message or event.cause or "unknown").splitlines()[0][:120]`. Or just `event.message or "unknown error"` — `cause` is debugger fodder, not user-facing.
+
+### LOW-6 — `/lltest` calls `player_manager.create()` purely as a side-effecting reachability probe
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/commands/lltest.py:48-52`
+- **Why it matters:** `create()` instantiates a `DefaultPlayer` and stores it in `player_manager.players[guild_id]`. The lltest never uses the returned player; it just wants to verify that node selection works. A user who runs `/lltest` then `/play` (when PR6a lands) will hit the existing player. That's idempotent (`create` returns the existing player), so no functional bug — but it's a mismatch between the command's apparent purpose ("smoke check") and its actual side effect ("create a player on the lowest-penalty node"). Keep in mind for PR6b's removal — `/lltest` going away means orphaned players go away with it.
+- **Fix:** Either drop the `create()` call (just listing nodes is enough for "lavalink reachable"), or add a comment that this intentionally exercises the node-selection path PR6a will rely on. The latter is more useful for the wire-up validation goal but should be explicit.
+
+### LOW-7 — `_clear_player_queue` casts `BasePlayer` access via getattr; the cast in `on_track_stuck` does not
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/lavalink_glue.py:144-152` vs `src/ryzic/lavalink_glue.py:245`
+- **Why it matters:** Two places handle the BasePlayer-vs-DefaultPlayer split inconsistently. `_clear_player_queue` uses `getattr(player, "queue", None)` for runtime safety. `on_track_stuck` does `cast(lavalink.DefaultPlayer, event.player).skip()` — type-only, no runtime guard. If the codebase ever uses a custom player subclass that doesn't implement `skip()`, the cast hides the bug; if it skips `queue`, the getattr handles it gracefully. Pick one convention. Plan §7 commits to DefaultPlayer; both could just type-assert it once.
+- **Fix:** Either (a) cast at the boundary (`event.player`) once and treat the typed local as DefaultPlayer everywhere, or (b) keep the runtime guards consistently. The hybrid is the maintenance hazard.
+
+### LOW-8 — `auto_leave_tasks.pop(guild_id, None)` self-pop has a small race with rescheduling
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/lavalink_glue.py:126`
+- **Why it matters:** When `_auto_leave` finishes its sleep and reaches line 126 to pop itself from the dict, a task switch could let `_start_auto_leave(guild_id)` run between sleep-completion and pop. The new sequence: `_cancel_auto_leave` pops the (about-to-finish) old task → cancels it (already past the cancel point, so no-op) → `_start_auto_leave` inserts NEW task → old `_auto_leave` resumes and pops the NEW task from the dict. Result: a live auto-leave task with no entry in `auto_leave_tasks`, so the next `_cancel_auto_leave` is a no-op and the timer fires when it shouldn't. The window is microseconds wide and requires a `QueueEndEvent` to land in that exact window, which itself requires the queue to have just emptied. Realistically reachable only under stress/CI. Worth a note in the watchlist.
+- **Fix:** Drop the self-pop and use `discard`-style: `if auto_leave_tasks.get(guild_id) is asyncio.current_task(): del auto_leave_tasks[guild_id]`. Or simpler: don't track completion at all; let the dict carry the completed task until the next cancel/replace clears it (Python tasks don't leak memory in this shape).
+
+### LOW-9 — Module-level `_voice_ready_events` cross-test contamination is mitigated only by the `autouse` fixture
+
+- **Severity:** LOW
+- **Where:** `tests/test_lavalink_bridge.py:108-111` (the `_reset_state` fixture)
+- **Why it matters:** Module-level state per plan §8 is a deliberate KISS choice and the autouse fixture handles it. Just noting: any future test file that uses `lavalink_glue` and forgets the autouse fixture will see leaked state. The reset helpers (`_reset_state_for_test`, `_set_lavalink_client_for_test`) are named clearly enough that this is unlikely to bite, but worth documenting in `lavalink_glue.py`'s "test seams" section that downstream tests must call them.
+- **Fix:** Move the fixture into `tests/conftest.py` so it autouses across the entire test directory, or add a one-line note in the test-seams docstring directing readers to the fixture pattern.
+
+### NOTE — Comment hygiene is good
+
+- **Severity:** observation, not a finding
+- **Where:** `src/ryzic/lavalink_glue.py` throughout
+- The module docstring and inline comments document **why** (the #153 mitigation, the handshake race, why `removeprefix` over `[6:]`) rather than narrating **what**. Two TODOs (PR6a wiring) explain the deferred forward references. The `_clear_player_queue` docstring explains the BasePlayer vs DefaultPlayer split, which is exactly the kind of non-obvious context worth recording. Aligns with the maintainer's standards.
+
+### NOTE — Future-incident watchlist
+
+- **Long-blocking listener under degraded lavalink:** see LOW-4. If the server stops responding, every voice event blocks per request timeout. Probably fine; flag if future incidents tie back to voice-event throughput.
+- **Auto-leave self-pop race:** see LOW-8. Only matters under churn.
+- **Channel-switch handshake:** `wait_for_voice_ready` returns True immediately after the first join; if the bot ever switches channels mid-session (currently disallowed by the plan, but a future "follow VC" feature might), the second handshake would race because the event is already set. Reset on `update_voice_state(guild_id, new_channel)` would be needed.
+- **Singleton DI lifetime:** linkd caches singletons at first successful resolve. If `_ll_client` is ever swapped (e.g., PR-future "rebuild on persistent failure"), the DI cached instance will be stale. Currently moot — PR keeps the client across reconnects deliberately.
+- **`/lltest` orphaned player:** see LOW-6. PR6b removes `/lltest`; clean up players-from-lltest as part of that PR or document that `/leave` resets state.
+
+---
+
+## Verdict
+
+**minor revisions.**
+
+The plan §7 hazards are all addressed correctly: `removeprefix("wss://")` not `[6:]`, both listeners short-circuit when `_ll_client is None`, EventHandler covers all required hooks, the voice-handshake race fix is implemented and timeout-bounded, the 5-minute auto-leave is cancellable on `TrackStartEvent` and replaceable on subsequent `QueueEndEvent`, `TrackEndEvent` never calls `player.play()` (#153 mitigation), `TrackStuckEvent` skips with notification (#144 mitigation), `NodeDisconnectedEvent` notifies last-known channels and clears queues. State model matches plan §8 (three module-level dicts, no `GuildState`). Conventional-commit message, scope is tight, comments narrate why not what, ruff/ty/pytest all green.
+
+The blocking-ish issue is **MEDIUM-1** (the DI factory raising a custom error that linkd will wrap, breaking the contract PR6a is supposed to consume). Recommend dropping the DI factory in favor of the `get_lavalink_client()` pattern that `/lltest` already uses, and removing `LavalinkNotReadyError` along with it. **MEDIUM-2** and **MEDIUM-3** are quick mechanical fixes (move two lines + add one test). The LOWs are nice-to-haves; LOW-1 (drop `_make_starter`) and LOW-2 (re-raise `CancelledError`) are worth doing for code-hygiene; the rest can wait or land as an in-PR cleanup commit.
+
+Once the MEDIUMs are addressed, ship.

--- a/docs/plans/PR3-security-review.md
+++ b/docs/plans/PR3-security-review.md
@@ -1,0 +1,216 @@
+# PR #3 — Security Review
+
+**PR**: `feat(audio): lavalink.py wire-up + voice bridge`
+**Branch**: `feat/lavalink-wireup` → `main`
+**Repo**: `VeryLongOrgNameSuchWow/ryzic`
+**Commit reviewed**: `de57af4`
+**Files in scope** (PR diff only):
+
+- `src/ryzic/lavalink_glue.py` (new, 456 lines)
+- `src/ryzic/commands/lltest.py` (new, 60 lines)
+- `src/ryzic/commands/__init__.py` (new, 1 line)
+- `src/ryzic/bot.py` (+19/-2)
+- `tests/test_lavalink_bridge.py` (new, 299 lines)
+
+No dependency or build-system changes. `hikari`, `lavalink`, `hikari-lightbulb` were already declared in PR #1.
+
+This review covers the ten focus areas from the brief: voice-update bridge pass-through, scheme-stripping safety, DI factory credentials, singleton init race, `LavalinkNotReadyError` leakage, `/lltest` info disclosure, `WebSocketClosedEvent` channel-routing trust, `TrackException` payload leakage, auto-leave timer hygiene, and test isolation.
+
+---
+
+## Findings
+
+### 1. Voice-update bridge — pass-through, no logging of secrets
+
+**Severity**: (informational — no finding)
+**What**: `_bridge_voice_server_payload` and `_bridge_voice_state_payload` (`src/ryzic/lavalink_glue.py:312-349`) read `endpoint`/`token`/`session_id` straight off the hikari event into a dict and hand it to `lavalink.Client.voice_update_handler`. No logging at any level touches `event.token` or `state.session_id`. Grepped every `_log.*` call in `lavalink_glue.py`: the only voice-shape values that ever reach a log line are `guild_id`, `code`, `reason`, `node.name`, and `cfg.lavalink_host`/`cfg.lavalink_port` — never `token`, `session_id`, or `password`. The lavalink.py library itself (verified `transport.py:151`/`transport.py:401`) sends the password as `Authorization` header but does not log it; its `_log.info` lines reference `node.name` only.
+
+**Endpoint trust model**: the endpoint string is delivered over Discord's authenticated TLS gateway after the bot's token has authenticated the session. ryzic forwards it opaquely to lavalink.py, which forwards it in an `update_player` REST call to the lavalink server, which then opens its own WSS connection. Discord controls the value end-to-end; if Discord's gateway is itself compromised, the threat model has bigger problems than ryzic's pass-through. **Verdict: clean.**
+
+---
+
+### 2. `removeprefix("wss://")` — scheme handling
+
+**Severity**: (informational — no finding)
+**What**: `event.endpoint` (the hikari property, `voice_events.py:128-138`) returns `f"wss://{self.raw_endpoint}"` when `raw_endpoint` is non-None, else `None`. The bridge calls `endpoint.removeprefix("wss://") if endpoint else None`. If hikari ever changes the prefix to `ws://` or omits scheme entirely:
+
+- `ws://host` → `removeprefix` no-op → lavalink receives `ws://host` (mostly harmless: `nodemanager.get_region` does a `startswith` substring scan against region prefixes — `ws://` is not a region prefix, so the lookup returns `None`, and the player is assigned to the configured `"us"` node anyway). The endpoint string is then forwarded to the lavalink server which would fail to parse it as a hostname; effect is a connection failure for that guild, not a redirect.
+- `host` (no scheme) → `removeprefix` no-op → lavalink receives bare host → works as today.
+- `wss://attacker.example` (Discord platform-side bug or attacker-controlled gateway) → strip → `attacker.example` forwarded to lavalink server, which would open a WSS connection there for the voice traffic. **However**, this requires Discord itself to send a malicious endpoint over an authenticated session, which is outside the threat model. There is no allowlist of `*.discord.media` / `*.discord.gg` hosts as a defense-in-depth check — see #10 for the LOW.
+
+The choice of `removeprefix` over `[6:]` is explicitly documented (lines 28-30) and pinned by `test_bridge_voice_server_payload_does_not_substring`. Strong. **Verdict: clean for the chosen threat model.**
+
+---
+
+### 3. DI factory and lavalink.Client construction — credentials handling
+
+**Severity**: (informational — no finding)
+**What**: `_build_lavalink_client` (lines 391-404) reads `cfg.lavalink_password` from a frozen-dataclass `Config` (`config.py:24`, `field(repr=False)` so the password never appears in `repr(cfg)`). It is passed positionally to `client.add_node(...)` and stored inside `Transport._password` (lavalink/transport.py:84) as a `Final[str]`. The only log line touching the connection at INFO (`lavalink_glue.py:403`) reads `host=%s port=%d` — no password. lavalink.py's own logs use `node.name` (set explicitly to `"ryzic-default"`, line 400, so default `f'{region}-{host}:{port}'` fallback is bypassed).
+
+The DI factory `_lavalink_client_factory` (lines 425-428) returns the singleton or raises `LavalinkNotReadyError`. No credential touches the registry path. **Verdict: clean.**
+
+---
+
+### 4. Singleton `_ll_client` init — race under concurrent ShardReadyEvents
+
+**Severity**: (informational — no finding)
+**What**: `_on_shard_ready` (lines 377-388):
+
+```python
+async def _on_shard_ready(...) -> None:
+    global _ll_client
+    if _ll_client is not None:
+        return
+    _ll_client = _build_lavalink_client(bot, cfg, event.my_user.id)
+```
+
+There is **no `await` between the check and the assignment**. `_build_lavalink_client` is fully synchronous (`lavalink.Client.__init__`, `add_node`, `add_event_hooks` are all sync — verified in `client.py:105-124`, `nodemanager.py:87-126`, `client.py:201`). hikari dispatches each subscriber as its own task (`event_manager_base.py:564`), so two concurrent `ShardReadyEvent`s would create two tasks, but each runs the body atomically with respect to the other under asyncio's single-threaded scheduling. The second task sees `_ll_client is not None` and returns. **No race possible.**
+
+**Side note**: even though `lavalink.Client.__init__` constructs `aiohttp.ClientSession` (`client.py:118`), aiohttp only requires a running loop at request time, not at construction — and we are inside an async event handler so a loop is running anyway. **Verdict: clean.**
+
+---
+
+### 5. `LavalinkNotReadyError` — credential leakage in message
+
+**Severity**: (informational — no finding)
+**What**: `_lavalink_client_factory` raises `LavalinkNotReadyError("Lavalink client requested before ShardReadyEvent fired.")` (line 427). String is hardcoded, contains no host/port/password/state. The exception class itself extends `RuntimeError` with no extra fields. Even if a slash command catches this and echoes it to the user via lightbulb's default error reporter, the user only sees the hardcoded message. **Verdict: clean.**
+
+---
+
+### 6. `/lltest` — surface area and information disclosure
+
+**Severity**: LOW (defense-in-depth + side effect)
+**What**: `LLTest` (`commands/lltest.py:19-60`) has no `default_member_permissions`, no `dm_enabled=False`, and no admin gate. Any guild member with the application-default "Use Application Commands" permission can invoke it. The response is `ephemeral=True` so visible only to the invoker.
+
+**What it exposes** (per node, all ephemeral): `node.name` ("ryzic-default" — admin-controlled, set in `_build_lavalink_client`), `node.region` ("us"), `node.available` (bool). No host, port, password, or session id. As long as a future maintainer doesn't drop the explicit `name="ryzic-default"` (which would let lavalink default `name` to `f'{region}-{host}:{port}'`, leaking host:port in the response), the information surface is a static admin-chosen string. The `_log.info` line at `lavalink_glue.py:403` already logs `host=%s port=%d` once at startup, so the values are not secret per se — but the pattern of "node.name is safe to surface" depends on the explicit override.
+
+**Side effect**: line 49, `ll_client.player_manager.create(guild_id=ctx.guild_id)`. This **creates a player** inside lavalink.py's PlayerManager (`playermanager.py:170-260`). The call is idempotent per guild (`if guild_id in self.players: return self.players[guild_id]`), so spam from one guild creates one player. Across guilds, the cap is the number of guilds the bot is in — bounded, not exhaustible. But a smoke-check command that mutates state is surprising; the M1 plan calls this command "throwaway" and deletes it in PR6b once `/play` exists.
+
+**Where**: `src/ryzic/commands/lltest.py:19-60`.
+**Why it matters**: Mostly a hygiene call. The command is documented as throwaway. Two concrete deltas worth making before merge:
+
+1. Add a comment next to `name="ryzic-default"` in `_build_lavalink_client` warning that the name leaks to `/lltest` invokers if the explicit override is dropped.
+2. Consider gating `/lltest` to `default_member_permissions=hikari.Permissions.MANAGE_GUILD` for its short remaining lifetime — minimal cost, removes the "any user can mutate PlayerManager state" property.
+
+Neither blocks merge.
+
+---
+
+### 7. `last_play_channel` — channel-routing trust
+
+**Severity**: LOW (channel cleanup, not exploitable)
+**What**: `last_play_channel: dict[int, int]` (line 54) maps guild_id → channel_id. In this PR, **only `_reset_state_for_test` writes to it**; PR6a's `/play` will populate it. The brief asks: "could a malicious user manipulate `last_play_channel` to make the bot post in a different channel?"
+
+Threat-model walk: the only writer (in this PR's design and per M1 §8) is `/play`, which writes `ctx.channel_id` of its own invocation. That means the entry reflects the **last user who invoked `/play` in that guild** — which is by design where error messages should land. A user CAN cause the bot to post in a channel of their choosing by invoking `/play` there; there is no cross-guild leak (keyed by guild_id) and no way to direct posts to a channel the user doesn't already have access to (Discord's slash-command surface only exposes channels the user can see).
+
+Remaining residual: `_send_to_last_play_channel` (lines 155-166) catches `hikari.HikariError` (channel deleted, bot lacks Send Messages permission), logs at WARNING, and moves on. The dict entry is **not removed** on failure — a deleted-channel id will sit in the dict forever, generating one warning per future failure. Bounded by # of guilds. Not security; a LOW hygiene nit.
+
+**Where**: `src/ryzic/lavalink_glue.py:155-166`.
+**Fix** (optional): on `hikari.NotFoundError` specifically, `last_play_channel.pop(guild_id, None)` so the stale entry is forgotten.
+
+---
+
+### 8. `TrackExceptionEvent` — server-side error text posted publicly to channel
+
+**Severity**: MEDIUM (information disclosure + Discord markdown injection)
+**What**: `on_track_exception` (lines 210-228) posts:
+
+```python
+f"Track **{title}** failed: {event.message or event.cause}. Skipping."
+```
+
+via `_send_to_last_play_channel`, which calls `bot.rest.create_message(channel_id, content)`. This message is **public to the channel** (not ephemeral; `create_message` has no ephemeral flag — that's a slash-interaction concept).
+
+Two distinct concerns:
+
+(a) **`event.cause` is a Java exception string from the lavalink server** (`events.py:121-136`: `cause: str` is the cause-of-exception text; `cause_stacktrace: str` is the full stacktrace, which we correctly do NOT use). Real-world `cause` values for the YouTube source plugin can include:
+  - Internal lavalink server filesystem paths (`/opt/Lavalink/...`, especially in sideloader/plugin error paths).
+  - Java exception class FQNs and the failing URL (which itself may contain query-string secrets if a yt-dlp-resolved track URL embedded a signed `pot` token or session-bound stream-id).
+  - Hostnames / IPs of internal infrastructure if the lavalink server is on a private network.
+
+These leak to **every user in the channel**, not just to the `/play` invoker.
+
+(b) **No Discord markdown sanitisation** on `title` or `event.message`/`event.cause`. The `**…**` wrapper around `title` makes a YouTube-supplied title actively render as markdown — a video titled `*x*\n# pwn` would break formatting. M1 §6 item 10 explicitly mandates "strip backticks from yt-dlp error strings BEFORE wrapping in inline code", and item 11 mandates length truncation via `safe_truncate`. Neither helper exists yet (`ux.py` is a future PR), so the implementer correctly couldn't call them — but this handler ships TODAY and posts unsanitised text TODAY (in any environment where this PR is merged before PR6's `ux.py`).
+
+  - `@everyone` injection in titles is **already blocked**: hikari's `bot.rest.create_message` always emits `allowed_mentions: {parse: []}` by default (verified in `hikari/internal/mentions.py:67-90` and `hikari/impl/rest.py:1549-1552`). So track titles cannot trigger mass-mentions.
+  - Length: Discord rejects messages > 2000 chars with HTTP 400, which `_send_to_last_play_channel` swallows as `hikari.HikariError`. Long Java causes simply produce a warning log instead of posting — UX issue, not security.
+
+**Where**: `src/ryzic/lavalink_glue.py:224-228`.
+**Why it matters**: This is the same scrubbing rule the M1 plan called out for the yt-dlp wrapper (PR2 review item 10), now applied at the lavalink boundary. A self-hoster's lavalink server may run with default plugins that surface internal paths in exception text. Posting that to a public channel violates the "internal info stays internal" property the plan implicitly assumes.
+
+**Fix**: replace the message with a sanitised, capped version. Until `ux.py` lands, do it inline:
+
+```python
+detail = (event.message or event.cause or "unknown error")
+# Strip backticks/asterisks/underscores so the snippet can't break out of
+# inline code formatting; cap so a Java stack trace can't flood the channel.
+detail = re.sub(r"[`*_~|]", "", detail).splitlines()[0][:200]
+title_safe = re.sub(r"[`*_~|]", "", title)[:100]
+await _send_to_last_play_channel(
+    self._bot, guild_id,
+    f"Track **{title_safe}** failed: `{detail}`. Skipping.",
+)
+```
+
+(Alternatively: post a fixed message `"A track failed and was skipped."` and only log the `event.cause`/`event.message` server-side. Loses some UX, gains "no untrusted content ever leaves the server.")
+
+The same fix should be applied to the `TrackStuckEvent` handler (line 248-252) — title-only there, so a single regex cap on `title` suffices. The `WebSocketClosedEvent` (line 277-279) and `NodeDisconnectedEvent` (line 301-305) handlers post hardcoded strings, no sanitisation needed.
+
+---
+
+### 9. Auto-leave timer — task lifecycle and growth
+
+**Severity**: LOW (hygiene, not exploitable)
+**What**: `_start_auto_leave` (lines 108-117) replaces any existing timer for the same guild via `_cancel_auto_leave`, so the dict size is bounded by the number of guilds the bot is in. No unbounded growth.
+
+The cleanup paths are:
+
+- `_cancel_auto_leave` is called from `TrackStartEvent` (line 184) and `WebSocketClosedEvent` 4014 (line 275). These are the routine cancellation paths.
+- `_auto_leave` itself does `auto_leave_tasks.pop(guild_id, None)` after the sleep (line 126), so the entry is cleaned up after firing.
+- `bot.update_voice_state(guild_id, None)` failures are caught with a broad `except Exception` (line 137-138). This is fine.
+
+**Gap**: if the bot is **kicked from a guild** while the timer is mid-sleep, the task continues to completion 5 minutes later, then tries `update_voice_state` (will fail, swallowed) and `_send_to_last_play_channel` (will fail, swallowed). No crash, but two wasted REST attempts. There is no `GuildLeaveEvent` listener to proactively cancel the task. M1 §8's restart behaviour ("All state dies on restart") tolerates this, and the per-guild ceiling means the wasted work is bounded by guilds-being-kicked-during-idle.
+
+**Where**: `src/ryzic/lavalink_glue.py:108-141`.
+**Fix** (optional): subscribe to `hikari.GuildLeaveEvent` and call `_cancel_auto_leave(event.guild_id) + last_play_channel.pop(event.guild_id, None) + _voice_ready_events.pop(event.guild_id, None) + _ll_client.player_manager.destroy(...)` to clean up the per-guild state. Outside this PR's brief; arguably belongs to PR6.
+
+**Test hygiene side note** (LOW, separate from production code): `test_auto_leave_replaces_existing_timer` (tests/test_lavalink_bridge.py:273-282) calls `_start_auto_leave` twice. The autouse `_reset_state` fixture (lines 108-111) clears the dict but does **NOT cancel the second pending 300s sleep task**. The task is leaked into the asyncio event loop until pytest-asyncio tears down the loop at the end of the function-scoped test. pytest-asyncio's default loop scope is function, so the leak is recovered after each test, but the `_reset_state` fixture should call `_cancel_auto_leave(guild_id)` for any pending timer to be tidy. Tests pass in 0.40s with no warnings; not a correctness issue, just untidy.
+
+---
+
+### 10. Endpoint allowlist — defense-in-depth (none today)
+
+**Severity**: LOW (defense-in-depth gap)
+**What**: The endpoint forwarded to lavalink is `event.raw_endpoint` (Discord-supplied) with `wss://` stripped. No regex check, no allowlist of known Discord voice-server suffixes (`*.discord.media`, `*.discord.gg`). M1 §6 doesn't require one; the security model trusts Discord's authenticated gateway as the source of truth.
+
+**Where**: `src/ryzic/lavalink_glue.py:312-331`.
+**Why it matters**: If Discord's gateway were ever to send a malicious endpoint (gateway compromise, bot-token-replay attack against a stale connection, etc.), lavalink would obey and connect there. An allowlist (`endpoint.endswith((".discord.media", ".discord.gg"))`) would be a free defense-in-depth check. Not blocking; not in scope of M1.
+
+**Fix** (optional, deferable to a hardening PR): add a `_VALID_ENDPOINT_SUFFIXES = (".discord.media", ".discord.gg")` constant and reject (return without forwarding, log at WARNING) any endpoint that doesn't match.
+
+---
+
+### 11. Tests do not hit any real network
+
+**Severity**: (informational — no finding)
+**What**: `test_lavalink_bridge.py` constructs hikari events directly (`hikari.VoiceServerUpdateEvent(app=cast(Any, _FakeApp()), ...)`, `hikari.VoiceState(...)`) — no gateway connection. The bridge listeners are fed a `_FakeLavalinkClient` (lines 98-105) that only appends to a list. `_FakeApp` (lines 31-50) is a duck-typed stub for `hikari.GatewayBot` whose `rest.create_message` and `update_voice_state` methods append to in-memory lists.
+
+Confirmed by running the suite: 20 tests pass in 0.40 s with no network warnings. No `aiohttp.ClientSession`, `discord.py`, `socket`, or `urllib.request` import in `tests/`. **Verdict: clean.**
+
+---
+
+## Summary
+
+| Severity | Count |
+| --- | ---: |
+| HIGH (merge-blocking) | 0 |
+| MEDIUM (fix soon) | 1 |
+| LOW (nit) | 4 |
+
+The single MEDIUM is **#8 (TrackException posts unsanitised server-side error text to a public channel)** — a 4-line inline fix until `ux.py` lands, or a 1-line "fixed message" alternative. This is the only finding with a real exploitability story (lavalink server exposes internal paths/hostnames in exception text → public Discord channel). The four LOWs are defense-in-depth (#6, #7, #9, #10).
+
+The brief's primary attack vectors — credential leakage in logs/messages/exceptions, scheme-strip injection, singleton init race, `/lltest` info leak, `last_play_channel` channel-routing manipulation, auto-leave runaway — are all defended (the endpoint trust model is a stated assumption, not a defended boundary). 20 unit tests, all passing in 0.40 s, mocked-network only.
+
+## Verdict
+
+**fixes recommended** — not merge-blocking. Address #8 (MEDIUM) in this PR or as the next immediate commit on the branch (since the handler ships and runs the moment a track fails). #6, #7, #9, #10 are optional polish; #6 should be revisited when `/lltest` is removed in PR6b.

--- a/docs/plans/PR3-simplify.md
+++ b/docs/plans/PR3-simplify.md
@@ -1,0 +1,237 @@
+# PR #3 Simplification Pass — `feat(audio): lavalink.py wire-up + voice bridge`
+
+**Branch:** `feat/lavalink-wireup` -> `main`
+**Diff reviewed:** +837 LOC across 5 files (~540 LOC src, ~300 LOC tests).
+**Companion docs:** `docs/plans/M1-simplify.md` (already-decided plan-level cuts), `docs/plans/M1.md` §7 (PR5 spec), `docs/plans/M1-review.md` §6 (voice handshake race fix).
+
+This pass looks only for code that's *more elaborate than its M1 §7 surface justifies*. It does **not** re-litigate decisions already locked in `M1-simplify.md` (module-level state dicts vs `GuildState` registry, the two-listener bridge being mandated by the libs' shape). It does not critique correctness or security — those are other agents' lanes.
+
+Honest framing: PR3 is **already pretty tight**. There's no big subsystem to delete. The wins below are small, mostly in cosmetic indirection (`_make_starter`, `_clear_player_queue`'s getattr-guard, voice-ready event registry) and a few obviously WHAT-narrating comments. Realistic floor of LOC saved: **~30–45 LOC of source + ~10–20 LOC of tests/comments**, none of which changes the surface API or risks correctness regressions.
+
+---
+
+## Findings
+
+### S-1 — Inline `_make_starter` factory into `main()`
+
+**What to cut/collapse:** `_make_starter` is a 10-line factory (including the `TYPE_CHECKING` block + import + signature line) that returns a closure. The user is right that hikari's `subscribe` rejects lambdas — but the simpler shape is to define the `async def` directly in `main()` and pass it to `subscribe`. No factory layer; hikari's check passes the same way.
+
+```python
+async def _on_starting(_: hikari.StartingEvent) -> None:
+    await client.load_extensions("ryzic.commands.lltest")
+    await client.start()
+
+bot.subscribe(hikari.StartingEvent, _on_starting)
+bot.subscribe(hikari.StoppingEvent, client.stop)
+```
+
+The `TYPE_CHECKING` import block (`Callable`, `Coroutine`) goes away since the only thing that needed it was `_make_starter`'s return-type annotation.
+
+**Where:** `src/ryzic/bot.py` lines 6, 14–15, 39–48, 69.
+
+**Why safe:** Identical runtime behavior. `iscoroutinefunction` accepts `async def` defined inside any function body — the closure captures `client` from `main()`'s scope, same as the factory does. The factory is only justified if `_on_starting` were defined at module scope (where it would need parameters injected). At call site, factory is pure ceremony.
+
+**Could `client.start` be subscribed directly without wrapping?** Not in this PR — the wrapper does **two** things: load the `/lltest` extension *then* start the client. Once `/lltest` is removed (PR6b per `M1-simplify.md` §7) and the package-load happens on `client` construction or via `load_extensions_from_package`, you could likely subscribe `client.start` directly. But that's a PR6b move, not PR3.
+
+**Estimated LOC saved:** ~7 LOC (factory + the `TYPE_CHECKING`-guarded `Callable/Coroutine` import block).
+
+---
+
+### S-2 — Drop the getattr-guard in `_clear_player_queue`; cast like `on_track_stuck` does
+
+**What to cut/collapse:** `_clear_player_queue` defends against a `BasePlayer` lacking a `queue` attribute via `getattr(player, "queue", None)`. But the project always uses `DefaultPlayer` (verified in `lavalink/player.py:50,122` — `self.queue: List[AudioTrack] = []`). The defensive shape exists only because the lavalink event objects type the player as `BasePlayer`. The rest of the file already handles this exact mismatch with a direct cast (line 245: `cast(lavalink.DefaultPlayer, event.player).skip()`). Be consistent and inline the call:
+
+```python
+# At each of the 2 call sites (lines 274, 295):
+cast(lavalink.DefaultPlayer, event.player).queue.clear()
+cast(lavalink.DefaultPlayer, player).queue.clear()
+```
+
+Drop the helper + its docstring + the two tests pinning the defensive branch (`test_clear_player_queue_handles_missing_attribute`, `test_clear_player_queue_clears_when_present`).
+
+**Where:** `src/ryzic/lavalink_glue.py` lines 144–152, 274, 295. `tests/test_lavalink_bridge.py` lines 285–299.
+
+**Why safe:** The project owns the player type (`DefaultPlayer` is the lavalink.py default and never overridden in this codebase). Defensive code at an internal trust boundary is the exact thing the maintainer's "no premature abstraction" rule warns against. The cast already exists once; extending the same pattern is consistent. If someone later wires a custom `BasePlayer` subclass, it's a 1-line fix at the cast site, not an obscure helper.
+
+**Estimated LOC saved:** ~10 LOC src + ~15 LOC tests = ~25 LOC.
+
+---
+
+### S-3 — Replace `_voice_ready_events` dict with a per-guild `Future` (or just inline the `setdefault`)
+
+**What to cut/collapse:** The voice-ready primitive is currently:
+
+- `dict[int, asyncio.Event]`
+- a `_voice_ready_event(guild_id)` getter that lazy-creates
+- a `_reset_voice_ready(guild_id)` that pops the entry
+- `wait_for_voice_ready` calling `event.wait()` with timeout
+
+The handshake is a **one-shot signal**: set once when our own `VoiceStateUpdateEvent` arrives, then either consumed by `/play` or popped on disconnect. `asyncio.Event` is fine, but the `_voice_ready_event` lazy-getter is the indirection worth cutting — `dict.setdefault(guild_id, asyncio.Event())` at the two call sites is the canonical Python idiom (same logic, no helper):
+
+```python
+# In _on_voice_state_update (line 374):
+_voice_ready_events.setdefault(event.state.guild_id, asyncio.Event()).set()
+
+# In wait_for_voice_ready (line 89):
+event = _voice_ready_events.setdefault(guild_id, asyncio.Event())
+```
+
+`Future` is **not** a win here — `Future.set_result()` raises `InvalidStateError` on a second call (the bot can rejoin/reconnect repeatedly), so callers would need the same guard logic plus a recreate. Stick with `Event`; just delete the helper.
+
+**Where:** `src/ryzic/lavalink_glue.py` lines 73–78, 89, 374.
+
+**Why safe:** `dict.setdefault` is the textbook "lazy create entry" pattern; replacing one wrapper with the stdlib idiom doesn't change semantics. `_reset_voice_ready` stays (it's called from 3 places and `pop(..., None)` is concise enough as a 1-line helper, but you could equally inline that too — judgment call).
+
+**Estimated LOC saved:** ~7 LOC (delete helper + its docstring; possibly 3 more if `_reset_voice_ready` also gets inlined).
+
+---
+
+### S-4 — Share a small `_log_track_event` helper between `TrackEndEvent` and `TrackExceptionEvent`
+
+**What to cut/collapse:** Both handlers (and `TrackStuckEvent`) repeat the same `track = event.track; title = track.title if track is not None else "<unknown>"` shim, then log with similar fields. The repetition is on the threshold of "three is fine" per the maintainer's rule — but the title-extraction is a real WET pattern that appears **four** times (TrackStart, TrackEnd, TrackException, TrackStuck). One module-level helper:
+
+```python
+def _track_title(track: lavalink.AudioTrack | None) -> str:
+    return track.title if track is not None else "<unknown>"
+```
+
+Each handler's first 2 lines collapse to 1: `title = _track_title(event.track)`.
+
+The audio-cache release shim noted in the `TrackEndEvent` comment (lines 200–205) and the `TrackExceptionEvent` TODO (line 222) are explicitly deferred to PR6a — once they land, a `_release_track_cache(track)` helper will earn its keep across both handlers. **Don't add it now** (no audio_cache module to import yet); just leave the existing notes.
+
+**Where:** `src/ryzic/lavalink_glue.py` lines 185–186, 192–193, 213–214, 237.
+
+**Why safe:** A 1-line title-extraction helper called four times is a clean refactor — the maintainer's "three similar lines" rule is satisfied (4 > 3). It doesn't introduce a class, a module, or any framework concept. If the lavalink lib ever changes the optional shape of `track`, there's now one place to update.
+
+**Estimated LOC saved:** ~6 LOC (replace 4× 2-line shims with 4× 1-line calls + 2-line helper definition).
+
+---
+
+### S-5 — Drop `LavalinkNotReadyError`; raise `RuntimeError` directly
+
+**What to cut/collapse:** `LavalinkNotReadyError` is a 2-line subclass of `RuntimeError` raised by exactly one site (`_lavalink_client_factory`, line 427). Caught nowhere. The lightbulb DI registry will surface whatever the factory raises as a `DependencyResolutionError`; downstream code never `except LavalinkNotReadyError` anywhere. Per the project convention noted in the brief — custom exceptions need a real reason — this one has none beyond a marginally nicer name in the traceback.
+
+```python
+def _lavalink_client_factory() -> lavalink.Client:
+    if _ll_client is None:
+        raise RuntimeError("Lavalink client requested before ShardReadyEvent fired.")
+    return _ll_client
+```
+
+The one test that pins it (`test_lavalink_factory_raises_before_bootstrap`) becomes `with pytest.raises(RuntimeError):`.
+
+**Where:** `src/ryzic/lavalink_glue.py` lines 421–422, 427. `tests/test_lavalink_bridge.py` line 241.
+
+**Why safe:** `errors.py` is the project's home for caught/typed domain exceptions (per `M1-simplify.md` "Things I considered cutting and decided not to"). `LavalinkNotReadyError` lives in `lavalink_glue.py`, not `errors.py` — telling the same story: nobody catches it. If PR6a introduces a `/play` flow that genuinely needs to distinguish "lavalink not ready" from other RuntimeErrors, add it then; YAGNI for PR3.
+
+**Estimated LOC saved:** ~3 LOC.
+
+---
+
+### S-6 — Make `wait_for_voice_ready` internal (`_wait_for_voice_ready`) until PR6a needs the public surface
+
+**What to cut/collapse:** `wait_for_voice_ready` is exported as public (no leading underscore), but no caller in PR3 uses it — `/lltest` doesn't need it, and `/play` lands in PR6a. The function is well-named and its docstring is good, but until PR6a wires it up, it's a public surface awaiting a consumer. Rename to `_wait_for_voice_ready` for now; PR6a flips the underscore when it imports it. (Or: leave it public — it's fine either way; this is the weakest finding.)
+
+**Where:** `src/ryzic/lavalink_glue.py` line 81.
+
+**Why safe:** Cosmetic — no LOC change, just signaling that this is an unfinished surface. **Optional**, low-conviction. I'd actually recommend leaving it: the docstring documents intent and the tests pin behavior; making it public now means PR6a doesn't need to touch this file at all. Pulling it back to private only to re-promote it is churn.
+
+**Estimated LOC saved:** 0. **Recommend skipping.**
+
+---
+
+### S-7 — `auto_leave_tasks` -> `loop.call_later(...)` returning `TimerHandle`
+
+**What to cut/collapse:** Considered: replace the `dict[int, asyncio.Task[None]]` + the `_auto_leave` coroutine with `asyncio.get_event_loop().call_later(300, callback, ...)` returning a `TimerHandle`, which is `cancel()`-able. The current shape spawns a task that just `await sleep(300)` then does work — that's literally what `call_later` is for.
+
+**Why I'm not recommending it:** The work after the sleep is **async** (`await bot.update_voice_state(...)`, `await _send_to_last_play_channel(...)`). `call_later`'s callback must be a sync function — to call async code you'd need `loop.create_task(_do_disconnect(...))` inside the callback, which puts you right back to needing a tracked task. The `dict[int, Task]` shape with `_cancel_auto_leave` is the right primitive here; `TimerHandle` would be the same LOC plus an extra layer.
+
+**Where:** `src/ryzic/lavalink_glue.py` lines 102–141.
+
+**Estimated LOC saved:** 0. **Recommend skipping** — the current shape is already minimal for the async-after-delay pattern. The auto-leave task is named (`name=f"ryzic-auto-leave-{guild_id}"`) which makes traces readable; that disappears with `call_later`.
+
+---
+
+### S-8 — Test scaffolding richer than the surface
+
+**What to cut/collapse:** Two specific spots:
+
+- **`test_bridge_voice_server_payload_does_not_substring`** (lines 129–137) duplicates `test_bridge_voice_server_payload_strips_wss_scheme` (lines 114–120). Both assert that `removeprefix("wss://")` works correctly; the second one's docstring says it "pins behaviour so a regression silently corrupting hosts is caught" — but the first test already does that. The second test only adds value if it tested the **negative** case (`endpoint="https://example.com"` should NOT be stripped to `example.com`). As written it's a redundant happy-path. Either delete it or rewrite to test the `https://` case (which is what the comment is gesturing at).
+- **`test_clear_player_queue_handles_missing_attribute` + `test_clear_player_queue_clears_when_present`** (lines 285–299) — both go away as part of S-2 above.
+
+**Where:** `tests/test_lavalink_bridge.py` lines 129–137 (~9 LOC), 285–299 (~15 LOC, already counted in S-2).
+
+**Why safe:** Each removed test has either a duplicate doing the same job or a removed function to test.
+
+**Estimated LOC saved:** ~9 LOC (the duplicate); the other 15 LOC is already in S-2.
+
+---
+
+### S-9 — `/lltest` placement: keep as separate file, not inline
+
+**What to cut/collapse:** Considered: collapse `commands/lltest.py` into `lavalink_glue.py` since it's throwaway anyway.
+
+**Why I'm not recommending it:** Lightbulb v3's extension model **requires** commands to live in a module loaded via `client.load_extensions(...)` so that the `Loader` decorator's `@loader.command` registration runs at import time (per `lightbulb/client.py:668–717` — the loader walks the imported module looking for `Loader` instances). Inlining into `lavalink_glue.py` would require also exposing a `loader` from that module and loading `lavalink_glue` as an extension, which entangles the bridge code with the slash-command framework's lifecycle. The 60-line throwaway file is the right shape; PR6b deletes it cleanly per the plan.
+
+**Where:** `src/ryzic/commands/lltest.py`.
+
+**Estimated LOC saved:** 0. **Recommend skipping.**
+
+---
+
+### S-10 — Trim WHAT-narrating comments
+
+**What to cut/collapse:** Several comments narrate WHAT the next line does without adding intent. Specific cuts:
+
+- `lavalink_glue.py:60–61` — `# Singleton lavalink client. Created once on the first ``ShardReadyEvent`` ... ``None`` until then; bridge listeners short-circuit while we wait.` This restates the type annotation (`lavalink.Client | None`) and the if-None guards visible 30 lines below. Drop to one line: `# Constructed on first ShardReadyEvent (needs the bot's user id).`
+- `lavalink_glue.py:411` — `# Idempotent across calls is NOT guaranteed; call once at startup.` This one is **WHY**, keep it.
+- `lavalink_glue.py:438–440` — the `# Test seams` ASCII separator. The function names already start with `_` and have `_for_test` suffix; the visual divider is decorative. Cut.
+- `bot.py:43–44` — `# Extensions register commands; commands are synced inside ``client.start``, so load before starting.` This is **WHY** (call ordering matters), keep it.
+
+**Where:** `src/ryzic/lavalink_glue.py` lines 59–61, 438–440.
+
+**Why safe:** WHY-comments and load-bearing intent stay. Only ASCII decoration and restated-from-context narration go.
+
+**Estimated LOC saved:** ~5 LOC.
+
+---
+
+## Top 3 wins by impact
+
+1. **S-2 (drop `_clear_player_queue` getattr-guard, cast like the rest of the file)** — ~25 LOC, removes a defensive-at-internal-boundary helper, and makes the file's `BasePlayer`-vs-`DefaultPlayer` story consistent (already cast for `.skip()`; do the same for `.queue`).
+2. **S-1 (inline `_make_starter`)** — ~7 LOC, removes a factory + the `TYPE_CHECKING` import block. The factory exists only to placate `iscoroutinefunction`'s lambda rejection; an inline `async def` solves the same problem without a layer.
+3. **S-4 (`_track_title` helper across 4 handlers)** — ~6 LOC, the only finding that *adds* a tiny abstraction, and only because the WET pattern is at 4 sites (not 3) and the lavalink lib's `event.track` is genuinely `Optional`.
+
+---
+
+## Keep as-is
+
+- **The two-listener voice-update bridge.** Mandated by the lib shapes, called out in `M1-simplify.md` "Things I considered cutting and decided not to". Nothing to simplify.
+- **`auto_leave_tasks: dict[int, asyncio.Task[None]]`.** `TimerHandle`/`call_later` would be worse for async-work-after-delay; the named task makes traces readable. (S-7 considered and rejected.)
+- **`/lltest` as a separate file.** Lightbulb v3's `Loader` model requires the command in its own importable extension module; inlining would entangle `lavalink_glue.py` with the command framework. (S-9 considered and rejected.)
+- **`wait_for_voice_ready` as public.** PR6a will import it; flipping the underscore now is churn. (S-6 considered and rejected.)
+- **`_bridge_voice_server_payload` / `_bridge_voice_state_payload` extracted.** The module docstring justifies it: tests can exercise the dict translation without spinning up a real lavalink client. Worth the 2 small helpers.
+- **The module docstring.** Long but every paragraph carries a non-obvious WHY (handshake race, why `play()` from `TrackEndEvent` is wrong, `removeprefix` over `[6:]`). Keep as-is.
+- **`_set_lavalink_client_for_test` / `_reset_state_for_test` test seams.** Module-global state needs explicit test reset; these are minimum-viable.
+- **`_FakeApp` test fixture.** Stand-in for `hikari.GatewayBot` is necessary because hikari's events are tightly bound to the gateway machinery; mocking it ad-hoc per test would be more code, not less.
+
+---
+
+## Total impact
+
+- **LOC saved (source):** ~30–35 (S-1: 7, S-2-src: 10, S-3: 7, S-4: 6, S-5: 3, S-10: 5; net of S-4 adding 2 lines for the helper).
+- **LOC saved (tests):** ~25 (S-2-tests: 15, S-8: 9).
+- **Total LOC: ~55–60 across 837 added,** about 7%. PR3 is **already pretty tight**; no big subsystem to delete.
+
+---
+
+## Report
+
+(a) File saved at `/home/user/Projects/ryzic/docs/plans/PR3-simplify.md`.
+
+(b) Top 3:
+   1. S-2 — drop `_clear_player_queue` getattr-guard + the two tests pinning it (~25 LOC).
+   2. S-1 — inline `_make_starter` factory into `main()` (~7 LOC + `TYPE_CHECKING` block).
+   3. S-4 — `_track_title` helper across 4 EventHandler hooks (~6 LOC).
+
+(c) Total LOC the PR could lose: **~55–60 LOC** (out of +837), most of which is removing one defensive helper and its tests. The PR is mostly tight; no structural rewrites are warranted.

--- a/docs/plans/PR4-review.md
+++ b/docs/plans/PR4-review.md
@@ -1,0 +1,139 @@
+# PR #4 Review — `feat(deploy): Dockerfile + docker-compose + Lavalink config`
+
+**Branch:** `feat/docker-compose` → `main`
+**Scope per plan:** `docs/plans/M1.md` §9 (compose shape), §10 (env vars), §12 PR7 (Dockerfile + compose + lavalink config + integration test).
+**Diff:** 11 files changed, +548 / -1. Dockerfile (43), `compose.yaml` (34), `lavalink/application.yml` (57), `tests/integration/test_lavalink_smoke.py` (140), `.dockerignore` (43), CI delta (+36), `pyproject.toml` (+7), `lavalink/plugins/.gitkeep` (0), `tests/integration/__init__.py` (0), `tests/integration/fixtures/silence.ogg` (4526 B), `uv.lock` (+188).
+**External version checks:** Lavalink `4.2.2` is the latest tag (released 2026-03-06) — pin is current. youtube-source `1.18.0` is the latest plugin release (2026-02-23) — pin is current. Lavalink's documented Maven coordinate for v4 is `dev.lavalink.youtube:youtube-plugin:VERSION` with `snapshot: false`, which the PR uses verbatim. `defaultPluginRepository` (`https://maven.lavalink.dev/releases`) is the right host for that artifact, so no `repository` key is needed. Confirmed via the upstream README at the `1.18.0` tag.
+**Local verification:** `lavalink.py` 5.11.0 exposes `Client`, `LavalinkError`, `LoadType.TRACK`, `Node.get_tracks(query)`, `Client.add_node(..., connect=False)`, async `Client.close()` — all the surface the integration test relies on. Lavalink ready-log line ("Lavalink is ready to accept connections.") matches the wait-strategy substring (verified via `gh search code` on `lavalink-devs/Lavalink:LavalinkServer/src/main/java/lavalink/server/Launcher.kt`). Lavalink container ships `wget` at `/usr/bin/wget` (verified via `podman run`), so the compose healthcheck's `CMD wget …` works on the upstream image.
+**Container-mount sanity:** Reproduced the bind-mount permissions issue described in MEDIUM-1 below by hand against `ghcr.io/lavalink-devs/lavalink:4.2.2`.
+
+---
+
+## Findings
+
+### MEDIUM-1 — `lavalink/plugins/` host bind-mount is owned by the cloning user; Lavalink (uid 322) cannot write the downloaded plugin jar on first boot
+
+- **Severity:** MEDIUM
+- **Where:** `compose.yaml:24` (`./lavalink/plugins:/opt/Lavalink/plugins`) + `lavalink/plugins/.gitkeep`
+- **Why it matters:** The official Lavalink image runs as `lavalink:lavalink` uid/gid `322:322` (`LavalinkServer/docker/Dockerfile`@4.2.2 confirms it). On first boot the container writes the resolved `youtube-plugin-1.18.0.jar` into `/opt/Lavalink/plugins/`. With the current PR, that path is a bind-mount from `./lavalink/plugins/` in the cloned repo — owned by whichever uid did the `git clone` (typically `1000:1000`) with mode `755`. Reproduced locally:
+  ```
+  $ podman run --rm --userns=keep-id:uid=322,gid=322 \
+      -v /tmp/host_plugins:/opt/Lavalink/plugins:rw \
+      ghcr.io/lavalink-devs/lavalink:4.2.2 \
+      touch /opt/Lavalink/plugins/test.txt
+  touch: cannot touch '/opt/Lavalink/plugins/test.txt': Permission denied
+  ```
+  The Lavalink service will crash on plugin resolution, the healthcheck will never go green, ryzic's `depends_on.lavalink.condition: service_healthy` will block forever, and `docker compose up` exits with a confused error chain. Plan §10 step 7 even promises "First boot pulls Lavalink image and downloads `youtube-source` plugin (~30s)" — so the README will lie. The integration test sidesteps this by `chmod 0o777` on its tmpdir plugins dir (`test_lavalink_smoke.py:79`), which is exactly the workaround that has to live in `compose.yaml` to keep the contract honest. Upstream Lavalink docs explicitly call out this footgun ("make sure to create the folder & set the correct permissions and user/group id mentioned above"). The PR neither documents nor automates around it.
+- **Fix:** Pick one:
+  1. **Use a Docker named volume for plugins** (preferred for this PR's KISS bias):
+     ```yaml
+     volumes:
+       - ./lavalink/application.yml:/opt/Lavalink/application.yml:ro
+       - lavalink_plugins:/opt/Lavalink/plugins
+       - cache:/var/cache/ryzic:ro
+     volumes:
+       cache:
+       lavalink_plugins:
+     ```
+     Compose creates the named volume root-owned and Lavalink's image is allowed to write inside it. Cost: the plugin re-downloads if the user runs `docker compose down -v` — acceptable (~30s, one-time).
+  2. **Keep the bind mount but pre-set perms in repo** — `chmod 0777 lavalink/plugins/` and document it. Loses on `git clone` (umask resets) and is ugly.
+  3. **Bake the plugin into a custom Lavalink image** — overkill for M1; defer to a follow-up if pre-pulled images become valuable.
+
+  Drop the `lavalink/plugins/.gitkeep` placeholder if you go with option 1.
+
+### MEDIUM-2 — `lavalink/application.yml` is bind-mounted host-readable but `LAVALINK_SERVER_PASSWORD` substitution requires the env var to be set inside the lavalink container (it is — but only because of compose env wiring; the YAML's literal default contradicts compose's default)
+
+- **Severity:** MEDIUM
+- **Where:** `lavalink/application.yml:13` (`password: "${LAVALINK_SERVER_PASSWORD:youshallnotpass}"`) vs `compose.yaml:21` (`LAVALINK_SERVER_PASSWORD: ${LAVALINK_PASSWORD:-youshallnotpass}`)
+- **Why it matters:** Two different "default password" code paths, both saying `youshallnotpass`. That's harmless today, but they can drift. More importantly, the compose env mapping reads `LAVALINK_PASSWORD` from the host (via `.env`) and exports it to the container as `LAVALINK_SERVER_PASSWORD`. The bot side (per plan §10) reads `LAVALINK_PASSWORD`. So a self-hoster who sets `LAVALINK_PASSWORD=…` in `.env` gets a matched bot↔Lavalink password — that's correct. But the YAML's `${LAVALINK_SERVER_PASSWORD:youshallnotpass}` default exists only as a safety net; if compose's env wiring is ever simplified (or someone copies just the YAML to a non-compose deployment), they'll silently get `youshallnotpass` — the M1 plan's "weakest default in the repo" footgun. Worth one comment line in `application.yml` saying "compose passes this; literal default is the dev/test fallback only". Not a blocker, but documents the contract.
+- **Fix:** Add a one-line comment above the password key explaining the indirection. Or, more aggressively, set `password: "${LAVALINK_SERVER_PASSWORD}"` (no default) so the dev/test fallback can't silently kick in if compose wiring breaks. Pick one — the current state is "two defaults, no comment".
+
+### LOW-1 — `_JAVA_OPTIONS: "-Xmx512m"` is an "unsupported, may go away" knob; prefer `JAVA_TOOL_OPTIONS` or a JVM `-Xmx` arg directly
+
+- **Severity:** LOW
+- **Where:** `compose.yaml:19`
+- **Why it matters:** `_JAVA_OPTIONS` is an internal HotSpot debug envvar — Oracle's docs label it "unsupported", IBM JDK ignores it, and Lavalink's own docs use `_JAVA_OPTIONS` in examples but `JAVA_OPTS` is the more common Lavalink-blessed knob. Plan §9 specified `_JAVA_OPTIONS` verbatim, so the PR is faithful, but the eclipse-temurin image (Lavalink's base) honors `JAVA_TOOL_OPTIONS` officially. Either works today; this is a forward-compat note, not a defect.
+- **Fix:** Optional. If you change anything, switch to `JAVA_TOOL_OPTIONS: "-Xmx512m"` and update plan §9 in the same commit so the contract stays single-source.
+
+### LOW-2 — CI `docker-build` job has no top-level cache permission; GHA cache works only via injected runtime token
+
+- **Severity:** LOW
+- **Where:** `.github/workflows/ci.yml:8-9` and `.github/workflows/ci.yml:67-81`
+- **Why it matters:** Top-level `permissions: contents: read`. `cache-to: type=gha` writes to GitHub Actions cache. `docker/build-push-action@v6` reads `ACTIONS_RUNTIME_TOKEN` from the runner env (auto-injected) so this works in practice — but if GitHub ever tightens that path or you migrate to a self-hosted runner that strips it, the cache silently no-ops. Worth being explicit:
+  ```yaml
+  docker-build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write   # for type=gha cache
+  ```
+- **Fix:** Add the per-job permission block. Two lines, prevents future surprise.
+
+### LOW-3 — `_load_with_retry` only catches `LavalinkError`; aiohttp/asyncio connection errors aren't retried during the readiness window
+
+- **Severity:** LOW
+- **Where:** `tests/integration/test_lavalink_smoke.py:129-140`
+- **Why it matters:** `Node.get_tracks` raises `RequestError` (≤ `LavalinkError`) for HTTP non-200, but `aiohttp.ClientError` and `asyncio.TimeoutError` for connection-level failures — neither subclasses `LavalinkError` (verified locally). The `LogMessageWaitStrategy` returns once "ready to accept connections" prints, but the Spring REST endpoint settles a beat later, so the first call is still the most likely to hit a connection-refused. With the current `except LavalinkError`, that first connection error escapes the loop and fails the test instead of retrying.
+- **Fix:** Broaden the catch:
+  ```python
+  except (LavalinkError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
+  ```
+  Need `import aiohttp` (already a transitive of lavalink.py). Defensive against CI flake.
+
+### LOW-4 — `lavalink_container` fixture pins `tmp_path_factory` mode 0755 / 0777 and chmods `application.yml` 0644 — the "permissions guard" comment is correct but the chmod chain doesn't survive `pytest --basetemp` to a 0700 parent
+
+- **Severity:** LOW
+- **Where:** `tests/integration/test_lavalink_smoke.py:75-79`
+- **Why it matters:** The fixture chmods the *contents* of `tmp_path_factory.mktemp(...)` to 0755, but pytest's tmp root (`/tmp/pytest-of-<user>/pytest-<n>/`) defaults to 0700 ownership. On standard rootless setups, in-container uid 322 can't traverse a 0700 ancestor regardless of leaf perms. Reproducible if pytest's tmp root inherits a restrictive parent — common on CI runners that override `TMPDIR`. The comment at line 71-74 acknowledges this is the failure mode but the fix only chmods the leaf, not the chain. In practice GitHub runners give world-traversable temps, so this is latent — but flagging in case CI moves.
+- **Fix:** Either (a) `os.chmod` the parent chain up to a known-traversable root, (b) bind-mount via a stage dir under `cache_dir` itself so only one chmod path exists, or (c) note it in a comment instead of the current "0700 yields …" line which describes the symptom but not the cause.
+
+### LOW-5 — Dockerfile's two-stage `uv sync` runs the resolver twice (once with `--no-install-project --no-dev`, once with `--no-editable --no-dev`); cache layers are correct but the second invocation re-walks the lockfile
+
+- **Severity:** LOW
+- **Where:** `Dockerfile:17-22`
+- **Why it matters:** The split is the canonical uv pattern (deps layer cached separately from source) and works as intended — but `uv sync --frozen` against a populated venv is a no-op for already-installed wheels, and the `--no-editable` flag on the second pass installs only the project itself non-editably. So the cost is one `uv` resolver pass for a one-package install, ~150ms. Not worth changing unless you trim further; mentioned only because the implementer report flagged "image 197 MB" as a metric and someone might wonder if the two-step costs space (it doesn't — both write to `/opt/ryzic`).
+- **Fix:** None recommended. Consider whether `UV_CACHE_DIR` benefit (the `--mount=type=cache` block) is real on second invocation; it should be, for the project wheel build.
+
+### LOW-6 — `.dockerignore` excludes `.python-version` but build relies on `python:3.13-slim-bookworm` base image; if you ever add `.python-version` for local pinning, ensure base image stays in sync
+
+- **Severity:** LOW
+- **Where:** `.dockerignore:6`, `Dockerfile:4,26`
+- **Why it matters:** No `.python-version` in repo today, so this is a pre-emptive note. The Dockerfile hardcodes 3.13. If a future dev adds `.python-version` for `uv python install` convenience locally and bumps it (e.g. 3.14), the Docker image will silently keep building 3.13. Worth a comment in the Dockerfile near the `FROM` line: "If you change Python version here, also update `pyproject.toml`'s `requires-python` and the CI matrix."
+- **Fix:** Optional, near-zero ROI.
+
+### LOW-7 — `compose.yaml` doesn't pin `version:` — fine on Compose v2 spec, but emit one if you want to be explicit
+
+- **Severity:** LOW (informational)
+- **Where:** `compose.yaml:1`
+- **Why it matters:** Compose v2 deprecated the `version:` key — omitting it is now correct. Just confirming the absence is intentional, not an oversight. (`docker-compose-v1` users still hit this path; M1's audience is `docker compose` v2+, so fine.)
+- **Fix:** None.
+
+### NOTE — Comment hygiene aligns with maintainer standards
+
+- The Dockerfile has one-line "why" comments per stage (`# Build stage:`, `# Runtime stage:`). The integration test's docstring explains what the boundary test guards (the deploy-stack contract that only fails at the container boundary) and inline comments explain the SELinux `:Z` trick, the Lavalink uid 322 footgun, and the retry rationale — all "why" not "what". `application.yml` has one comment block calling out the deprecated bundled YouTube source. Good fit for the project standard.
+
+### NOTE — `silence.ogg` provenance is clean
+
+- 4526 bytes, mono Opus at 48 kHz, ~1 second. `ogginfo` shows `Vendor: Lavf62.3.100`, `encoder=Lavc62.11.100 libopus`, no other metadata. This is a synthetic ffmpeg-encoded silence (no third-party-derived audio), so it's de facto royalty-free — no licensing concern. The PR doesn't ship a README in the fixtures dir documenting how it was generated; would be nice to add a short comment in `tests/integration/fixtures/README.md` (one line: "ffmpeg -f lavfi -i anullsrc=cl=mono:r=48000 -t 1 -c:a libopus silence.ogg"). Optional.
+
+### NOTE — Future-incident watchlist
+
+- **Multi-arch image:** The `docker-build` CI job uses default `linux/amd64` only. The Lavalink image ships `linux/amd64,linux/arm/v7,linux/arm64/v8`, but ryzic's image is amd64-only. Any self-hoster running on Raspberry Pi / Apple Silicon Linux VM / Ampere Cloud needs to rebuild locally. Worth a follow-up issue: add `platforms: linux/amd64,linux/arm64` to `docker/build-push-action` and verify yt-dlp / lavalink-py wheels exist for arm64.
+- **uv pin drift:** `Dockerfile:6` pins `ghcr.io/astral-sh/uv:0.11.6`. `pyproject.toml` requires `uv_build>=0.11.6,<0.12.0`. Latest uv is 0.11.8 (5 days fresher). Renovate/dependabot for the `COPY --from=ghcr.io/astral-sh/uv:X` line specifically would catch the drift; standard GH Dependabot supports this via the `docker` ecosystem on Dockerfiles. Add to a follow-up dependabot config.
+- **Lavalink major-version pin protection:** `compose.yaml` pins `4.2.2`. Plan §9 watchlist already calls this out. When 4.3.x or 5.x lands, the integration test (`LAVALINK_IMAGE = "ghcr.io/lavalink-devs/lavalink:4.2.2"`) is the second place that hardcodes the version — the duplication is fine for a deploy PR but a bump touches three files (compose.yaml + test + the implementer-report comment in the commit message). Would be cleaner with a single `LAVALINK_IMAGE` constant referenced from both, but that's overkill for a two-file duplication.
+- **youtube-source plugin lifecycle:** Plugin 1.18.0 already removed `TVHTML5EMBEDDED` (we're using `MUSIC, ANDROID_VR, WEB, WEBEMBEDDED` — none of which are the removed one, good). Future client removals are SemVer-exempt per the youtube-source versioning policy ("clients are not removed unless there is good reason"). The current client list is conservative; flag if a future plugin upgrade silently drops one of these four.
+- **PID 1 signal handling:** The Dockerfile uses `ENTRYPOINT ["python", "-m", "ryzic"]` directly — Python is PID 1. `hikari.GatewayBot.run()` installs SIGINT/SIGTERM handlers explicitly, so `docker stop` should propagate cleanly. If a future refactor changes the entry path, watch for shutdown hangs and consider `tini` as init.
+- **`.env` in compose context:** `compose.yaml:7` uses `env_file: .env` for the bot but compose itself also auto-loads `.env` for variable substitution (`${LAVALINK_PASSWORD:-…}`). Two layers, both reading the same file — harmless, just confusing if a self-hoster moves variables between the two scopes. Worth one line in the README's setup section.
+- **Compose's `lavalink/plugins/` empty bind mount:** see MEDIUM-1. Once fixed, also consider whether `cache:/var/cache/ryzic:ro` on the lavalink side needs a `delegated`/`Z` flag for SELinux self-hosters. The bind variant already does in the integration test; the named-volume variant in compose doesn't need `:Z`.
+
+---
+
+## Verdict
+
+**minor revisions.**
+
+The scope is tight, the multi-stage Dockerfile is clean (cache-friendly COPY layers, non-root uid 1001 set up correctly with `--home-dir` + `--shell /usr/sbin/nologin`, ENTRYPOINT runs `python -m ryzic` matching `__main__.py`), and the compose shape matches plan §9 nearly verbatim with the appropriate Lavalink 4.2.2 bump. The `application.yml` correctly disables every non-local source per the plan, declares `youtube-plugin:1.18.0` with the right `dev.lavalink.youtube` Maven coordinates and Lavalink-v4 `snapshot: false` shape, and selects a sensible client tuple (`MUSIC, ANDROID_VR, WEB, WEBEMBEDDED`) — none of which are the deprecated `TVHTML5EMBEDDED`. The integration test idiomatically uses `testcontainers-python`'s `LogMessageWaitStrategy`, scopes the container to a module fixture (cleanup via `try/finally`), and explicitly handles the SELinux+rootless-Podman case with `:Z` mounts and chmod 0o644/0o755/0o777 on staged files. CI split is sound: `lint-and-test` → `integration` (sequential, post-lint), `docker-build` parallel with GHA layer cache. `pyproject.toml` adds `testcontainers>=4.14.2` to dev deps and `addopts = "-m 'not integration'"` keeps the unit lane fast — the right call.
+
+The blocker-ish item is **MEDIUM-1**: the `lavalink/plugins/` host bind-mount will cause first-boot to fail for any self-hoster whose host uid isn't 322, which is essentially all of them. Reproduced locally. The cleanest fix is to swap to a named volume; it preserves restart-survival of the downloaded plugin and removes the empty `.gitkeep` artifact. **MEDIUM-2** is a five-minute clarity fix on the `application.yml` password indirection. The LOWs are nice-to-haves; **LOW-2** (`actions: write` on docker-build) and **LOW-3** (broaden the retry's exception net) are worth the two-line patches as defensive hygiene.
+
+Once MEDIUM-1 is addressed, ship.

--- a/docs/plans/PR4-security-review.md
+++ b/docs/plans/PR4-security-review.md
@@ -1,0 +1,168 @@
+# PR #4 — Security Review
+
+**PR**: `feat(deploy): Dockerfile + docker-compose + Lavalink config`
+**Branch**: `feat/docker-compose` -> `main`
+**Repo**: `VeryLongOrgNameSuchWow/ryzic`
+**Commit reviewed**: `6d5283f`
+**Files in scope** (PR diff only):
+- `Dockerfile` (new, 43 lines)
+- `compose.yaml` (new, 34 lines)
+- `lavalink/application.yml` (new, 57 lines)
+- `lavalink/plugins/.gitkeep` (new, empty)
+- `.dockerignore` (new, 43 lines)
+- `.github/workflows/ci.yml` (added `integration` + `docker-build` jobs)
+- `tests/integration/__init__.py` (new, empty)
+- `tests/integration/test_lavalink_smoke.py` (new, 140 lines)
+- `tests/integration/fixtures/silence.ogg` (new, 4526 bytes binary)
+- `pyproject.toml` (added `testcontainers` dev dep + `integration` marker)
+- `uv.lock` (resolution for `testcontainers` and its transitive closure)
+
+This review covers the ten focus areas from the brief: Dockerfile hygiene, compose
+exposure surface, Lavalink config, GHA workflow security, `.dockerignore`
+completeness, integration-test isolation, fixture provenance, dependency CVE
+scan, reproducibility, and self-hoster permission posture.
+
+---
+
+## Findings
+
+### 1. Dockerfile — non-root user, layer hygiene, no baked secrets
+
+**Severity**: (informational - no finding)
+**What**: The runtime stage creates a fixed `ryzic` user (uid 1001, gid 1001), `mkdir -p /var/cache/ryzic` with `chown ryzic:ryzic`, `COPY --chown=ryzic:ryzic` for the staged venv, and finishes with `USER ryzic`. Login shell is `/usr/sbin/nologin`. Build stage does not declare any `ARG` (no build-time args that could leak via image history) and does not set any `ENV` containing default tokens or passwords - only `UV_*` knobs and `PATH/PYTHON*/RYZIC_CACHE_DIR`. The `COPY` lines copy `pyproject.toml`, `uv.lock`, `README.md`, `LICENSE`, then `src/`. Combined with `.dockerignore` (see #5), `.env`, `.git`, `lavalink/`, `tests/`, `docs/` are excluded from the build context, so they cannot land in any layer. `--mount=type=cache,target=/root/.cache/uv` keeps the uv cache out of the final image. Final stage is `python:3.13-slim-bookworm` (no shell-on-`apt-add` calls; no `apt-get install` adds attack surface). Verified `--chown` is applied to the COPY-from-build, so the runtime user owns its venv. **Verdict: clean.**
+
+---
+
+### 2. Dockerfile reproducibility - base images pin to floating tags
+
+**Severity**: LOW (M1 deploy posture; not exploitable by itself)
+**What**: Three image references in the build are pinned by tag, not by `@sha256:` digest:
+- `python:3.13-slim-bookworm` (build + runtime stages)
+- `ghcr.io/astral-sh/uv:0.11.6` (uv binary)
+- (related, see #4) `ghcr.io/lavalink-devs/lavalink:4.2.2` in `compose.yaml`
+**Where**: `Dockerfile:4`, `Dockerfile:6`, `Dockerfile:26`; `compose.yaml:17`.
+**Why it matters**: A tag is mutable. If any of those publishers were compromised (or an upstream registry hijack occurred), `docker pull` would fetch a substitute image transparently. uv is at least pinned to a patch version (`0.11.6`), but the publisher could republish that tag. Python's `:3.13-slim-bookworm` floats across patch releases - acceptable for a hobbyist self-hoster but not what a security-conscious deployer would want. The same concern applies to `4.2.2` Lavalink tag. The `docker-build` CI job rebuilds on every push, so this also means CI runs are not bit-reproducible: a quiet upstream change can break or compromise builds at any time without a corresponding diff.
+**Why it's LOW, not MEDIUM**: M1 plan §9 explicitly accepts a tag-pinned posture for the first deploy iteration; there's no signed/notary pipeline to anchor digests against; and the Discord-bot threat model is "self-hoster runs this on a personal box," not "production multi-tenant service." Pinning by digest also means dependabot won't auto-bump security fixes - the project would need to either accept staleness or wire up renovate's `pinDigests + updatePinnedDependencies`. Deferring to a later iteration is the principled tradeoff.
+**Fix**: Defer to follow-up issue. When pinning, swap to e.g. `python:3.13.0-slim-bookworm@sha256:<digest>` and `ghcr.io/astral-sh/uv:0.11.6@sha256:<digest>`. Pair with a renovate/dependabot rule that updates the digest alongside the tag. Add a TODO comment in `Dockerfile` at the affected lines so the next pass finds them.
+
+---
+
+### 3. compose.yaml - Lavalink not exposed on host, password handling correct
+
+**Severity**: (informational - no finding)
+**What**: The `lavalink` service in `compose.yaml` declares no `ports:` mapping, so Lavalink's port 2333 lives on the compose-default bridge network only and is unreachable from the host or LAN. Inter-service traffic uses the compose service DNS (`LAVALINK_HOST: lavalink`). The Lavalink container's listen address (`0.0.0.0:2333`) is fine because it's confined to the bridge network. Password defaults to `youshallnotpass` via the `${LAVALINK_PASSWORD:-youshallnotpass}` substitution in compose **and** in `application.yml` - because the network is not host-reachable, the default is acceptable for a home deploy. `cache:/var/cache/ryzic:ro` correctly enforces read-only on the Lavalink side (only `ryzic` writes; Lavalink reads). The `application.yml` mount uses `:ro`. The shared `cache` named volume is isolated to compose. `restart: unless-stopped` is appropriate; the bot's bad-credentials path (Discord 4004) raises and exits the process with no auto-recovery loop within the bot - compose will restart, the user will see the same crash, and they'll need to fix the token. Not an infinite-loop credential-spam risk against Discord because hikari backs off on auth failures and the restart cadence is capped by the start time of the container. **Verdict: clean.**
+
+---
+
+### 4. compose.yaml - `lavalink/plugins/` mount is read-write (by necessity), but that's the only attack surface a malicious plan-modifier has
+
+**Severity**: LOW (defense-in-depth observation, not an exploitable bug)
+**What**: `./lavalink/plugins:/opt/Lavalink/plugins` is mounted **without** `:ro`. Lavalink writes the downloaded `youtube-source` plugin jar there on first boot, so it must be writable. That's the correct tradeoff for an out-of-the-box experience - documented in M1 plan §10 and visible in the integration test (`plugins_dir.chmod(0o777)` for the same reason).
+**Where**: `compose.yaml:24`.
+**Why it matters**: A self-hoster who mistakenly drops a malicious `.jar` into `./lavalink/plugins/` on the host would have it executed inside the Lavalink container at next start. This is defense-in-depth at most: the attacker would already need shell on the host. No realistic attack vector unless someone misuses the directory as a download target. The README (PR9) should mention "do not put files in `lavalink/plugins/`; Lavalink manages it."
+**Fix**: Optional. Either accept and document, or split: declare the youtube-source jar via `application.yml` only, mount `lavalink/plugins:` `:ro`, and on first boot bind a separate `plugins-cache:` named volume. The added complexity probably isn't worth it for M1; flag for PR9 README copy: "this directory is managed by Lavalink; do not put untrusted jars here."
+
+---
+
+### 5. lavalink/application.yml - password sourced from env, no hardcoded credentials, plugin source authentic
+
+**Severity**: (informational - no finding)
+**What**: `password: "${LAVALINK_SERVER_PASSWORD:youshallnotpass}"` reads from the env var Lavalink receives via compose. The fallback `youshallnotpass` matches `compose.yaml` and `.env.example` - consistent default, not a hardcoded secret. The `youtube-source` plugin dependency `dev.lavalink.youtube:youtube-plugin:1.18.0` resolves to the official `lavalink-devs/youtube-source` Maven artifact - same group/artifact published by `lavalink-devs` (the same org that publishes the Lavalink server image). All other source managers (`bandcamp`, `soundcloud`, `twitch`, `vimeo`, `nico`, `http`) are explicitly disabled, narrowing the attack surface to "audio that the bot intentionally cached" plus YouTube via the plugin. `server.sources.youtube: false` (deprecated bundled source) is correctly disabled per M1 plan §9. The dual-config of `server.sources.youtube: false` + `plugins.youtube.enabled: true` + `allowSearch: false`, `allowDirectVideoIds: false`, `allowDirectPlaylistIds: false` further restricts the YouTube plugin to "load only what the bot resolved to a URL," preventing arbitrary search/ID lookup from network-reachable callers. **Verdict: clean.**
+
+---
+
+### 6. GHA workflow - `permissions: contents: read` is correct floor, but third-party actions pin to major tags
+
+**Severity**: LOW (supply-chain hardening gap)
+**What**: `permissions: contents: read` is set at the workflow root - explicitly minimal. `concurrency` cancels stale runs. No `pull_request_target` is used (the `pull_request` trigger checks out the head SHA without secrets). `GITHUB_TOKEN` is implicit and limited to `contents: read`. `actions/checkout@v6`, `astral-sh/setup-uv@v8.1.0`, `docker/setup-buildx-action@v3`, and `docker/build-push-action@v6` are all referenced by tag. Of these, `setup-uv` is the only one pinned to a patch (`@v8.1.0`); `actions/checkout`, `docker/setup-buildx-action`, and `docker/build-push-action` use major-only tags that float. This is identical to the existing PR #1 posture and consistent with the rest of `.github/workflows/`.
+**Where**: `.github/workflows/ci.yml:22, 25, 51, 54, 70, 71, 73`.
+**Why it matters**: A compromised release of `actions/checkout@v6` (org owns the repo, so the threat model is supply-chain compromise of the action publisher itself - rare but documented; e.g. `tj-actions/changed-files` 2024) would leak our `GITHUB_TOKEN` (read-only here, so impact is small) and could plant code in the build context for the `docker-build` job (which sees the full repo). The minimal `permissions:` block keeps the blast radius small. Pinning to a full `@<commit-sha>` would close the residual risk, at the cost of every dependabot bump producing churn. Recommend deferring to a follow-up issue along with #2 (digest pinning); they're the same class of decision.
+**Fix**: Defer to follow-up. When tightened, pin all third-party actions to commit SHAs and add a `dependabot.yml` group rule for "github-actions" that includes commit-sha bumps.
+
+---
+
+### 7. GHA workflow - `docker-build` job missing `permissions:` override (inherits the workflow-level `contents: read`, which is correct, but worth noting)
+
+**Severity**: (informational - no finding)
+**What**: The `docker-build` job correctly inherits `permissions: contents: read` from the workflow root (no per-job override). It does not push the image (`push: false, load: true, tags: ryzic:ci`), so no registry credential is required and `GITHUB_TOKEN` write is not needed. `cache-from: type=gha, cache-to: type=gha,mode=max` uses the GitHub Actions cache backend, which scopes to the workflow's repo and refs - no cross-repo leak path. The `docker-build` job runs on every PR including from forks, but because `pull_request` (not `pull_request_target`) is the trigger, the fork SHA is checked out without access to repo secrets. **Verdict: clean.**
+
+---
+
+### 8. .dockerignore - excludes the right things plus defense-in-depth credential patterns; one omission
+
+**Severity**: LOW (consistency nit)
+**What**: `.dockerignore` excludes `.env`, `.env.*` (with `!.env.example` override), `.git`, `.github`, `.venv`, tests, docs, compose/lavalink files, IDE noise. **Missing relative to `.gitignore`**: the credential-pattern hardening lines from `.gitignore` (`*.pem`, `*.key`, `*.crt`, `id_rsa*`, `id_ed25519*`, `secrets/`, `credentials.json`). These are unlikely to ever exist in the repo (they'd violate the project rule too) but `.dockerignore` should mirror `.gitignore`'s defense-in-depth posture so that if a self-hoster fork accidentally drops a key into the repo root and then runs `docker build`, the key never enters a layer.
+**Where**: `.dockerignore:1-44` (compare `.gitignore:26-33`).
+**Why it matters**: One of the top "I baked a secret into a Docker image" failure modes is a self-hoster dropping a `creds.json` next to their `compose.yaml` for some unrelated reason; `.dockerignore` is the last line of defense.
+**Fix**: Append to `.dockerignore`:
+```
+# Generic credential patterns (defense-in-depth — never expected, never wanted)
+*.pem
+*.key
+*.crt
+id_rsa*
+id_ed25519*
+secrets/
+credentials.json
+```
+One-liner, no behavior change for current repo state, mirrors `.gitignore`.
+
+---
+
+### 9. Integration test - no embedded Discord token, password is the same `youshallnotpass` default, image pinned by tag (mirrors compose.yaml)
+
+**Severity**: (informational - no finding for token; tag-pin shared with #2)
+**What**: `tests/integration/test_lavalink_smoke.py` does not import or reference any Discord credential; it constructs `lavalink.Client(user_id=1)` with a synthetic user_id and never connects to a real Discord. The Lavalink password literal `"youshallnotpass"` is the same harmless default used in `compose.yaml`/`application.yml` (i.e. the test is not betraying a production secret - the default exists publicly in the source). The image `ghcr.io/lavalink-devs/lavalink:4.2.2` is tag-pinned, not digest-pinned (same observation as #2; if you fix one, fix both). The fixture is mounted `:ro,Z` and the cache dir is mounted `:ro,Z` - the test can't write outside its tmpdir. SELinux relabel via `:Z` is a function-correctness fix, not a security risk. **Verdict: clean (modulo #2).**
+
+---
+
+### 10. OGG fixture - generated by ffmpeg/libopus, royalty-free
+
+**Severity**: (informational - no finding)
+**What**: `file tests/integration/fixtures/silence.ogg` reports `Ogg data, Opus audio, version 0.1, mono, 48000 Hz`. The OpusTags packet inside the file lists encoder strings `Lavf62.3.100` and `Lavc62.11.100 libopus` (FFmpeg's libavformat/libavcodec + libopus encoder). This is consistent with a one-shot synthesis like `ffmpeg -f lavfi -i anullsrc=r=48000:cl=mono -t 0.X -c:a libopus -b:a ... silence.ogg` rather than a re-encoded copyrighted source - the file is silence, only 4526 bytes, and contains no IRSC/title/album metadata. ffmpeg, libavformat, libavcodec, libopus are all under permissive/LGPL/BSD-style licenses; the encoded silence has no original creative content to copyright (Naruto Hiru notwithstanding - silence is not copyrightable). **Verdict: clean.**
+
+---
+
+### 11. uv.lock - new transitive deps audit
+
+**Severity**: (informational - no finding)
+**What**: This PR adds eight packages (one direct, seven transitive):
+
+| Package | Version | Source | Notes |
+| --- | --- | --- | --- |
+| `testcontainers` | 4.14.2 | PyPI | Direct dev dep; current as of early 2026 |
+| `docker` | 7.1.0 | PyPI | testcontainers transitive; current as of early 2026 |
+| `requests` | 2.33.1 | PyPI | docker transitive; current as of early 2026 |
+| `urllib3` | 2.6.3 | PyPI | requests transitive; CVE-2024-37891 fixed in 2.2.2 - we're well past |
+| `certifi` | 2026.4.22 | PyPI | requests transitive; cert bundle, regularly refreshed |
+| `charset-normalizer` | 3.4.7 | PyPI | requests transitive; pure Python, low risk |
+| `pywin32` | 311 | PyPI | docker transitive; **only resolved on Windows** (env-marker gated, not installed on Linux/macOS hosts) |
+| `wrapt` | 2.1.2 | PyPI | testcontainers transitive; widely used decorator helper |
+
+All sources are `https://pypi.org/simple` (verified via `grep -E "^source = " uv.lock | sort -u` -> only PyPI and the editable project). No private indices, no Git URLs, no path-overrides. As of cutoff (Jan 2026), I'm not aware of an open critical/high CVE against the pinned versions of these packages. The dev-only scope (testcontainers is in `[dependency-groups].dev`, not `[project].dependencies`) means none of this ships in the runtime image - confirmed by `tests/` being in `.dockerignore` and `uv sync --no-dev` in the Dockerfile build stage. **Verdict: clean.**
+
+---
+
+### 12. Self-hoster permission posture (Administrator perm) - documented in M1 plan, README still pending
+
+**Severity**: LOW (deferred to PR9, but flagged because the brief asks)
+**What**: M1 plan §10 step 4 says: "Generate invite URL... permissions `Connect`, `Speak`, `Send Messages`, `Embed Links`, `Use Slash Commands`. **Do NOT use Administrator** - common rookie mistake; security smell in a music bot." The README is currently empty (PR9 is dedicated to docs). Nothing in the bot's runtime code can prevent a self-hoster from inviting the bot with Administrator - that's a Discord OAuth scope decision the deployer makes. No code path in `src/ryzic/` uses `MANAGE_GUILD`, `KICK_MEMBERS`, etc., so the bot doesn't *want* admin; the only exposure if a self-hoster ignores the doc is "if the Discord token leaks, the attacker has admin on every guild that invited the bot."
+**Where**: This PR's diff doesn't touch README. The plan-level mitigation lives in `docs/plans/M1.md:430` and will land in PR9.
+**Why it matters**: This is the canonical self-hoster footgun for Discord bots. The mitigation is doc-only - hard to enforce in code - so PR9 must call it out prominently. The bot DOES get one strong code-level mitigation right: `dm_enabled=False` at command registration (M1 plan §3) means commands can't be triggered in DMs even if the bot is in a guild as Administrator. Required intents are `GUILDS | GUILD_VOICE_STATES` - no `GUILD_MEMBERS`, `MESSAGE_CONTENT`, or `PRESENCES` - which limits what an admin-scoped token would expose.
+**Fix**: Out of scope for this PR. Tracking note for PR9 reviewer: README "Setup" section MUST include the "Do NOT use Administrator" call-out + the recommended permission integer/scope set, and SHOULD include a "rotating your bot token" link to the Discord Developer Portal in case it leaks.
+
+---
+
+## Verdict
+
+**fixes recommended**
+
+No HIGH-severity findings. No merge blockers. Three LOW-severity items worth addressing:
+- **#5 (.dockerignore credential patterns)** - one-line fix in this PR; mirrors `.gitignore`. Low effort, defense-in-depth win, recommend doing now.
+- **#2 + #6 + #9 (digest pinning for base images and GHA actions)** - same class of decision; recommend a single follow-up issue tracking digest pinning + dependabot/renovate config to keep digests fresh.
+- **#4 (lavalink/plugins writeable mount)** - documentation note in PR9; no code change needed.
+- **#12 (Administrator perm warning)** - PR9 README must include the call-out.
+
+The Dockerfile correctly drops to a non-root user with a deterministic uid, the compose stack confines Lavalink to a bridge network with no host port, the Lavalink config sources its password from env and disables every audio source manager except YouTube-via-plugin (with search/direct-id disabled), the GHA workflow has a minimal `permissions:` block and uses `pull_request` (not `pull_request_target`), the integration test embeds no real credentials and isolates volumes correctly, and the OGG fixture is a 4.4 KB ffmpeg-generated silence with no copyright concern. The transitive dependency closure is small (eight new packages, all from PyPI, all dev-only) and free of known critical CVEs at cutoff.
+
+Apply the `.dockerignore` patch (#5) before merge if you want a fully clean review; otherwise the LOW items can ride into M2 follow-ups.

--- a/docs/plans/PR4-simplify.md
+++ b/docs/plans/PR4-simplify.md
@@ -1,0 +1,313 @@
+# PR #4 Simplification Pass — `feat(deploy): Dockerfile + docker-compose + Lavalink config`
+
+**Branch:** `feat/docker-compose` -> `main`
+**Diff reviewed:** +548 LOC across 11 files (Dockerfile 43, .dockerignore 43, ci.yml +37, compose.yaml 34, application.yml 57, integration test 140, pyproject 7, plus uv.lock + fixtures).
+**Companion docs:** `docs/plans/M1-simplify.md` (locked plan-level cuts), `docs/plans/M1.md` §9 (compose shape) + §10 (env vars) + PR7 entry in §12.
+
+This pass looks only for shapes that are more elaborate than M1 §9–§10 justifies, and that the maintainer would reasonably want collapsed under "three similar lines is better than a premature abstraction." It does not critique correctness or security (other agents).
+
+Honest framing: PR4 is **mostly tight** — the Dockerfile, compose stack, and `.dockerignore` are at or near the right size. The biggest real wins live in `application.yml` (one block is verbatim upstream defaults) and in the integration test's permissions stanza (over-engineered for a smoke test). Realistic floor of LOC saved: **~30–55 LOC**, none of which changes the surface contract or weakens the testcontainer's signal.
+
+---
+
+## Findings
+
+### S-1 — Drop the explicit `clients:` list in `application.yml`
+
+**What to cut/collapse:** Remove the `plugins.youtube.clients` block (lines 40–44, six lines):
+
+```yaml
+    clients:
+      - MUSIC
+      - ANDROID_VR
+      - WEB
+      - WEBEMBEDDED
+```
+
+**Where:** `lavalink/application.yml` lines 40–44.
+
+**Why it's safe:** This list is the verbatim `DEFAULT_CLIENTS` array from `youtube-source` upstream (`common/src/.../YoutubeAudioSourceManager.java`):
+```java
+public static final Client[] DEFAULT_CLIENTS = new Client[] {
+    new Music(), new AndroidVr(), new Web(), new WebEmbedded()
+};
+```
+The plugin's `YoutubePluginLoader` falls back to `DEFAULT_CLIENTS` when `clients:` is unset. Restating the default in our config buys nothing now and pins us to the **v1.18.0 default** in perpetuity — meaning when upstream rotates clients (which they do, as YouTube breaks individual InnerTube clients), self-hosters get the stale list until they manually edit `application.yml`. Letting the default float is the better default for an OSS project that's tracking upstream's plugin minor.
+
+The plan (§9) doesn't mention specific clients; this is an implementer choice, and "no opinion → take upstream's" is the right posture.
+
+**Estimated LOC saved:** 6 lines (5 list entries + the `clients:` key).
+
+---
+
+### S-2 — Drop the verbose source toggles; rely on global `local: true` only
+
+**What to cut/collapse:** In `lavalink/application.yml` lines 14–22, the eight explicit `false` source toggles:
+
+```yaml
+    sources:
+      youtube: false
+      bandcamp: false
+      soundcloud: false
+      twitch: false
+      vimeo: false
+      nico: false
+      http: false
+      local: true
+```
+
+Collapse to:
+```yaml
+    sources:
+      youtube: false   # plugin replaces it
+      local: true
+```
+
+**Where:** `lavalink/application.yml` lines 14–22.
+
+**Why it's safe:** Lavalink's `application.yml` defaults already enable bandcamp / soundcloud / twitch / vimeo / nico / http — but the plan's threat-model in §3 / §4 is **YouTube only**, so the bot will never *send* loadtracks queries that match those source managers' patterns. `url_validator.py`'s allowlist (`youtube.com`, `youtu.be`, `m.youtube.com`, `music.youtube.com`) bounces them at the bot layer first. The defense-in-depth value of `bandcamp: false` etc. is real but small — and the plan doesn't ask for it. Per "three similar lines vs premature abstraction," six identical `false` lines for a constraint not in the spec is bloat.
+
+If the maintainer *does* want belt-and-suspenders source restriction, a one-line comment `# only the URL validator and `youtube: false` are load-bearing; other source managers idle without input` documents the intent without 6 toggles.
+
+**Estimated LOC saved:** 6 lines (could go to 7 if `youtube: false` retains its existing inline comment).
+
+**Note:** This is the most arguable cut on the list — if the maintainer prefers explicit-deny for security posture, keep it. Listed because the PR doesn't reference any plan section that asks for these toggles, so it qualifies as "more elaborate than the spec justifies."
+
+---
+
+### S-3 — Replace the chmod stanza in the integration test with a single tmpdir mode
+
+**What to cut/collapse:** `tests/integration/test_lavalink_smoke.py` lines 71–79:
+
+```python
+# Lavalink runs as uid 322 inside the container. Bind mounts must be
+# readable (and the plugins dir writable) by that uid; pytest tmpdirs
+# default to 0700, which silently yields a permission-denied container
+# crash or an EMPTY load result.
+for d in (config_dir, plugins_dir, cache_dir):
+    d.chmod(0o755)
+(config_dir / "application.yml").chmod(0o644)
+(cache_dir / FIXTURE.name).chmod(0o644)
+plugins_dir.chmod(0o777)  # Lavalink needs to drop the downloaded jar here.
+```
+
+Collapse to:
+```python
+# pytest tmpdirs are 0700; Lavalink (uid 322) needs world-read on dirs
+# and write on plugins/ for its first-boot jar download.
+for d in (config_dir, plugins_dir, cache_dir):
+    d.chmod(0o755)
+plugins_dir.chmod(0o777)
+```
+
+(File-level chmods are unnecessary — `shutil.copy` preserves source modes, and source files in the repo are already 0644.)
+
+**Where:** `tests/integration/test_lavalink_smoke.py` lines 71–79.
+
+**Why it's safe:** `shutil.copy` copies file mode along with data; the repo's `application.yml` and `silence.ogg` are already mode 0644 in the worktree. The redundant per-file chmods just guard against a hypothetical future where those files become 0600 in the repo — a problem nothing else in the project addresses or signals. Comment WHAT (line 79 narrates "Lavalink needs to drop the downloaded jar here") collapses into the consolidated WHY at the top.
+
+**Estimated LOC saved:** 4–5 lines.
+
+---
+
+### S-4 — Drop `_load_with_retry` helper; let testcontainers' wait strategy do its job
+
+**What to cut/collapse:** `tests/integration/test_lavalink_smoke.py`:
+- Lines 17 (`import asyncio`), 19 (`import time`)
+- Lines 26 (`from lavalink import ... LavalinkError ...` — only `LavalinkError` is used by the helper)
+- Lines 119 (call site `result = await _load_with_retry(node, ...)`)
+- Lines 129–140 (the entire `_load_with_retry` function body)
+
+Replace with:
+```python
+result = await node.get_tracks(f"{CACHE_PATH_IN_CONTAINER}/{FIXTURE.name}")
+```
+
+**Where:** `tests/integration/test_lavalink_smoke.py` lines 17, 19, 26 (`LavalinkError`), 119, 129–140.
+
+**Why it's safe:** The test already gates on `LogMessageWaitStrategy("Lavalink is ready to accept connections")` — that log line is emitted by Lavalink **after** `LavalinkServer` finishes binding to its REST port and source managers are loaded. The "loadtracks settles a moment after the readiness log line" claim in the helper's comment is speculative; if it really were true, the fix would be a *different* wait strategy (e.g. `HttpWaitStrategy("/version")`), not a per-test retry loop layered on top.
+
+Worst case: the first `get_tracks` call hits a 1–2s window where Lavalink is "ready but warming," fails, and the test reports it directly via the assertion message. That's a clearer failure mode than "10s of silent retry then assertion." If we ever observe this happen in CI, swap the wait strategy in one place. Until then, 12 lines of speculative retry are net-negative.
+
+**Estimated LOC saved:** ~14 lines (helper + imports + call-site indirection).
+
+---
+
+### S-5 — Drop the `:Z` suffix from integration-test volume mounts (or comment-only documentation)
+
+**What to cut/collapse:** `tests/integration/test_lavalink_smoke.py` lines 81–94:
+
+```python
+# `:Z` is a no-op on Docker hosts without SELinux; on Podman + SELinux
+# (Fedora) it relabels the mount so the in-container lavalink uid can read.
+# First boot also fetches the youtube-source plugin from Maven (~30s cold).
+container = (
+    DockerContainer(LAVALINK_IMAGE)
+    ...
+    .with_volume_mapping(
+        str(config_dir / "application.yml"), "/opt/Lavalink/application.yml", "ro,Z"
+    )
+    .with_volume_mapping(str(plugins_dir), "/opt/Lavalink/plugins", "rw,Z")
+    .with_volume_mapping(str(cache_dir), CACHE_PATH_IN_CONTAINER, "ro,Z")
+```
+
+Collapse mode strings to the unsuffixed forms (`"ro"`, `"rw"`, `"ro"`).
+
+**Where:** `tests/integration/test_lavalink_smoke.py` lines 91, 93, 94 (`,Z` suffix on three mode strings) and the 3-line comment block at 81–83.
+
+**Why it's safe:** The companion `compose.yaml` (lines 23–25) does **not** use `:Z` for the same three mounts (`./lavalink/application.yml`, `./lavalink/plugins`, `cache:/var/cache/ryzic`). Either both should have it (consistency) or neither does. If the test passes locally on Maddie's Fedora VM today via the Docker-not-Podman path, then `:Z` was never actually exercised; if the suite is meant to run under rootless Podman + SELinux, `compose.yaml` is the one with the bug, not the test. Pick one rule:
+
+- **Drop from test** (recommended): match compose, accept "Podman + SELinux requires `--security-opt label=disable` or running the test on a Docker host."
+- **Add to compose**: more code, but consistent. Defer to PR9 (docs) — out of scope here.
+
+This PR's job is to ship M1 deployment; SELinux portability of tests is not in M1 §9 acceptance criteria. Picking the test-drop variant for now is the smaller change.
+
+**Estimated LOC saved:** 3 inline (`,Z` suffix on three lines) + the 3-line comment. Net ~6 lines, with bonus consistency between test and compose.
+
+---
+
+### S-6 — Inline `_probe_docker` body into the fixture, drop the function
+
+**What to cut/collapse:** `tests/integration/test_lavalink_smoke.py` lines 38–51 + 56:
+
+```python
+def _probe_docker() -> bool:
+    # The CLI binary is irrelevant — testcontainers talks to the daemon socket
+    # directly (DOCKER_HOST or unix:///var/run/docker.sock by default), which
+    # also happens to work with rootless Podman's compatible socket.
+    try:
+        from docker.errors import DockerException  # type: ignore[import-untyped]
+        from testcontainers.core.docker_client import DockerClient
+    except ImportError:
+        return False
+    try:
+        DockerClient().client.ping()
+    except DockerException:
+        return False
+    return True
+
+
+@pytest.fixture(scope="module")
+def lavalink_container(tmp_path_factory: pytest.TempPathFactory):
+    if not _probe_docker():
+        pytest.skip("Docker daemon not reachable")
+```
+
+Inline:
+```python
+@pytest.fixture(scope="module")
+def lavalink_container(tmp_path_factory: pytest.TempPathFactory):
+    try:
+        from docker.errors import DockerException  # type: ignore[import-untyped]
+        from testcontainers.core.docker_client import DockerClient
+        DockerClient().client.ping()
+    except (ImportError, DockerException):
+        pytest.skip("Docker daemon not reachable")
+```
+
+**Where:** `tests/integration/test_lavalink_smoke.py` lines 38–51, 56.
+
+**Why it's safe:** Single caller, single use. Function-extraction is justified when there are ≥2 callers or when the body is inscrutable enough to need a name. The probe body is ~3 lines of try/except; the surrounding 4-line WHY comment is the actual valuable part and stays. No reuse exists or is planned (the test is intentionally the only integration test in M1 per §12 PR7).
+
+**Estimated LOC saved:** ~5 LOC (function def + return statement + the redundant try-block split).
+
+---
+
+### S-7 — Cut comments narrating WHAT in `application.yml`, `.dockerignore`, `compose.yaml`
+
+Small, scattered. Examples:
+
+- `lavalink/application.yml` line 7: `# Bundled YouTube source is deprecated in Lavalink v4 — use the dedicated plugin.` — keep (this one is genuine WHY).
+- `.dockerignore` lines 30–31: `# Tests + docs aren't needed in the runtime image. README.md is intentionally / # kept — pyproject.toml references it and uv build reads it during sync.` — keep (real WHY: explains the absence of `README.md` from the ignore list).
+- `.dockerignore` line 16: `# Python build artefacts` — narrates WHAT (the next 6 lines are obviously Python build artifacts). Cut.
+- `.dockerignore` line 24: `# Local sqlite scratch` — narrates WHAT. Cut.
+- `.dockerignore` line 35: `# Compose stack and lavalink config aren't part of the bot image` — borderline; this one is WHY-ish (explains why `compose.yaml` is in `.dockerignore` despite being a runtime-adjacent file). Keep.
+- `.dockerignore` line 41: `# Editor + OS noise` — WHAT. Cut.
+
+**Where:** `.dockerignore` lines 16, 24, 41.
+
+**Why it's safe:** `__pycache__`, `*.sqlite`, and `.DS_Store` are self-documenting to anyone who works on Python projects. Comments that name the category without explaining the policy are skim-noise.
+
+**Estimated LOC saved:** 3 LOC.
+
+---
+
+### S-8 — Inline `pytest.ini_options.markers` registration, drop the explanatory comment
+
+**What to cut/collapse:** `pyproject.toml` lines 58–63:
+
+```toml
+# Integration tests (Docker required) are opt-in: `pytest -m integration` to run them,
+# `pytest -q` (the default in CI's fast lane) skips them.
+addopts = "-m 'not integration'"
+markers = [
+    "integration: tests that spin up real services (Docker required)",
+]
+```
+
+The marker-self-description (`"integration: tests that spin up real services..."`) and the toml-level comment say the same thing twice. Trim the comment:
+
+```toml
+addopts = "-m 'not integration'"
+markers = [
+    "integration: tests that spin up real services (Docker required); run with `pytest -m integration`",
+]
+```
+
+**Where:** `pyproject.toml` lines 58–59.
+
+**Why it's safe:** Pytest prints the marker description on `--markers` and in `PytestUnknownMarkWarning`s — that's where someone discovers what `integration` means. The toml-level comment is invisible to that user; it's only seen by someone reading `pyproject.toml`, who can also read `addopts` directly. Single source of truth.
+
+**Estimated LOC saved:** 2 LOC.
+
+---
+
+### S-9 — Things to keep as-is
+
+These I considered cutting and decided not to.
+
+#### Dockerfile two-stage build — **keep**.
+Single-stage would either ship `uv` + the build cache in the runtime image (size penalty + attack surface) or cram everything into one `RUN` block to clean up after itself (less readable, no longer leverages BuildKit's cache mounts cleanly). The two stages here aren't a "premature abstraction" — they're the canonical uv-on-Debian pattern, and `astral-sh/uv-docker-example` ships exactly this shape. ~25 lines of `FROM build` is justified.
+
+#### CI split into 3 jobs — **keep**.
+- `lint-and-test` is the fast feedback lane.
+- `docker-build` runs in parallel (no `needs:`) and is independent of Python — it gates "image still builds" without serializing on the test job. Merging it into `lint-and-test` would double the wall-clock for the fast lane.
+- `integration` is correctly behind `needs: lint-and-test` (don't pay testcontainer cost when unit tests are red).
+
+This is the right shape. It earned its split.
+
+#### `.dockerignore` comprehensive list — **keep mostly**.
+`.dockerignore`'s job is to be paranoid. `.git`, `.env*`, `.claude/`, `.venv`, `*.sqlite*` all genuinely belong; the secrets-related entries (`.env.*` with `!.env.example` re-include) are load-bearing. Only the WHAT-narrating headers in S-7 should go.
+
+#### Healthcheck retry count / interval — **keep**.
+`interval: 10s, timeout: 3s, retries: 5` is 50s of grace before compose declares the lavalink container unhealthy. First boot downloads `youtube-source` from Maven (~30s cold per the plan's README §10 step 7); 50s grace covers cold boot without leaving headroom for an actually-stuck Lavalink. If anything, this could be tightened, but the current shape is conservative-correct, not over-engineered.
+
+#### `addopts = -m 'not integration'` + a separate `integration` marker — **keep**.
+Yes, there's only one integration test today. But (a) the marker is the canonical pytest mechanism for opt-in slow tests, (b) PR descriptions reference it (`pytest -q` in fast lane / `pytest -m integration` for the integration job), and (c) the alternative — a `pytest.skip` inside the test based on env var — moves the gate from configuration to runtime, which is the worse shape. The marker earns its keep with one user.
+
+#### `tmp_path_factory` + `shutil.copy` of `application.yml` into a tmpdir — **keep**.
+The fixture copies the repo's `application.yml` into a tmpdir before mounting. The comment ("the repo file may live under restricted parent dirs in some sandboxes") is real — pytest CI runners and containerized dev shells sometimes have non-traversable parents. Worth the 5 lines.
+
+#### Skipping when `FIXTURE` is missing — **keep**.
+Fixture file is committed (`silence.ogg`), so the skip is defensive. But it's two lines and is the difference between a clean skip and a `FileNotFoundError` from `shutil.copy`. Cheap insurance.
+
+#### No README/docs changes — **excellent, exactly right**.
+PR9 in the M1 plan explicitly defers all README work until after PR7 lands. PR4 ships zero doc changes — no preview README sections to drift, no `compose up` instructions that PR9 will rewrite. This is the discipline the plan asked for.
+
+---
+
+## Top 3 simplification wins
+
+1. **Drop `clients:` block in `application.yml` (S-1)** — 6 LOC, but the bigger win is *not pinning the bot to v1.18.0's default client list when upstream rotates them*. This is the single best signal-to-noise trim.
+2. **Drop `_load_with_retry` and use the readiness wait strategy directly (S-4)** — 14 LOC, removes a speculative retry loop that masks the failure mode it pretends to handle.
+3. **Collapse the chmod stanza (S-3) + drop the verbose source toggles (S-2)** — together ~10 LOC, and reduces "stuff that's there because the implementer wasn't sure" to "stuff that's there because it's needed."
+
+## Report
+
+**(a)** File saved at `/home/user/Projects/ryzic/docs/plans/PR4-simplify.md`.
+
+**(b)** Top 3: see above.
+
+**(c)** Total LOC the PR could lose: **~38–48 LOC** (S-1: 6, S-2: 6–7, S-3: 4–5, S-4: 14, S-5: 6, S-6: 5, S-7: 3, S-8: 2). No structural rewrites; all are local cuts that preserve PR4's surface contract (compose stack still boots, Dockerfile still produces the same runtime image, integration test still gates the same Lavalink ↔ local-file path).
+
+**Honest verdict:** PR4 is *mostly* tight. The Dockerfile, compose stack, healthcheck, CI split, and pytest marker setup are all earned. The cuts are real but small — clustered in `application.yml` (verbatim upstream defaults) and the integration test (over-engineered permissions handling for a one-test smoke check). No "delete a whole subsystem" win; this is polish, not rework.

--- a/docs/plans/PR5-review.md
+++ b/docs/plans/PR5-review.md
@@ -1,0 +1,139 @@
+# PR #5 Review — `feat(cache): playlist metadata cache (live-first with TTL fallback)`
+
+**Branch:** `feat/playlist-cache` → `main`
+**Scope per plan:** `docs/plans/M1.md` §5 (playlist metadata cache) + `M1-simplify.md` §3 (drop TTL env var) and §10 (module functions, no class). Implements PR4 per the §12 PR breakdown.
+**Diff:** 2 files changed, +564 / -0. `src/ryzic/playlist_cache.py` (+209), `tests/test_playlist_cache.py` (+355).
+**Local verification:** `uv run pytest tests/test_playlist_cache.py -v` → 42 passed in 0.13s. `uv run ruff check`, `ruff format --check`, `ty check` on the two new files all clean.
+
+---
+
+## Findings
+
+### MEDIUM-1 — `is_stale` re-reads the cache file synchronously inside an async call site
+
+- **Severity:** MEDIUM
+- **Where:** `src/ryzic/playlist_cache.py:145-166` (`is_stale`)
+- **Why it matters:** Per the plan §3 wording around the playlist embed, `is_stale` will be invoked from the `/play` command handler immediately after `fetch_with_fallback` returns. That handler is an `async def` running on the event loop. `is_stale` is `def` (not `async def`) and calls `_read_sync(path)` directly — so the event loop blocks for a `path.read_text(...)` + `json.loads(...)` round-trip on every `/play` of a playlist URL whose live fetch failed. Writes go through `asyncio.to_thread`; this is the only sync disk I/O in the module called from async land. `path.read_text` in particular touches the disk on the loop thread, which is what `asyncio.to_thread` exists to avoid.
+
+  There is also a **double-read** in the cache-fallback path: `read()` already pulled and parsed the same JSON file moments earlier, and `is_stale(returned_info, cache_root=...)` does it again. So the branch most likely to surface staleness pays for two reads.
+
+- **Fix (cheap, no API change):** make `is_stale` `async def` and route the disk hit through `asyncio.to_thread(_read_sync, path)`. While there, consider eliminating the double-read either by (a) caching `fetched_at` on the returned `PlaylistInfo` via a private sidecar field, or (b) returning `(info, fetched_at | None)` from `read()` so `fetch_with_fallback` can return the timestamp directly. Option (b) is the cleaner SRP play — the timestamp is cache-layer metadata, the dataclass stays clean, and `is_stale` collapses to a one-line `> _TTL_SECONDS` predicate against the timestamp the caller already has.
+
+  The PR description's argument for re-reading ("keep `PlaylistInfo` clean") is sound, but blocking the event loop is the wrong way to pay for it. If the second read is to stay, `await asyncio.to_thread(...)` is mandatory.
+
+---
+
+### LOW-1 — `_extract_playlist_id` only inspects the first `list=` query value; URLs with multiple `list=` params silently lose later ones
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/playlist_cache.py:169-179` (`_extract_playlist_id`)
+- **Why it matters:** `parse_qs` returns a list when a key repeats. `values[0]` takes the first; everything else is discarded. For a URL like `?list=../../etc&list=PLgoodgoodgood`, the first value fails the regex and the function returns `None`, which raises `FetchFailed` — the safer default. But the underlying behavior ("first wins, rest ignored") is undocumented and the test for the adversarial path (`test_fetch_with_fallback_reraises_when_list_param_invalid`) doesn't exercise the multi-value case. yt-dlp's own URL parser may pick a different `list=` value (typically the last one) when handed the same URL, so cache-key drift is theoretically possible if YouTube ever serves redirects with stacked `list=` params.
+- **Fix:** Either (a) document the "first `list=` wins" contract in the docstring, or (b) match yt-dlp's actual choice (usually `parsed.query`'s last `list=` for a duplicate key). A one-line test asserting current behavior locks the contract: `?list=BAD&list=PL_valid_______` returns `None` (i.e. fail-closed when ANY `list=` is bad).
+
+---
+
+### LOW-2 — No `relative_to(cache_root)` defense-in-depth on the derived path
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/playlist_cache.py:47-50` (`_path_for`)
+- **Why it matters:** Plan §4 (audio cache) prescribes regex-validate-then-`relative_to(cache_root).resolve()` as the path-safety pattern, and `ytdlp.download` (PR3a) implements the `relative_to` check in code. Plan §5 (this PR) doesn't make the second step explicit, but the same threat model applies. The regex `^[A-Za-z0-9_-]{10,50}$` is exhaustive enough that no in-band character can construct a traversal — `.`, `/`, NUL are all rejected — so the missing belt-and-suspenders check is theoretical. Still, if the regex ever loosens (e.g. someone widens it to allow `.` for a future YouTube format), there's no second wall. The audio-cache PR has the second wall by design.
+- **Fix:** Add a one-liner after path construction:
+  ```python
+  derived = cache_root / _PLAYLISTS_DIR / f"{playlist_id}.json"
+  derived.resolve().relative_to(cache_root.resolve())  # raises ValueError → wrap in InvalidVideoID
+  return derived
+  ```
+  Or accept the asymmetry and add a comment to `_path_for` noting "regex is exhaustive; no `relative_to` second wall is needed — change this if widening the charset". Either is fine; silence is the worst option because the next reviewer will wonder.
+
+---
+
+### LOW-3 — `InvalidVideoID` raised for `playlist_id` is lossy naming
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/playlist_cache.py:42-44, 138-139` and `src/ryzic/errors.py:13-14`
+- **Why it matters:** The exception class docstring says "A video ID failed character-set or path-safety validation." Reusing it for playlist-ID failures means any logged exception, debugger trace, or future caller `except InvalidVideoID:` handler can't tell which kind of input failed. The PR's own message strings disambiguate (`"playlist_id failed validation: ..."`, `"playlist_id mismatch: ..."`), but the type does not. `M1-simplify.md` §10 keeps a two-exception roster (`FetchFailed`, `InvalidVideoID`) deliberately, so this is a defensible reuse — but the class name lies about its scope.
+- **Fix (pick one):**
+  1. Rename the class to `InvalidIdentifier` (or `InvalidCacheKey`) and update the docstring + the one PR3a usage. Two-call-site rename, low blast radius. Keeps the two-exception roster.
+  2. Leave the class as-is and update its docstring to `"A cache-key identifier (video_id or playlist_id) failed character-set or path-safety validation."` Cheapest fix, preserves type hierarchy.
+
+  My recommendation: option 2 — the name is regrettable but cheap to live with at this stage; the comment fix removes the false advertising and leaves a refactor trail for later.
+
+---
+
+### LOW-4 — `is_stale` accepts a `PlaylistInfo` whose `playlist_id` may itself fail validation; the resulting `InvalidVideoID` is leaked
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/playlist_cache.py:156` (`_path_for(info.playlist_id, cache_root)`)
+- **Why it matters:** `is_stale` does not catch the `InvalidVideoID` that `_path_for` raises if `info.playlist_id` is malformed (e.g. a deserialization-skipped check, or a `PlaylistInfo` constructed by the caller for some other purpose). The other failure modes (missing file, bad JSON, missing `fetched_at`) are normalized to `return True` per the docstring's "safer default when staleness can't be proven fresh" promise, but a bad ID raises out — inconsistent with the rest of the function.
+
+  This is a thin edge in M1 (the only producers of `PlaylistInfo` are `resolve_playlist` and `_deserialize`, both of which validate); the test suite doesn't cover it. It will become a real footgun once a future caller hand-builds a `PlaylistInfo` for testing or a feature like "rename" lands.
+- **Fix:** Wrap the `_path_for` call in `try/except InvalidVideoID: return True`. One line, matches the documented contract. Add a parametrized test variant.
+
+---
+
+### LOW-5 — `_write_sync` tempfile is not cleaned up on partial failure (mid-write crash leaves `*.json.tmp`)
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/playlist_cache.py:97-107` (`_write_sync`)
+- **Why it matters:** If `tmp.write_text(...)` succeeds but `tmp.replace(path)` fails (rare — disk full mid-rename, EROFS toggling, etc.), or if the process is killed between them, the `*.json.tmp` file lingers in `playlists/`. There's no orphan sweep for the playlist cache (audio_cache has one in its design). On a cluttered cache dir, this creates eventual disk-leak noise. Failure modes are narrow and the file is small (kilobytes per playlist); not urgent. The audio-cache spec calls out the same risk and addresses it via startup orphan sweep.
+- **Fix:** Either (a) accept the leak (defensible — JSON files are small and the cache dir is bot-owned), or (b) add a `try/finally: tmp.unlink(missing_ok=True)` around the `replace` call. Option (b) is two lines and zero behavioral cost on the happy path; recommend it.
+
+---
+
+### NIT-1 — `read` and `is_stale` have overlapping responsibilities; the `fetched_at` round-trip is the symptom
+
+See MEDIUM-1's recommended fix (option b) — returning the timestamp from `read()` collapses the symmetry helper duplication and makes `is_stale` a synchronous predicate over data the caller already holds. This is the cleanest SRP outcome, but it changes the public API shape (`read` now returns `tuple[PlaylistInfo, int] | None` or similar). Defensible to defer to a follow-up if MEDIUM-1 is fixed via the simpler `asyncio.to_thread` route.
+
+---
+
+### NIT-2 — `_PLAYLISTS_DIR` constant is single-use; a `Final` string for one path segment is over-modeled
+
+- **Severity:** NIT
+- **Where:** `src/ryzic/playlist_cache.py:39`
+- **Why it matters:** The constant is referenced exactly once (in `_path_for`). Per `M1-simplify.md` §11's locality-of-reference principle, inlining `"playlists"` in the only place it's used is more readable than the indirection. Counter-argument: keeping it as a `Final` documents the on-disk layout in one place. Both are defensible; minor.
+- **Fix:** Either inline it, or add a one-line comment explaining why it's hoisted (e.g. "// Layout per M1 §4 storage diagram"). Drop-in at maintainer's discretion.
+
+---
+
+### NIT-3 — `_deserialize` accepts numerically-coerceable `duration_ms` strings (e.g. `"213000"`)
+
+- **Severity:** NIT
+- **Where:** `src/ryzic/playlist_cache.py:82` (`duration_ms=int(e["duration_ms"])`)
+- **Why it matters:** `int("213000")` succeeds; `int("213.0")` raises `ValueError` and is correctly caught. `str(...)` calls on the string fields (`video_id`, `url`, `title`, `uploader`) similarly tolerate non-string JSON values by stringifying them. Defense-in-depth against payload drift, but slightly more permissive than "exact JSON shape per spec". Not a security risk — payloads are bot-written. Document the latitude or tighten to `isinstance` checks; either is fine. The current behavior is the more useful one in practice (handles a yt-dlp version bump that flips a field type without crashing the cache).
+
+---
+
+### Validation summary against the brief's seven review prongs
+
+1. **Correctness vs plan §5** — Signatures match within the documented `is_stale` exception (kwarg `cache_root` for the disk-read rationale; PR description justifies the deviation). JSON shape includes the four spec'd fields plus `fetched_at`. Regex `^[A-Za-z0-9_-]{10,50}$` enforced before path join in `_path_for`. Path safety: regex is exhaustive; no `relative_to(cache_root)` second wall (LOW-2).
+2. **Lookup flow** — Live-first, write on success, read on `FetchFailed`, return regardless of TTL. Confirmed in `fetch_with_fallback` and locked in by `test_fetch_with_fallback_returns_stale_cache_unconditionally`. `is_stale` is decoupled from the fallback decision — correct per spec.
+3. **Module functions only, no class** — Confirmed. Five public surfaces (`read`, `write`, `is_stale`, `fetch_with_fallback`, plus the implicit `PlaylistInfo` re-export via direct import). No class.
+4. **`InvalidVideoID` reuse** — Defensible per the simplify decision (LOW-3); name lies about scope; cheap docstring fix.
+5. **Atomic write** — Earned. Two `/play` calls for the same playlist URL while a download is in progress (rare but possible) would race a non-atomic `write_text`. The cost is one tempfile + one rename — trivial. Correct call.
+6. **Tests** — All six brief-requested cases covered:
+   - Round-trip (incl. unicode): `test_round_trip_preserves_playlist`, `test_round_trip_preserves_unicode`.
+   - Regex rejection: `test_validate_rejects_invalid_on_{read,write}` parametrized.
+   - Fallback flow when yt-dlp raises: `test_fetch_with_fallback_uses_cache_on_yt_dlp_failure`, `test_fetch_with_fallback_reraises_when_no_cache`, `test_fetch_with_fallback_returns_stale_cache_unconditionally`.
+   - `is_stale` boundary: `test_is_stale_just_under_24h_is_fresh`, `test_is_stale_exactly_24h_is_fresh`, `test_is_stale_just_over_24h_is_stale`.
+   - Malformed JSON: `test_read_malformed_returns_none`, `test_read_structurally_invalid_returns_none`.
+   - Plus path-traversal defense: `test_traversal_id_does_not_create_file_outside_cache`.
+   - Plus non-`FetchFailed` propagation: `test_fetch_with_fallback_propagates_unexpected_exceptions`.
+   Coverage is high — no obvious untested branches except the LOW-4 case (bad `playlist_id` on `is_stale`).
+7. **Comments** — Module docstring and function docstrings explain WHY (especially the `is_stale` deviation, `fetch_with_fallback`'s "unsinkable" rationale, the atomic-write contract). One narrative comment at line 31-34 (the `_PLAYLIST_ID_RE` constant) does narrate WHY (path-safety motivation) — appropriate. No WHAT-narration comments spotted.
+
+### Watchlist (out of scope but worth tracking)
+
+- **W1 — sync I/O in async modules.** The `is_stale` precedent (MEDIUM-1) is the only sync disk-touch in this module. As `audio_cache.py` lands, watch for the same anti-pattern in any predicate-shaped helper.
+- **W2 — Two-exception roster strain.** This PR is the second consumer of `InvalidVideoID` for non-video-id semantics. If `audio_cache.py` adds a third (e.g. for cache-key validation on a non-video artifact), it's time to widen the name (LOW-3 option 1).
+- **W3 — Playlist-cache orphan sweep.** None today. If `*.json.tmp` files start accumulating under `playlists/` in production, retroactively add a startup sweep mirroring audio_cache's orphan-clear logic.
+- **W4 — `is_stale` boundary on system clock skew.** Strict `>` over a wall-clock subtraction is correct per spec wording, but if the host clock jumps backward (NTP correction), a freshly-written cache can read as stale. Acceptable for "embed warning" semantics; if `is_stale` ever gates the fallback decision, revisit.
+
+---
+
+## Verdict
+
+**Minor revisions.**
+
+One real blocker (MEDIUM-1: `is_stale` blocks the event loop on a sync `read_text` from an async call path) plus a handful of polish items (LOW-1 through LOW-5). The MEDIUM is a straightforward `async def` + `asyncio.to_thread` change — five-line fix, no API impact. The plan-conformance, test coverage, and security posture are otherwise solid; the deviations from plan §5 (kwarg on `is_stale`, atomic write, fetch_with_fallback wrapper) are all earned and well-defended in the PR description.
+
+Recommend: fix MEDIUM-1, accept LOW-2 with a docstring note (or implement the one-liner), apply LOW-3 docstring fix, defer LOW-1/LOW-4/LOW-5 to follow-ups (or batch them in if the implementer wants the full sweep). Then ship.

--- a/docs/plans/PR5-security-review.md
+++ b/docs/plans/PR5-security-review.md
@@ -1,0 +1,169 @@
+# PR #5 — Security Review
+
+**PR**: `feat(cache): playlist metadata cache (live-first with TTL fallback)`
+**Branch**: `feat/playlist-cache` → `main`
+**Repo**: `VeryLongOrgNameSuchWow/ryzic`
+**Commit reviewed**: `1980b4a`
+**Files in scope** (PR diff only):
+- `src/ryzic/playlist_cache.py` (new, 209 lines)
+- `tests/test_playlist_cache.py` (new, 355 lines)
+
+No dependency or build-system changes (`pyproject.toml`/`uv.lock` unchanged from PR2).
+
+This review covers the nine focus areas from the brief: `playlist_id` regex robustness, path safety, JSON read trust boundary, atomic-write file mode, `fetch_with_fallback` error leakage, log content, `_deserialize` round-trip type safety, test isolation, and dependency surface.
+
+The 42 tests in `tests/test_playlist_cache.py` all pass under `uv run pytest -q`.
+
+---
+
+## Findings
+
+### 1. `_PLAYLIST_ID_RE` allows trailing newline → cache poisoning + log injection
+
+**Severity**: HIGH
+**What**: The regex `^[A-Za-z0-9_-]{10,50}$` is matched against the playlist id with no `re.MULTILINE` flag, but Python's default `$` *also* matches the position immediately before a final `\n`. So `"PLabcdefghi\n"` (12 chars including a trailing newline) passes `_validate_playlist_id`, and `_path_for` then composes `cache_root/playlists/PLabcdefghi\n.json` — a different filename from the canonical `PLabcdefghi.json`.
+
+End-to-end exploitability via a Discord-supplied URL (verified with a POC against the unmodified branch):
+
+1. Attacker sends `/play https://www.youtube.com/playlist?list=PLabcdefghi%0a` (URL-encoded `%0a` = `\n`).
+2. `_extract_playlist_id` calls `parse_qs`, which percent-decodes `%0a` to a literal `\n`, yielding the candidate `"PLabcdefghi\n"`.
+3. `_PLAYLIST_ID_RE.match(candidate)` returns a match (the regex pitfall above), so the candidate is returned.
+4. If yt-dlp's `resolve_playlist` ever fails for this URL, `read("PLabcdefghi\n", cache_root)` is called → `_path_for` validates the regex (passes), then composes `cache_root/playlists/PLabcdefghi\n.json`.
+5. An attacker who has previously seeded that cache file (via the same trick on a successful live fetch — yt-dlp would presumably return `playlist_id="PLabcdefghi"` (without newline) so the cache write goes to the canonical filename, but the read on the newline variant would return `None`. **Not a write-side cache poison via yt-dlp.**)
+
+The actual attack surface, then, is narrower than first appears, but still real:
+
+   - **Cache namespace pollution / collision**: `read("PLabcdefghi\n", ...)` and `read("PLabcdefghi", ...)` resolve to **different files** despite being the same logical playlist. After PR6 wires `/play` up, two URLs that differ only by `%0a` will be served from different cache entries with no operator visibility into why.
+   - **Log injection** (LOW on its own, but enabled by this same root cause): `_log.warning("yt-dlp failed for playlist %s; serving cached metadata: %s", playlist_id, exc)` interpolates the unsanitized `playlist_id` (which now contains `\n`) directly into the log line. POC log output (line break is real, copied verbatim from a run):
+     ```
+     yt-dlp failed for playlist PLabcdefghi
+     ; serving cached metadata: yt-dlp down
+     ```
+     A determined attacker could include `\n` plus a forged second-line prefix to make log scrapers see fabricated ERROR entries from other modules.
+   - **Filesystem garbage**: writes via `write()` directly (e.g. when yt-dlp echoes back a malformed id, however unlikely) would create on-disk filenames containing control characters. Annoying for ops, harmless to security.
+
+The same bug also accepts `\r` only at end-of-string? No — `\r` is not in the special-case list; only `\n` is. Confirmed by `re.match(r"^abc$", "abc\r")` returning `None`.
+
+**Where**: `src/ryzic/playlist_cache.py:32` (`_PLAYLIST_ID_RE`). Affects every callsite: `read`, `write`, `is_stale`, `_extract_playlist_id`, plus the test invariant in `test_validate_rejects_invalid_on_read` / `test_validate_rejects_invalid_on_write` (which lacks a `\n`-suffix case and so doesn't catch this).
+
+**Why it matters**: This regex is the entire trust boundary for everything path- and log-related in this module. It's also the exact concern called out in the brief ("regex enforced BEFORE any path join? Edge cases: empty, leading dot, `..`, traversal attempts (`%2e%2e`, unicode normalization)?"). The path-traversal cases the dev tested for (`../`, `%2e%2e`, `\x00`) all fail the regex correctly because the offending chars are outside the charset; `\n` slips through because of Python's quirky default-mode `$`. There's no `path.relative_to(cache_root)` second-wall check anywhere in the module to catch a regex regression.
+
+**Fix**:
+- **Preferred**: change the validator to `_PLAYLIST_ID_RE.fullmatch(playlist_id)` (one-word change in `_validate_playlist_id` AND in `_extract_playlist_id`'s ternary). `fullmatch` requires the regex to match the entire string and is immune to the trailing-`\n` quirk.
+- **Or**: change the regex to `r"\A[A-Za-z0-9_-]{10,50}\Z"` (raw `\A` and `\Z` anchors are absolute, unlike `^` and `$`).
+- **Defense-in-depth**: add `path.resolve().relative_to(cache_root.resolve())` inside `_path_for` (or a standalone helper) so a future regex regression cannot escape the cache directory.
+- **Test coverage**: add `"PLabcdefghi\n"`, `"PLabcdefghi\r\n"`, `"\nPLabcdefghi"` (already rejected — newline at front is blocked by `^`) to the `test_validate_rejects_invalid_on_*` parametrize lists. Also add a parametrized URL test for `?list=PLabcdefghi%0a` going through `fetch_with_fallback`.
+
+---
+
+### 2. JSON cache file has no size cap; `path.read_text()` reads entire file into memory
+
+**Severity**: LOW (different threat model)
+**What**: `_read_sync` calls `path.read_text(encoding="utf-8")` followed by `json.loads(text)`. Neither has a size cap. A 1 GB cache file would consume 1 GB of RSS while being parsed.
+**Where**: `src/ryzic/playlist_cache.py:88-92` (`_read_sync`).
+**Why it matters**: Not exploitable from a Discord URL — the only writer of cache files is the bot itself, and the writer is bounded by yt-dlp's `playlist_items="1-1000"` cap (per PR2). A 1000-track flat playlist serializes to roughly 200 KB. The risk is a co-resident or post-compromise attacker filling cache files with junk to degrade the bot. PR2's review item #8 already documents that the cache directory's deploy-time permissions (0o700, bot-owned) are the mitigation here — extending that to "the bot trusts the contents of files it can write" is consistent.
+**Fix** (optional defensive): cap `_read_sync` at e.g. 5 MB by `path.stat().st_size > 5 * 1024 * 1024` early-return + log warning. The dev cost is small; the operational benefit is marginal but real for forensic clarity. I'd defer this to the M2 audio-cache PR which faces the same issue.
+
+---
+
+### 3. `_deserialize` `int()` cast on `duration_ms` is bounded, but other casts have no overflow protection
+
+**Severity**: LOW
+**What**: `_deserialize` constructs each `TrackInfo` with `int(e["duration_ms"])`. This call delegates to Python's built-in `int()`, which since Python 3.11 enforces a 4300-digit limit on string→int conversion (raises `ValueError`). The brief asks whether `duration_ms` is validated as an int rather than something that explodes later — it is, and `_deserialize` correctly catches `ValueError` and treats the file as malformed (`read()` returns `None`).
+
+I verified the limit: `int("9" * 1_000_000)` raises `ValueError: Exceeds the limit (4300 digits)...` — and `_deserialize`'s try/except in `read()` catches it. Round-trip with 100 000 entries deserializes in ~50 ms, well below any DoS threshold.
+
+The `str(...)` casts on `video_id`, `url`, `title`, `uploader` are unbounded but stringifying any JSON value is bounded by file size (#2). No structural mismatch can cause a crash later in the pipeline because the dataclass is frozen and downstream consumers (per the brief, future PRs) will treat its fields as opaque strings.
+
+**Where**: `src/ryzic/playlist_cache.py:62-86`.
+**Verdict**: clean for the spec'd threat model. **No fix required.**
+
+---
+
+### 4. Atomic write uses default umask; tempfile name is predictable
+
+**Severity**: LOW
+**What**: `_write_sync` calls `path.parent.mkdir(parents=True, exist_ok=True)` then `tmp.write_text(...)` then `tmp.replace(path)`. Both `mkdir` and `write_text` honor the process umask. With a typical Linux umask of `0o022`:
+
+- `playlists/` directory: `0o755` (world-traversable)
+- `<id>.json.tmp` and `<id>.json`: `0o644` (world-readable)
+
+Empirically verified.
+
+For a self-hosted bot in a container with `cache_root` owned 0o700 by the bot UID, the inherited 0o755/0o644 modes are masked by the parent's mode bits — nothing leaks. But if `cache_root` were ever 0o755 (e.g. a misconfigured bind mount), the per-file 0o644 means anyone in the host filesystem can read playlist titles and uploader names. Low signal value, but worth noting.
+
+The tempfile name `<id>.json.tmp` is **fully predictable**. A co-resident attacker with write access to `cache_root/playlists/` could `mkfifo cache_root/playlists/PLabcdefghi.json.tmp` or symlink it to `/path/the/bot/can/write/but/shouldnt`. The bot's `tmp.write_text(...)` would either block (FIFO) or follow the symlink and clobber the target. This is the same threat model as PR2 §8 — assumes a co-resident attacker with cache write permission, which the deployment doc must rule out via 0o700 ownership.
+
+**Where**: `src/ryzic/playlist_cache.py:95-104`.
+**Why it matters**: Defense-in-depth; not exploitable from a Discord URL.
+**Fix** (optional): use `tempfile.NamedTemporaryFile(dir=path.parent, delete=False, prefix=f"{path.name}.", suffix=".tmp")` to randomize the tempfile suffix; close + `os.replace` to the final path. This eliminates the predictable-name TOCTOU. Per-file mode (0o600 instead of umask-default) can be set with `os.fchmod(f.fileno(), 0o600)` before close. Worth bundling into a generic `atomic_write` helper if/when the audio-cache PR lands the same primitive.
+
+---
+
+### 5. `fetch_with_fallback` re-raises `FetchFailed` from the wrapper — already scrubbed by PR2
+
+**Severity**: (informational — no finding)
+**What**: When `resolve_playlist` raises `FetchFailed`, `fetch_with_fallback` may re-raise it unchanged (no cache hit) or log+swallow (cache hit). Both paths preserve the original exception object via `raise` (no rebinding). The exception's `args[0]` was constructed by the PR2 wrapper, which already runs every yt-dlp error through `_scrub` (strips backticks, masks absolute paths, caps at 200 chars) before wrapping in `FetchFailed`.
+
+I traced the flow: `_extract` → `except YoutubeDLError as exc` → `scrubbed = _scrub(detail)` → `friendly = ... f"yt-dlp said: \`{scrubbed}\`"` → `raise FetchFailed(friendly) from exc`. The internal-exception path (`except Exception`) wraps as `FetchFailed(f"internal error: {exc.__class__.__name__}")` — class name only, no message text.
+
+So the cached-fallback log line `_log.warning("...serving cached metadata: %s", playlist_id, exc)` cannot leak unsanitized yt-dlp internals. The downstream `/play` embed (future PR) will need to keep treating `FetchFailed.args[0]` as already-clean (PR2's posture) or re-scrub at the embed boundary — but that's not a PR5 concern.
+
+**Where**: `src/ryzic/playlist_cache.py:193-207`; relies on `src/ryzic/ytdlp.py:200-218`.
+**Verdict**: clean.
+
+---
+
+### 6. Log content includes raw `playlist_id` (subject to finding #1)
+
+**Severity**: LOW (rolled into HIGH-1)
+**What**: Three `_log.warning` calls embed `playlist_id` or `path` (which contains `playlist_id`) directly into the log line. With the regex hardened per finding #1, all of these will only ever see `[A-Za-z0-9_-]{10,50}` — perfectly safe. Without the fix, the trailing-`\n` log-injection demonstrated in #1 applies. No additional fix needed beyond #1.
+**Where**: `src/ryzic/playlist_cache.py:120, 127, 202`.
+
+---
+
+### 7. Symlink at `cache_root/playlists/` is followed (out-of-scope ops concern)
+
+**Severity**: LOW (different threat model, inherited from PR2 §8)
+**What**: `_write_sync` calls `path.parent.mkdir(parents=True, exist_ok=True)` — if `playlists/` already exists as a symlink to e.g. `/etc/`, the bot will `mkdir` the (already-existing) target and write JSON files into it. `_read_sync` and `is_stale` follow the symlink chain too.
+**Where**: `src/ryzic/playlist_cache.py:97`.
+**Why it matters**: Requires a co-resident attacker who can pre-create the symlink before the bot's first `write()`. PR2's §8 covers the same class of issue for the audio cache; the mitigation is the same — `cache_root` permissions 0o700 owned by the bot's UID.
+**Fix** (defer): when a generic atomic-write helper lands, also assert `path.parent.is_symlink()` is False, or use `O_NOFOLLOW` opens. Not blocking.
+
+---
+
+### 8. Tests are network-isolated and tmp_path-only
+
+**Severity**: (informational — no finding)
+**What**: `tests/test_playlist_cache.py` imports only stdlib + `pytest` + the project's own modules. No `requests`, `httpx`, `urllib.request`, or `socket` imports. The yt-dlp call is mocked via `unittest.mock.patch.object(playlist_cache, "resolve_playlist", ...)` in every fallback test. All disk usage flows through the `tmp_path` fixture (pytest-managed, auto-cleaned). The `_write_with_fetched_at` helper writes only under `tmp_path`. The `test_traversal_id_does_not_create_file_outside_cache` test goes one step further and asserts no leakage into `tmp_path.parent`.
+**Verdict**: clean.
+
+---
+
+### 9. Dependency surface — no changes from PR2
+
+**Severity**: (informational — no finding)
+**What**: `git diff main..feat/playlist-cache -- pyproject.toml uv.lock` is empty. The new module imports only from stdlib (`asyncio`, `json`, `logging`, `re`, `time`, `dataclasses`, `pathlib`, `typing`, `urllib.parse`) and the project's own `errors` and `ytdlp` modules.
+**Verdict**: clean.
+
+---
+
+## Summary
+
+| Severity | Count |
+| --- | ---: |
+| HIGH (merge-blocking) | **1** |
+| MEDIUM (fix soon) | 0 |
+| LOW (nit / defense-in-depth) | 5 |
+
+The HIGH is **#1** — the `^...$` vs. `\n` regex pitfall, exploitable end-to-end from a Discord-supplied URL via `%0a`-encoded list parameter, leading to cache namespace pollution and log injection. The fix is a one-character change (`match` → `fullmatch`, used in two spots) plus tests. Low cost, high payoff, and matches the spec's intent of "validation BEFORE any path join."
+
+The LOWs are: cache-file size cap (#2), atomic-write umask + predictable tempfile name (#4), log injection (#6 — duplicate of #1), and symlink follow on `playlists/` (#7). All four are defense-in-depth; none are exploitable from a Discord URL given the current call surface; #4 and #7 echo PR2's review and should be bundled into a future shared `atomic_write` helper (likely M2's audio cache).
+
+The brief's other primary concerns — `_deserialize` int-cast safety (#3), error-message leakage from yt-dlp via `fetch_with_fallback` (#5), test isolation (#8), and dependency drift (#9) — are all clean.
+
+## Verdict
+
+**fixes recommended**
+
+Not strictly merge-blocking on its own (the cache poisoning has no live consumer until PR6 wires `/play`), but the fix for #1 is so cheap and so structurally important that it should land in this PR rather than as a follow-up. Treat #1 as a hard "fix before merge" and the LOWs as polish — most are best addressed when the matching primitives are needed for the audio cache.

--- a/docs/plans/PR5-simplify.md
+++ b/docs/plans/PR5-simplify.md
@@ -1,0 +1,391 @@
+# PR #5 Simplification Pass — `feat(cache): playlist metadata cache`
+
+**Branch:** `feat/playlist-cache` -> `main`
+**Diff reviewed:** +564 LOC across 2 files (`src/ryzic/playlist_cache.py` 209 LOC, `tests/test_playlist_cache.py` 355 LOC).
+**Companion docs:** `docs/plans/M1-simplify.md` (locked plan-level cuts), `docs/plans/M1.md` §5 (PR4 spec — PR5 implements the same), prior `PR3-simplify.md` / `PR4-simplify.md` for tone calibration.
+
+This pass looks only for shapes that are more elaborate than M1 §5 justifies. It does **not** re-litigate decisions in `M1-simplify.md` (24h hardcoded TTL, no env var, module functions instead of class, no sidecars). It does not critique correctness or security — those are other agents' lanes.
+
+Honest framing: PR5 has a real bloat axis the brief correctly identified — the `is_stale` second-read and the test-side `_write_with_fetched_at` helper that hand-rolls a parallel serializer. Several smaller WHAT-narrating comments and three almost-identical boundary tests round it out. Realistic floor: **~35–55 LOC of source + ~25–35 LOC of tests**, ~12% of the PR. Nothing structural; no surface contract changes.
+
+---
+
+## Findings
+
+### S-1 — Return `(info, fetched_at)` from `read()`; let `is_stale` take a timestamp
+
+**What to cut/collapse:** `is_stale(info, *, cache_root)` does its own disk read just to recover `fetched_at`. The caller (`fetch_with_fallback` cache-hit branch + `/play`'s embed builder) has *already* called `read()` to get the `info` — two reads per fallback path, of which the second exists only because `fetched_at` got dropped on deserialization.
+
+Reshape `read()` to return both: `tuple[PlaylistInfo, int] | None` (or a tiny `CachedPlaylist` NamedTuple if the call sites read better with a name). Reshape `is_stale` to a 1-line function that takes the timestamp directly:
+
+```python
+async def read(playlist_id: str, cache_root: Path) -> tuple[PlaylistInfo, int] | None: ...
+
+def is_stale(fetched_at: int) -> bool:
+    return (time.time() - fetched_at) > _TTL_SECONDS
+```
+
+`fetch_with_fallback`'s cache branch becomes:
+```python
+cached = await read(playlist_id, cache_root)
+if cached is None:
+    raise
+info, fetched_at = cached
+...
+return info, fetched_at, True   # or change tuple shape; see S-2
+```
+
+**Where:** `src/ryzic/playlist_cache.py` lines 110–128 (`read`), 142–164 (`is_stale`); ripples into `fetch_with_fallback` (lines 188–209) and the `is_stale_*` tests (lines 209–247).
+
+**Why safe:** Today the on-disk state IS the source of truth — `is_stale` reads it back precisely because it doesn't trust the in-memory `info`. But once `read()` has returned, the on-disk `fetched_at` is *frozen* relative to that snapshot — a concurrent overwrite would yield a strictly newer timestamp, which can only flip a "stale" answer to "fresh" (and the embed warning is the conservative side anyway). Passing the value the caller already paid I/O to read eliminates the second I/O without changing the behavior the embed sees. The brief's framing — "the kwarg requires a disk read" — is exactly the right diagnosis: the kwarg exists *because* the function fundamentally wants the timestamp, and the dance to recover it is the smell.
+
+This is the single biggest signal-to-noise win in the PR. It also shrinks the `is_stale` docstring (the "missing file → stale" branch and the docstring's whole "we don't store fetched_at on the dataclass because that would leak the cache concern" paragraph both go away — once the timestamp travels alongside the info as a tuple, neither concern applies). The `is_stale_missing_*` tests become unreachable by construction (you can't ask "is this stale" without having read first), so they go away too.
+
+**Estimated LOC saved:** ~15 LOC src (`is_stale` body shrinks from ~22 to ~2 lines, the second `_read_sync` call disappears, the `_PLAYLISTS_DIR`-derived path computation in `is_stale` disappears) + ~25 LOC tests (the two `is_stale_missing_*` tests + the per-boundary `_write_with_fetched_at` setup gets collapsed — see S-7).
+
+---
+
+### S-2 — Tuple `(info, used_cache)` is fine; do **not** introduce a `FetchResult` dataclass
+
+**What to cut/collapse:** Nothing. Considered: replacing `tuple[PlaylistInfo, bool]` with a `@dataclass FetchResult(info: PlaylistInfo, is_fallback: bool)` (or NamedTuple) for self-documenting call sites.
+
+**Why I'm not recommending it:** The brief asks "could it return one type with an `is_fallback` field?" — the honest answer is yes-but-don't. The tuple has exactly one consumer (`/play` in PR6a) and two cardinality, returned at the end of one function. A 2-tuple destructured as `info, used_cache = await fetch_with_fallback(...)` is the canonical Python shape; a `FetchResult` adds a class import to the call site and a `result.info`/`result.is_fallback` ceremony for negative wins. Per "three similar lines vs premature abstraction" — there isn't even one similar line here.
+
+If S-1 lands, the natural shape becomes `tuple[PlaylistInfo, int, bool]` (info, fetched_at, used_cache_fallback) — at three elements I'd reconsider, but a 1-line NamedTuple `class CachedPlaylist(NamedTuple): info; fetched_at: int; used_fallback: bool` is the right answer there, NOT a dataclass. Defer to PR6a where the call site shape is observable.
+
+**Estimated LOC saved:** 0. **Recommend skipping.** Tuple is appropriately minimal for its current cardinality and consumer count.
+
+---
+
+### S-3 — Atomic write via tempfile + `os.replace` — keep, but trim the docstring
+
+**What to cut/collapse:** The atomic-replace machinery itself (lines 96–106) is ~10 lines and earned: one playlist cache file is read by `read()` concurrently with a `write()` for the same playlist (a `/play` retry while the previous fetch's writeback is in flight is a real race even on a single bot instance). `os.replace` is the stdlib idiom; no simpler shape gets the same property.
+
+But the 4-line docstring (lines 98–102) narrates **what** the next 3 lines do (`mkdir`, write to tmp, replace) rather than **why** the atomicity matters in this codebase. Trim to:
+
+```python
+def _write_sync(path: Path, payload: dict[str, Any]) -> None:
+    # Atomic replace: a concurrent reader sees either the prior version
+    # or the new one, never a half-written file.
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.tmp")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    tmp.replace(path)
+```
+
+**Where:** `src/ryzic/playlist_cache.py` lines 97–102.
+
+**Why safe:** Convert the docstring (formal API doc on a `_private` helper with one caller) to a comment that names the WHY in one sentence. The mechanics are stdlib-canonical and self-evident; the WHY (why bother for a per-playlist file) is the only part that needs words.
+
+**Estimated LOC saved:** ~3 LOC.
+
+---
+
+### S-4 — `_serialize` / `_deserialize` symmetry — keep; **do not** swap to Pydantic
+
+**What to cut/collapse:** Nothing. Considered the brief's framing: "could `model_dump_json` / `model_validate_json` cover it?"
+
+**Why I'm not recommending it:** Pydantic isn't a project dependency (M1 §1 lists only `aiosqlite` as new) and adding it to satisfy two helpers is a bad trade — Pydantic on the dependency floor pulls in 8MB and a transitive surface that nothing else in the bot uses. The dataclasses in `ytdlp.py` are intentionally thin (`@dataclass(frozen=True)` mirroring yt-dlp's shape — `M1-simplify.md` §10).
+
+What about `dataclasses.asdict` + a `**dict` constructor for symmetry? `_serialize` already uses `asdict` — that side IS one-liner-clean. The asymmetry is on `_deserialize` because it needs structural validation: a malformed cache file must NOT crash the bot, and a naïve `PlaylistInfo(**payload)` would `TypeError`-storm on missing/wrong-typed keys. The current shape — explicit `isinstance` checks + per-field `str()`/`int()` coercion — is the validation, not boilerplate. The bot has zero schema-validation library on the dep floor; rolling 15 lines of structural checks is the right size.
+
+A small WIN: `_serialize` is currently 7 lines including the wrapper dict — it could collapse to:
+```python
+def _serialize(info: PlaylistInfo, fetched_at: int) -> dict[str, Any]:
+    return {**asdict(info), "fetched_at": fetched_at}
+```
+…**but** that drops the explicit ordering of keys (currently `playlist_id`, `title`, `fetched_at`, `entries`) and means the on-disk file shape becomes implicitly tied to `PlaylistInfo`'s field order. The current explicit construction is more robust to dataclass-field reordering. Net: leave it, **0 LOC saved**.
+
+**Where:** `src/ryzic/playlist_cache.py` lines 53–86.
+
+**Estimated LOC saved:** 0. **Recommend skipping.**
+
+---
+
+### S-5 — Defensive read: collapse one of two warning sites; keep the four exception classes
+
+**What to cut/collapse:** The brief asks: "All four branches earned?" Looking at `read()` lines 110–128, the actual handling is a tree:
+
+```python
+try:
+    payload = await asyncio.to_thread(_read_sync, path)
+except (json.JSONDecodeError, OSError, UnicodeDecodeError):     # ← branch A
+    _log.warning("dropping unreadable playlist cache entry: %s", path)
+    return None
+if payload is None:                                              # ← branch B (file not found)
+    return None
+try:
+    return _deserialize(payload)
+except (ValueError, KeyError, TypeError):                        # ← branch C
+    _log.warning("dropping malformed playlist cache entry: %s", path)
+    return None
+```
+
+Three branches, not four — and all three are earned for distinct reasons:
+- **A** catches "file exists but is corrupted on disk" (truncated, bit-flipped, foreign-encoding, FS-level error).
+- **B** is the common case (cache miss), silent + no log.
+- **C** catches "JSON parsed but doesn't match our schema" (older code wrote a different shape, or the file was hand-edited).
+
+A and C BOTH log "dropping … cache entry" with the same path. The **diagnostic difference** between "unreadable" and "malformed" is real — one means "FS or encoding broke," the other means "schema drifted." Worth keeping as separate log lines. **Don't collapse.**
+
+The one tiny cleanup: the `_read_sync` helper currently catches only `FileNotFoundError` and lets `OSError`/`json.JSONDecodeError`/`UnicodeDecodeError` propagate to its async caller. That's fine — `_read_sync` is pure I/O, its caller is the policy layer. Leave it.
+
+The smell, if any, is the exception list `(json.JSONDecodeError, OSError, UnicodeDecodeError)` — `json.JSONDecodeError` IS a `ValueError`, and `UnicodeDecodeError` IS a subclass of `ValueError`. So the exception tuple could shorten to `(ValueError, OSError)` and catch the same set. But: **explicit-by-name is more grep-able**. A future contributor reading `except (ValueError, OSError)` has to remember which `ValueError` subclasses come from where; the current spelling tells the story at the point of catch. Net: leave it, **0 LOC saved**.
+
+**Where:** `src/ryzic/playlist_cache.py` lines 110–128.
+
+**Estimated LOC saved:** 0. **Recommend skipping.** The branches earn their keep; the redundant log site reads as defense-in-depth, and explicit exception names are friendlier than the deduped form.
+
+---
+
+### S-6 — Trim WHAT-narrating comments and over-formal docstrings
+
+**What to cut/collapse:** Several comments and docstrings narrate WHAT the next line does or restate the type signature:
+
+- **Module docstring lines 1–12** (12 lines): the second paragraph ("The cache exists for one job: keep `/play <playlist_url>` working when yt-dlp breaks") and the TTL paragraph (lines 10–11) carry real WHY and stay. The first sentence ("Stores resolved PlaylistInfo snapshots as JSON files under …") narrates the type signature visible 30 lines below. Could trim to ~6 lines but that's bikeshed-territory; **leave it** — module docstrings are the right place for context.
+
+- **`_path_for` line 47** docstring "Return the JSON path for `playlist_id` after validating the id." narrates the function name + the next two lines. Cut.
+
+- **`_serialize` lines 53–60** has no docstring (good).
+
+- **`_deserialize` lines 63–69** docstring's first sentence is intent. The `Raises:` paragraph narrates WHAT the next 15 lines visibly do. Cut the Raises paragraph; the caller catches them by name and the helper's `_private` underscore signals it's internal.
+
+- **`_PLAYLIST_ID_RE` comment lines 32–35** — 4 lines of WHY (charset bound, path-safety contract). **Keep.** Real load-bearing intent.
+
+- **`is_stale` docstring lines 142–151** — once S-1 lands, this whole docstring goes away (`is_stale(fetched_at: int) -> bool` is self-documenting). If S-1 is rejected: the "Reads `fetched_at` from disk so the function works on a freshly deserialized PlaylistInfo without storing the timestamp on the dataclass" paragraph is real WHY. The "missing file → stale" paragraph narrates a defensive default — keep that one line.
+
+- **`fetch_with_fallback` docstring lines 195–204** — both paragraphs are real WHY (`used_cache_fallback` consumer, "unsinkable" floor). **Keep.**
+
+- **`write()` docstring lines 132–137** — the WHY about the playlist_id mismatch IS real (silent breakage of next read). **Keep.**
+
+- **`_extract_playlist_id` line 178** — one-liner docstring restates the function name. Cut.
+
+**Where:** `src/ryzic/playlist_cache.py` lines 47, 63–69 (Raises paragraph), 142–151 (collapsed by S-1), 178.
+
+**Why safe:** Docstrings on private helpers narrating their bodies are noise; the helpers' names + 5-line bodies tell the story at the point of call. WHY-comments stay; WHAT-restatement goes.
+
+**Estimated LOC saved:** ~6 LOC (4 docstring lines + the `Raises:` paragraph + a couple of redundant one-liner docstrings).
+
+---
+
+### S-7 — Test boundary trio → one parameterized test; drop the `_write_with_fetched_at` shadow serializer
+
+**What to cut/collapse:** Three separate test functions probe the same `is_stale` function at the 24h boundary (lines 209–232):
+
+- `test_is_stale_just_under_24h_is_fresh` (`fetched_at = now - (24h - 1)` → `False`)
+- `test_is_stale_exactly_24h_is_fresh` (`fetched_at = now - 24h` → `False`)
+- `test_is_stale_just_over_24h_is_stale` (`fetched_at = now - (24h + 1)` → `True`)
+
+Each is 7 lines of identical setup + 1-line assertion delta. Standard pytest parameterization:
+
+```python
+@pytest.mark.parametrize(
+    ("offset_seconds", "expected_stale"),
+    [
+        (24 * 60 * 60 - 1, False),  # 23h59m59s
+        (24 * 60 * 60,     False),  # exactly 24h (boundary is strict >)
+        (24 * 60 * 60 + 1, True),   # 24h00m01s
+    ],
+)
+def test_is_stale_boundary(tmp_path, offset_seconds, expected_stale):
+    now = 1_700_000_000
+    info = _write_with_fetched_at(tmp_path, now - offset_seconds)
+    with patch.object(playlist_cache.time, "time", return_value=now):
+        assert playlist_cache.is_stale(info, cache_root=tmp_path) is expected_stale
+```
+
+(If S-1 lands, this test mostly evaporates — the boundary check becomes a 4-line pure-function test with no `tmp_path` and no `_write_with_fetched_at` machinery at all.)
+
+The `_write_with_fetched_at` helper itself (lines 186–207) is 22 lines that **hand-rolls a second copy of `_serialize`** — every field listed by hand, again, with the same shape constraint. If S-1 lands, this helper goes away. If S-1 is rejected, the helper could lean on the production serializer:
+
+```python
+def _write_with_fetched_at(tmp_path: Path, fetched_at: int) -> PlaylistInfo:
+    info = _playlist()
+    payload = playlist_cache._serialize(info, fetched_at=fetched_at)
+    path = tmp_path / "playlists" / f"{info.playlist_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return info
+```
+
+(Reaches into a `_private` helper from tests, which is a code smell — but the smell is the *symptom* of needing to override `fetched_at`, which is itself the smell S-1 fixes. The cleanest endgame is S-1.)
+
+**Where:** `tests/test_playlist_cache.py` lines 186–232.
+
+**Why safe:** Three back-to-back tests with structural duplication is exactly what `parametrize` exists for; each parameter row's comment explains the boundary it pins. If S-1 lands, both the helper and the helper-using tests become trivially shorter.
+
+**Estimated LOC saved:** ~10 LOC if S-7 alone (parameterize the trio, leave helper), ~30 LOC if S-1 + S-7 together (helper goes away entirely; the `is_stale_missing_*` tests go too).
+
+---
+
+### S-8 — Test `# ---` separator banners
+
+**What to cut/collapse:** Three 3-line ASCII separator blocks visually section the test file (lines 43–45, 113–115, 181–183, 249–251). They're ~12 lines of decoration.
+
+Replace with single `# region: round-trip` / `# region: validation` / `# region: is_stale` / `# region: fetch_with_fallback` comments (or just `# === <section> ===` 1-liners), or trust pytest's class-grouping. The banners restate what the next test names already say; the function names alone navigate fine.
+
+**Where:** `tests/test_playlist_cache.py` lines 43–46, 113–116, 181–184, 249–252.
+
+**Why safe:** Cosmetic; mirror the same finding in `PR3-simplify.md` S-10. Visual-separator banners are personal-style; in a file where every test name starts with `test_<area>_<scenario>`, they add no navigation value beyond the function names themselves.
+
+**Estimated LOC saved:** ~9 LOC (3 lines per banner × 4 banners − 4× 1-line replacements).
+
+---
+
+### S-9 — Validation-rejection tests: dedupe the "rejects on read" + "rejects on write" parameter lists
+
+**What to cut/collapse:** Two parameterized tests cover the same `_validate_playlist_id` rejection logic from two entry points (`read` line 133–149 vs `write` line 154–164). The `write` parameter list is a strict subset of the `read` list — it skips `"a" * 51`, `"abc.json"`, `"abc%20def"`, `"abc?def"`, `"abc/def"`, `"abc\x00def"`. The asymmetry isn't load-bearing; both functions pass through `_path_for` → `_validate_playlist_id` and reject identically. Either:
+
+(a) **Test the validator directly**: one `@pytest.mark.parametrize` block over the bad-id list against `playlist_cache._validate_playlist_id` (or `_path_for` if `_validate_playlist_id` is too internal). Drop the `read`/`write` integration variants entirely; the integration is one line of pass-through that doesn't need re-pinning at every entry point.
+
+(b) **Keep one integration variant** (say, on `read`, since it's the read-only path) + drop the `write` duplicate. Simpler at the cost of slightly weaker coverage at the `write` entry.
+
+Plus `test_traversal_id_does_not_create_file_outside_cache` (lines 170–178) is a defense-in-depth assertion that overlaps `test_validate_rejects_invalid_on_write` for the `"../escape"` case — its real value is the "nothing leaked into the parent" tail check. If we go with (a), keep this one as the single integration-level smoke for the path-safety story; otherwise it's redundant with the parameterized `write` rejection.
+
+**Where:** `tests/test_playlist_cache.py` lines 133–178.
+
+**Why safe:** Two parameterized blocks testing the same charset against two functions that both call the same validator is over-specification. The validator's contract is the right unit; the two callers are integration smoke at most. Mirrors the maintainer's preference (per `M1-simplify.md` review tone) for testing units of behavior, not 2× the same unit through two different doors.
+
+**Estimated LOC saved:** ~12 LOC (drop the `write`-side parameterized list + collapse traversal test into the validator-level test, OR drop the `write`-side and keep the traversal smoke; either path lands ~10–14 LOC under).
+
+---
+
+### S-10 — Collapse two redundant fetch_with_fallback re-raise tests
+
+**What to cut/collapse:** `test_fetch_with_fallback_reraises_when_url_has_no_list_param` (lines 318–329) and `test_fetch_with_fallback_reraises_when_list_param_invalid` (lines 332–342) both pin the same property: `_extract_playlist_id` returns `None` → reraise. Different inputs (no `list=` vs invalid `list=`), same assertion path.
+
+```python
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",  # no list= param
+        "https://www.youtube.com/playlist?list=../../etc",  # adversarial list=
+    ],
+)
+async def test_fetch_with_fallback_reraises_when_no_extractable_id(tmp_path, url):
+    with (
+        patch.object(playlist_cache, "resolve_playlist", side_effect=FetchFailed("x")),
+        pytest.raises(FetchFailed),
+    ):
+        await playlist_cache.fetch_with_fallback(url, cache_root=tmp_path)
+```
+
+The `await playlist_cache.write(PLIST_ID, _playlist(), tmp_path)` setup in `test_fetch_with_fallback_reraises_when_url_has_no_list_param` (line 322) is doing extra work to assert "even with an unrelated cache file present, no list= → no fallback." That negative-control adds value; keep it as a comment in the parameter row, OR keep it as a third parameter case where `cache_pre_populated=True`.
+
+**Where:** `tests/test_playlist_cache.py` lines 318–342.
+
+**Why safe:** Same mechanism, two inputs → parametrize. Pytest output still names the failing input via the parameter id. The "unrelated cache exists" negative control is a single `pre_populate=True` parameter, not a whole separate test function.
+
+**Estimated LOC saved:** ~10 LOC.
+
+---
+
+### S-11 — `_extract_playlist_id` swallows `urlparse` `ValueError` — drop the try/except
+
+**What to cut/collapse:** `_extract_playlist_id` (lines 178–187) wraps `urlparse(url)` in `try/except ValueError`. `urllib.parse.urlparse` is documented to be very permissive — it handles malformed URLs by returning empty components rather than raising. The `ValueError` branch fires only for IPv6 zone-id parsing pathologies (`urlparse("http://[::1%foo]")` and similar), which `_extract_playlist_id`'s callers will never see. The `parse_qs` of the `query` attribute is similarly tolerant.
+
+```python
+def _extract_playlist_id(url: str) -> str | None:
+    parsed = urlparse(url)
+    values = parse_qs(parsed.query).get("list")
+    if not values:
+        return None
+    candidate = values[0]
+    return candidate if _PLAYLIST_ID_RE.match(candidate) else None
+```
+
+**Where:** `src/ryzic/playlist_cache.py` lines 179–183.
+
+**Why safe:** The entry point is `fetch_with_fallback`, which only sees URLs that just survived `resolve_playlist` enough to fail at the **download** stage (not URL-parse stage). By that point, the URL has already passed through `is_supported_url` (`url_validator.py`) and `urlparse` once already without raising. A defensive wrapper around `urlparse` that's never tripped is dead branch.
+
+If this pattern recurs elsewhere in the codebase, it's worth a project-wide note. Standalone in this PR, it's a 3-line trim.
+
+**Estimated LOC saved:** ~3 LOC.
+
+---
+
+### S-12 — `_PLAYLISTS_DIR: Final = "playlists"`
+
+**What to cut/collapse:** A `Final` constant for one-string-used-twice (lines 36 + 49 in `_path_for`, plus references in tests). The string `"playlists"` appears in:
+- `playlist_cache.py` line 49 (the `_path_for` join)
+- `tests/test_playlist_cache.py` lines 71, 78, 85, 105, 204, 240, 290, 298 — 8 sites.
+
+Tests can't import a `_private` constant cleanly anyway (and ~half do hardcode the string), so the `Final` constant is a half-measure. Two viable shapes:
+
+(a) **Inline the string** at the one production site (`cache_root / "playlists" / f"{playlist_id}.json"`) and accept the tests hardcoding it — they're the only other 8 sites, and `tmp_path / "playlists" / f"{PLIST_ID}.json"` is more readable than `tmp_path / playlist_cache._PLAYLISTS_DIR / f"{PLIST_ID}.json"` anyway.
+
+(b) **Keep the `Final`** and stop here.
+
+(a) is one fewer named thing in the module. The constant earns its keep only if "playlists" is going to change (it isn't — it's the spec'd directory name from M1 §4 storage layout).
+
+**Where:** `src/ryzic/playlist_cache.py` lines 36, 49.
+
+**Why safe:** The string appears once in production code; the `Final` declaration is more characters than the use. Mirrors the project's preference for inline literals (e.g. `audio_cache` likely doesn't `Final`-name "audio" — verify in PR3b).
+
+**Estimated LOC saved:** 1 LOC. **Optional, low-conviction.**
+
+---
+
+### S-13 — Things considered and kept
+
+- **`_validate_playlist_id` as a separate function** — keep. Three callers (`_path_for`, `_extract_playlist_id`, `write`'s mismatch check via `_path_for`), each with the same regex. This is the "≥3 callers" threshold; helper earns it.
+- **The `playlists/` subdirectory** — keep. Spec'd in M1 §4 storage layout (sits next to `audio/`, `index.sqlite`, `tmp/`). Don't second-guess.
+- **`asyncio.to_thread(_read_sync, path)` for the *read* path** — keep. `read_text` is sync; running on the loop blocks. The brief doesn't ask, but this is cheap-correct, not over-engineered.
+- **The `_log.warning` on dropped entries** — keep. Operationally critical; without it, a corrupted cache silently re-misses on every `/play` retry without anyone noticing.
+- **`_extract_playlist_id` as a separate function (vs inlined into `fetch_with_fallback`)** — keep. The 8-line URL-parsing logic is a self-contained unit and tested at the integration level via `fetch_with_fallback_reraises_when_*`. Inlining would push the URL-parse decisions into the middle of the fallback flow.
+- **`fetched_at = int(time.time())`** — keep as int (vs float). On-disk JSON is more diff-friendly with integer seconds; sub-second precision is wasted given the 24h staleness window.
+- **The `info.playlist_id != playlist_id` mismatch guard in `write()`** — keep. The docstring's WHY is real: a mismatched payload would silently cache under the wrong filename and break the next read for both ids.
+- **`_serialize` taking `fetched_at` as a parameter (vs reading `time.time()` internally)** — keep. Pure function; testability is the right shape.
+- **Module docstring** — keep mostly. Slightly long but every paragraph carries non-obvious WHY (the live-first contract, the 24h-only-for-embed-not-fallback distinction). Mirrors the `PR3-simplify.md` "module docstring keep-as-is" verdict.
+
+---
+
+## Top 3 wins by impact
+
+1. **S-1 — Return `(info, fetched_at)` from `read()`; reduce `is_stale` to a 1-line pure function.** ~15 LOC src + ~25 LOC tests = **~40 LOC**, eliminates a second disk read on the cache-hit fallback path, and dissolves the "we don't store fetched_at on the dataclass because that would leak the cache concern" architectural justification entirely (it stops being a concern once the timestamp travels separately). The brief identified this; it's the right call.
+
+2. **S-7 + S-8 + S-10 — Test parameterization + banner trim.** Three is_stale boundary tests collapse to one parameterized test; two `fetch_with_fallback` re-raise tests collapse to one parameterized test; four ASCII separator banners become 1-line section markers. Together **~25–30 LOC** of test bloat without losing coverage. (Some of S-7's savings overlap with S-1; counted once below.)
+
+3. **S-9 — Test the validator once, not twice via `read` + `write`.** ~12 LOC by testing `_validate_playlist_id` (or `_path_for`) directly against the bad-id list, instead of re-asserting the same rejection through both `read` and `write` integration paths.
+
+---
+
+## Keep as-is
+
+- The atomic write via tempfile + `os.replace` (S-3 trims a docstring; the mechanism stays).
+- The defensive read with three branches (S-5: each branch is earned and the dual log-message distinction matters operationally).
+- `_serialize`/`_deserialize` as a symmetric pair using stdlib only (S-4: Pydantic adds 8MB transitive surface for two helpers; structural validation IS the value, not boilerplate).
+- The `(info, used_cache_fallback)` tuple return shape (S-2: 2-tuple with one consumer is appropriately minimal; introducing a `FetchResult` dataclass is premature).
+- Module docstring length (every paragraph is WHY, no narration).
+- `_validate_playlist_id` as a named helper (≥3 caller threshold met).
+- `_log.warning` at both drop sites (operational visibility on cache corruption is non-trivial value).
+- The hardcoded 24h `_TTL_SECONDS` constant (per `M1-simplify.md` §3, locked).
+- The `playlists/` subdirectory layout (per M1 §4, locked).
+
+---
+
+## Total impact
+
+- **LOC saved (source):** ~25–30 (S-1: 15, S-3: 3, S-6: 6, S-11: 3, S-12: 1).
+- **LOC saved (tests):** ~50–60 (S-1: 25, S-7: 10 standalone, S-8: 9, S-9: 12, S-10: 10; some overlap between S-1 and S-7 — count once).
+- **Realistic merged total: ~70–90 LOC** out of +564, ~13%.
+- **Net file ratio:** PR drops from 209/355 (1:1.7) to ~180/300 (1:1.7) — the test-to-source ratio stays the same, which is correct: the testing isn't the bloat; the production-side `is_stale` second-read is.
+
+The brief's "209 LOC vs ~150 estimate" diagnosis was right and S-1 is most of the answer — `is_stale`'s second-read drives the whole `_PLAYLISTS_DIR` constant + `_validate_playlist_id` re-call + duplicated path computation through a private function whose only job is to recover one int the caller already paid for. Fixing that pulls ~15 LOC of structure out of the production file and ~25 LOC of test scaffolding (the `_write_with_fetched_at` shadow serializer, the two `is_stale_missing_*` tests). The other findings are polish on top.
+
+The brief's "test scaffolding 355 LOC for 209 LOC of source" diagnosis was *partly* right — the cache subsystem genuinely needs heavy testing (round-trip preservation, validator robustness, fallback contract, boundary semantics), and a 1.7:1 test:source ratio is in the right ballpark for a security-sensitive serialization layer. The bloat is mostly in three places (banners, redundant `is_stale_missing_*` tests, write-side validation duplicating read-side), all S-7/S-8/S-9.
+
+---
+
+## Report
+
+(a) File saved at `/home/user/Projects/ryzic/docs/plans/PR5-simplify.md`.
+
+(b) Top 3:
+   1. S-1 — `read()` returns `(info, fetched_at)`; `is_stale(fetched_at)` becomes pure (~40 LOC including tests).
+   2. S-7 + S-8 + S-10 — parametrize three test trios, drop ASCII banners (~25–30 LOC).
+   3. S-9 — test `_validate_playlist_id` directly, not twice through read/write (~12 LOC).
+
+(c) Total LOC the PR could lose: **~70–90 LOC** out of +564, ~13%. Most of it is one architectural shift (S-1) plus standard test parameterization. No structural rewrites; surface contract unchanged for `fetch_with_fallback`'s caller (S-1 only changes `read()`'s return shape, which has one consumer inside this file).
+
+**Honest verdict:** PR5 is *mostly* tight, with one real diagnosable smell (`is_stale`'s second disk read driving 30+ LOC of architecture and tests). The brief's intuition that the kwarg "requires a disk read" was the right thread to pull. The atomic write, the dual-warning defensive read, the `_serialize`/`_deserialize` pair, and the tuple return shape are all earned. No subsystem-level cuts; this is targeted polish + one module-shape refactor.

--- a/docs/plans/PR6-review.md
+++ b/docs/plans/PR6-review.md
@@ -1,0 +1,191 @@
+# PR #6 Review — `feat(cache): audio cache (sqlite-LRU + per-video lock)`
+
+**Branch:** `feat/audio-cache` -> `main`
+**Scope per plan:** `docs/plans/M1.md` §4 (audio cache subsystem). Implements PR3b per the §12 PR breakdown.
+**Diff:** 2 files changed, +956 / -0. `src/ryzic/audio_cache.py` (+362), `tests/test_audio_cache.py` (+594).
+**Local verification:** `uv run pytest tests/test_audio_cache.py -q` -> 35 passed in 0.19s. PR description claims 98% coverage on the new module. Spot-checked path-safety, race-fix ordering, schema, WAL pragmas, and orphan-sweep behavior.
+
+The implementation closely tracks plan §4 and the explicit decisions called out in the brief. The code is clean, comments are WHY-only and load-bearing, SRP is respected (cache stays guild-agnostic; caller passes `TrackInfo`). Two genuine race issues found, neither catastrophic but both visible to users under specific timing; remaining findings are LOW polish.
+
+---
+
+## Findings
+
+### MEDIUM-1 — Fast-path TOCTOU: `_fast_lookup` -> `_touch` -> `_in_use += 1` has a race window where a concurrent eviction can delete the file before it is pinned
+
+- **Severity:** MEDIUM
+- **Where:** `src/ryzic/audio_cache.py:165-169` (the fast-path branch in `get_or_download`)
+- **Why it matters:** The plan's whole point of the in-use Counter is "eviction never deletes a file Lavalink is currently streaming." The slow path (`_download_locked`, line 226) correctly pins BEFORE running the evictor — that's the §4 race fix the brief specifically calls out. The fast path has the *symmetric* race in the *opposite* direction:
+
+  1. Coroutine A: `await self._fast_lookup(track.video_id)` returns path P (file exists at this instant) — line 165.
+  2. Coroutine A: `await self._touch(track.video_id)` — UPDATE + commit. **This is an `await` and yields the event loop.**
+  3. Coroutine B (concurrent `/play` for some *other* video): finishes `_download_locked`, pins itself, and runs `_evict_to_fit`. The evictor scans `ORDER BY last_used_ts ASC`, finds A's video_id with `_in_use.get(vid, 0) == 0` (A hasn't pinned yet), unlinks the file, DELETEs the row.
+  4. Coroutine A resumes: `self._in_use[track.video_id] += 1`, returns P. **P now points at a non-existent file**, and the row no longer exists in sqlite.
+
+  The blast radius is bounded — the very next play of the same id repairs via the lock-protected re-download branch — but the user-visible symptom is a Lavalink `LOAD_FAILED` for what looked like a hot cache hit. This directly contradicts the invariant the §4 plan and the module docstring promise. It is also the exact failure mode the slow-path race fix at line 226 was written to prevent; the symmetric fast-path version was missed.
+
+  Triggering it in the wild is not contrived: the evictor only runs when the cache is over capacity, which is the normal steady state for a healthy cache.
+
+- **Fix:** Swap the order so the pin happens *before* the awaited `_touch`. `_in_use[vid] += 1` is synchronous and cannot yield, so once it runs no concurrent evictor will pick this id:
+
+  ```python
+  hit = await self._fast_lookup(track.video_id)
+  if hit is not None:
+      # Pin BEFORE _touch (sync, no yield) — symmetric to the
+      # slow-path fix in _download_locked. Otherwise a concurrent
+      # download's evictor can delete the file between _fast_lookup
+      # and the +=1.
+      self._in_use[track.video_id] += 1
+      await self._touch(track.video_id)
+      return hit
+  ```
+
+  Apply identically to the double-checked branch at line 178. Add a regression test mirroring `test_just_inserted_file_not_evicted_due_to_pin` but for the fast path: prime an entry, second concurrent `/play` waits inside `_touch` while a third (different vid, large payload, low `max_bytes`) forces eviction; assert the first vid's file still exists when its `get_or_download` returns.
+
+---
+
+### MEDIUM-2 — Commit visibility: `INSERT OR REPLACE` and `_evict_to_fit` ordering can leave the on-disk file orphaned across a crash
+
+- **Severity:** MEDIUM
+- **Where:** `src/ryzic/audio_cache.py:198-227` (`_download_locked`)
+- **Why it matters:** The current order is: `os.replace(tmp, final)` -> `INSERT OR REPLACE` -> `commit()` -> `_in_use[vid] += 1` -> `_evict_to_fit()` (which has its own `commit()`). If the process crashes between `os.replace` and `commit()`, the file is on disk under `audio/...` but no row exists — the orphan sweep at next startup will eventually reclaim it (after 1h). That's acceptable.
+
+  The subtler case is in `_evict_to_fit` itself (lines 298-311): the loop unlinks the file *first*, then issues the DELETE, then loops to the next candidate, then a single `commit()` at the end. If the process crashes mid-loop, files have been unlinked but the DELETE is uncommitted in the WAL — on restart, sqlite will roll back the DELETEs and you have rows pointing at files that don't exist. `_fast_lookup` handles this gracefully (returns None when `path.exists()` fails) — so the user-visible behavior is "next play re-downloads", which is fine. **But** the now-stale row keeps occupying byte-budget in the SUM query at the next eviction, so the cache's effective capacity is silently understated until the row is overwritten by a fresh download for the same id (unlikely in practice — evicted videos by definition aren't recently played).
+
+  Compounded: an unlink that fails for I/O reasons (line 305 OSError branch) correctly keeps the row + logs WARN — that's the brief's specified behavior. But the `total -= int(size)` is only updated on success, so the loop will keep trying to evict more candidates. Good.
+
+- **Fix:** Two cheap improvements, either or both:
+  1. In `_evict_to_fit`, commit *per iteration* (DELETE then commit then unlink, or unlink then DELETE then commit). The commit is cheap under WAL+NORMAL and bounds the inconsistency window to a single entry. The brief's "unlink failure keeps row + logs WARN" guarantee is preserved either way.
+  2. In `get_or_download`'s fast path, when `_fast_lookup` returns None for an existing-but-stale row, *delete the row* under the lock (the lock prevents the originally-cited race — concurrent INSERT can't fire because the lock is held by the repairing coroutine). Currently the stale row is repaired only by `INSERT OR REPLACE` after a successful re-download, leaving a window where a hard re-download failure would leave the row dangling.
+
+  Neither is critical — the orphan sweep eventually reaps everything — but #1 in particular tightens an invariant that the rest of the code seems to assume holds.
+
+---
+
+### LOW-1 — `tmp/` partial-download path drops the `{ext}` suffix the plan specifies
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/audio_cache.py:183` (`_download_locked`), versus M1.md §4 storage layout
+- **Why it matters:** Plan §4 says `tmp/{video_id}.{ext}.partial`. The PR uses `tmp/{video_id}.partial`. The deviation is *justified* and documented in the PR description: ext isn't known until after download (yt-dlp doesn't surface it cleanly through PR3a's narrow API; the magic-byte sniff in `_detect_ext` runs against the partial file). The `os.replace` to `audio/{vid[:2]}/{vid}.{ext}` happens after sniffing, so the final layout matches the plan.
+
+  Worth noting because (a) the brief explicitly asks "schema matches exactly" — this is a tmp-path deviation, not a schema deviation, but worth flagging — and (b) if anything in the runtime ever scans `tmp/` for files matching `*.{ext}.partial` it will miss them. Currently nothing does.
+
+- **Fix:** Not strictly required. If you want to honor the plan literally, sniff the *partial* file's magic bytes during the download (or rename to add `.ext.partial` after the first chunk) — but that's a meaningful complication for no gain. Better fix: a one-line note in the M1.md §4 storage layout pointing at the deviation, OR a one-line comment at line 183 pointing back at the design decision in the PR description.
+
+---
+
+### LOW-2 — `release()` is `async def` but does no I/O; the false async signature locks a future where it must be
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/audio_cache.py:230-245` (`release`), `247-254` (`release_many`)
+- **Why it matters:** `release()` is purely in-memory Counter manipulation — no `await`, no I/O. It is `async def` only so that callers do `await cache.release(vid)`. That's defensible (preserves a stable API across future versions where release might do I/O — e.g. update sqlite's `last_used_ts` to "released at" for analytics) and is pragmatic for the planned PR5 wiring.
+
+  But: `release_many` iterates `await self.release(vid)` in a tight loop; if `release` ever DOES become I/O-bound, this becomes O(N) sequential awaits when a `gather` would be the right shape. And: the fast-path `_in_use[track.video_id] += 1` is *not* async — so the API is asymmetric (sync acquire, async release).
+
+- **Fix:** Either keep both sync (`release` becomes `def release` — symmetric with the sync `+=` increment), or document a comment at line 230 explaining the deliberate asymmetry. Since neither operation does I/O today, sync is the simpler choice and matches SRP/KISS. Tests would only need to drop a few `await`s.
+
+---
+
+### LOW-3 — `validate_video_id(track.video_id)` runs twice on the slow path
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/audio_cache.py:163` (entry check) and `194` (in `_audio_path` -> `validate_video_id`)
+- **Why it matters:** Pure DRY — the call at 163 already validated, and `_audio_path` at 194 re-validates. Two regex matches per slow-path download is meaningless cost (regex is precompiled with `re.compile`), but the fact that two layers each insist on validating suggests the contract is unclear: is `_audio_path` defensive against direct internal use, or does it trust the caller? The docstring at line 88-93 frames it as "defense-in-depth against future refactors that might widen the charset" — that's a reasonable reason to keep the second call. So this is style polish, not a fix request.
+- **Fix:** Optional. If kept, the doc comment at 88-93 already justifies it well. If removed, drop the call inside `_audio_path` and rely on the entry-point validation in `get_or_download` plus the `relative_to` post-check.
+
+---
+
+### LOW-4 — `_fast_lookup`'s "stale row whose file vanished" path leaks disk-row inconsistency until next download
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/audio_cache.py:256-274` (`_fast_lookup`)
+- **Why it matters:** When the row exists but the file is missing, `_fast_lookup` returns None. The caller then enters the lock-protected branch, downloads, and `INSERT OR REPLACE` repairs the row. Good. But: the row's stale `bytes` value continues to inflate the SUM in `_evict_to_fit` until that re-download completes. If many entries are in this stale state simultaneously (e.g. the deploy operator manually deleted a chunk of `audio/`), the cache will think it's over-capacity and aggressively evict valid pinned-or-not entries until the SUM matches reality.
+
+  Mitigation: this is a degraded-state recovery path — the orphan sweep at startup is meant to handle the inverse case. Stale rows whose files have been externally deleted *after* startup are an operator-error class of fault.
+
+- **Fix:** Either (a) accept as-is and document the rule in operator docs ("don't manually delete files from `.cache/audio/` while ryzic is running; restart to recover"), or (b) add a `cleanup_stale_rows()` module function symmetric to `sweep_orphans` that scans rows and drops ones whose files are gone (only safe under the lock for the same reason `_fast_lookup` doesn't delete). (a) is fine for M1.
+
+---
+
+### LOW-5 — `_evict_to_fit` reads the entire `entries` table sorted by `last_used_ts` in a single `fetchall()`
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/audio_cache.py:293-296`
+- **Why it matters:** For the `RYZIC_CACHE_MAX_GB` default of 5 GB and average 5 MB tracks, that's ~1000 rows — fine. For a tuned-up self-host with 100 GB cache and 5 MB tracks, that's 20k rows pulled into a Python list every time the cache exceeds capacity by a single byte. The `entries_lru` index makes the SELECT cheap, but the marshalling cost is linear in the row count.
+- **Fix:** Stream candidates with `LIMIT N` and re-query on the next iteration if not yet under cap, *or* iterate the cursor instead of `fetchall()`. Both are nontrivial because `_in_use` filtering is in-process — you'd need to fetch in batches. **Not worth doing for M1 capacity (5 GB default).** Worth a TODO comment if you want to remember it; otherwise a pure capacity-bound future-incident watch item.
+
+---
+
+### LOW-6 — `sweep_orphans` opens an aiosqlite connection independent of `AudioCache`'s; no cross-process or cross-call coordination
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/audio_cache.py:333-339`
+- **Why it matters:** The PR description says `sweep_orphans` is "independently invokable from CLI / scheduled jobs", which is the right design — but if a CLI invocation runs *while* the bot is up, both will hold connections to the same sqlite. WAL handles concurrent readers, and the sweep only reads (no writes to sqlite itself, only unlinks). The cross-process correctness of WAL+NORMAL is well-defined here, so this is not a bug. But the `1h` orphan threshold assumes cross-process clock agreement and assumes no individual download legitimately takes >1h — which is enforced by yt-dlp's `max_filesize: 500_000_000` + reasonable network. Fine for M1.
+
+  Watchlist item for a future "shared cache, multiple bot instances" deployment (which the plan does not currently support) — `_locks` is per-process and would not deduplicate downloads across instances. Two bot instances racing the same `/play` would both download, both `os.replace` (last wins atomically), both INSERT OR REPLACE (last wins). Not corrupt, just wasteful. Worth a note in the operator doc when multi-instance becomes a use case.
+
+- **Fix:** None for M1. Capture the multi-instance limitation in the operator README when PR9 lands, or at the top of `audio_cache.py` ("single-instance assumed; cross-process locks not implemented").
+
+---
+
+### LOW-7 — `_detect_ext` unconditionally falls back to `"audio"` for unknown formats; future Lavalink versions may sniff more strictly
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/audio_cache.py:63-84`
+- **Why it matters:** The fallback `"audio"` is harmless today because Lavalink's `LocalAudioSourceManager` content-sniffs the body. The on-disk suffix being `"audio"` is "decorative" per the comment at line 42-44, which is true. But the row in sqlite ALSO records `ext: "audio"` — if the row's `ext` is ever used for anything beyond the filename (e.g. metrics, format-specific decoder selection in a future PR), the `"audio"` value will be unhelpful. Currently nothing reads it programmatically.
+- **Fix:** None. Worth a one-liner test confirming the sqlite row's `ext` column matches the on-disk suffix when fallback hits (currently only the fallback-with-empty-bytes case is parametrized in `test_detect_ext_recognizes_known_codecs`, not the round-trip through the cache). Optional.
+
+---
+
+### LOW-8 — Magic bytes for "OggS" header don't distinguish Opus from Vorbis containers
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/audio_cache.py:78-79`
+- **Why it matters:** The format selector in PR3a's `_base_opts` is `bestaudio[ext=m4a]/bestaudio[ext=opus]/bestaudio[ext=webm]/bestaudio` — so "ogg with vorbis codec" is reachable only through the trailing `/bestaudio` fallback and is rare on YouTube. Even if it happens, `_detect_ext` would label it `"opus"` based on the OggS container. The on-disk suffix would be cosmetically wrong. Lavalink wouldn't care (sniffs the body).
+- **Fix:** None. Worth a sentence in the docstring noting "OggS is treated as Opus; Vorbis-in-Ogg gets the same suffix and is exceedingly rare on YouTube" if precision matters to a future maintainer.
+
+---
+
+### LOW-9 — `release` is no-op when called on a vid never inserted; `release_many` accepts arbitrary iterables, including duplicates
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/audio_cache.py:230-254`
+- **Why it matters:** `release_many([vid, vid])` decrements twice. If the caller (PR5/PR6a) accidentally builds the queue's vid list with duplicates (a very plausible bug in a later PR — same video queued twice triggers Counter hits 2; releasing the queue's vids must release each occurrence), behavior depends entirely on the caller building the list correctly. The cache is unable to detect "you over-released" beyond the soft `<= 0 -> pop` guard.
+
+  This is correct per the §4 plan ("Counter not set, same video may be queued multiple times"), and the test `test_release_idempotent_after_zero` covers the over-release safety net. Just noting that `release_many` is not idempotent over the same id and the contract is "caller passes one vid per queue entry, including duplicates" — which the PR description gets right.
+
+- **Fix:** Add the contract to the `release_many` docstring: "Pass one entry per queue position (duplicates expected for repeated tracks)." Currently the docstring says "iterates the guild's queue once and passes every video_id" which is close, but not explicit about duplicates.
+
+---
+
+### LOW-10 — `_audio_path` calls `cache_root.resolve()` on every invocation (not cached on the instance)
+
+- **Severity:** LOW
+- **Where:** `src/ryzic/audio_cache.py:98`
+- **Why it matters:** `_audio_path` is module-level (no `self`), so it can't cache anything on the instance — but it also can't easily memoize across calls without polluting module state. `resolve()` does a syscall stack walk; on the cache hot path this runs once per slow-path download (rare). On `_audio_path` calls from tests (frequent), it doesn't matter. Genuinely negligible.
+- **Fix:** None. If you find yourself profiling `_audio_path`, cache `cache_root.resolve()` on the `AudioCache` instance and pass it in. Not worth doing speculatively.
+
+---
+
+## Cross-cutting observations
+
+- **Comments are WHY-only.** Spot-checked all 14 inline comments; every one explains a non-obvious *why*, none narrate the *what*. The multi-line module docstring + class docstring + method docstrings are well-calibrated for FOSS-grade onboarding without being preachy.
+- **SOLID/SRP:** the design correctly keeps the cache guild-agnostic (caller passes the vid list to `release_many`); `sweep_orphans` is module-level rather than a class method, matching the spec; `_detect_ext` and `_audio_path` are module-level helpers (correctly so — they don't need instance state).
+- **DRY:** one minor duplication noted above (LOW-3, double `validate_video_id`); otherwise tight.
+- **KISS:** the implementation is genuinely small (362 lines including a generous module docstring). No premature abstractions, no extension hooks, no event emitters. Good.
+- **Test quality:** 35 cases, ~600 lines, one race-fix regression test that maps directly to plan §4's specified race fix. Tests use `_M4A_HEAD * 8` payloads so `_detect_ext` runs against real bytes — that's the right rigor. The concurrent-download test (`test_concurrent_get_or_download_triggers_one_download`) correctly uses an `asyncio.Event` as a synchronization barrier instead of timing-dependent `asyncio.gather`. Good.
+- **Async/sqlite:** `aiosqlite` shares a single connection across all coroutines via `self._conn`; aiosqlite serializes operations on a connection internally, so the implementation is safe but the connection is a serialization point. WAL+NORMAL is correctly applied per plan. The `_fast_lookup`'s `async with conn.execute(...)` pattern correctly releases the cursor — verified.
+- **Cross-process / multi-bot watchlist:** captured in LOW-6.
+- **No comment-as-narration anywhere I could find.** No `# Increment counter` or `# Acquire lock` style comments. Strong adherence to the maintainer's standard.
+
+---
+
+## Verdict
+
+**minor revisions.**
+
+MEDIUM-1 should be fixed before merge — it's a one-line reorder + a regression test, and it directly contradicts the cache's stated invariant. MEDIUM-2 is worth at least adding the per-iteration commit to `_evict_to_fit` (small change, tightens an invariant without complicating the code).
+
+Everything else is LOW polish — the LOW-1 tmp-path deviation is justified and documented in the PR description and is fine to leave as-is. LOW-2 (sync `release`) is a judgment call worth a one-line decision either way. The remaining LOW items (4-10) are watchlist / future-incident notes, not blockers.
+
+The implementer's six up-front decisions in the brief all check out: TrackInfo passed (no double round trip), `_fast_lookup` is read-only, magic-byte ext detection, module-level `sweep_orphans`, pin-before-evict in the slow path (correctly implemented at line 226), and unlink-failure WARN-and-keep-row (correctly implemented at line 307). The PR is materially correct and ships clean once MEDIUM-1 is addressed.

--- a/docs/plans/PR6-security-review.md
+++ b/docs/plans/PR6-security-review.md
@@ -1,0 +1,295 @@
+# PR #6 — Security Review
+
+**PR**: `feat(cache): audio cache (sqlite-LRU + per-video lock)`
+**Branch**: `feat/audio-cache` → `main`
+**Repo**: `VeryLongOrgNameSuchWow/ryzic`
+**Commit reviewed**: `3542c4c`
+**Files in scope** (PR diff only):
+
+- `src/ryzic/audio_cache.py` (new, 363 lines)
+- `tests/test_audio_cache.py` (new, 595 lines)
+
+No dependency or build-system changes (`pyproject.toml`/`uv.lock` unchanged in this PR; `aiosqlite>=0.20` was already declared in PR #1, resolved at `0.22.1`). Out of scope per the brief: yt-dlp wrapper, playlist cache, Discord layer.
+
+This review covers the ten focus areas from the brief: video_id input validation, path safety / traversal, TOCTOU on the orphan sweep, sqlite security under multi-instance, disk-fill enforcement, symlink-TOCTOU on the cache root, magic-byte ext detection, `release_many` arithmetic, test isolation / disk leaks, and dependency surface.
+
+---
+
+## Findings
+
+### 1. `video_id` validation — charset/length, pre-construction
+
+**Severity**: (informational — no finding)
+**What**: `validate_video_id` (PR3a, `src/ryzic/ytdlp.py:31,77-80`) compiles `^[A-Za-z0-9_-]{6,20}$` and raises `InvalidVideoID` on mismatch. The audio-cache module enforces it at three of three sites BEFORE any path or sqlite work:
+
+| Caller | Line | Order |
+| --- | --- | --- |
+| `_audio_path(...)` | `src/ryzic/audio_cache.py:94` | first statement of the function |
+| `get_or_download(track)` | `src/ryzic/audio_cache.py:163` | first statement |
+| `_audio_path` from `_download_locked` | invoked at line 194 | already validated by the entry point at 163 |
+
+I exercised the regex against:
+
+| Input | Outcome |
+| --- | --- |
+| `""` | rejected (length) |
+| `"short"` (5 chars) | rejected (length) |
+| `"a" * 21` | rejected (length) |
+| `".dotted"` | rejected (charset — leading dot) |
+| `".."` | rejected (length + charset) |
+| `"../etc"` | rejected (charset — `/`, `.`) |
+| `"%2e%2e"` | rejected (charset — `%`) |
+| `"a%2fb%2f"` | rejected (charset — `%`, `/`) |
+| `"NUL\x00d"` | rejected (charset — NUL) |
+| `"CR\rid"` / `"NL\nid"` | rejected (charset) |
+| `"unicodeㄒ"` | rejected (non-ASCII) |
+| `"ＡＢＣＤＥＦ"` (full-width) | rejected (regex matches **raw** code-points; no NFKC pre-fold) |
+| `"𝕒𝕓𝕔𝕕𝕖𝕗"` (mathematical double-struck) | rejected (raw code-points outside `[A-Za-z0-9_-]`) |
+| `"with.dot"` | rejected (charset — `.`) |
+| `"normal_id"` / `"dQw4w9WgXcQ"` / `"uppr0123_"` | accepted |
+
+The regex is applied to the raw string; Python's `re.match` does NOT NFKC-normalize, so unicode confusables that look like ASCII (e.g. fullwidth `Ａ`) cannot bypass the allowlist. The `tests/test_audio_cache.py:291-295` case (`video_id="../../etc/passwd"`) confirms invalid IDs are rejected before `download` is invoked.
+
+`release()` and `release_many()` deliberately do NOT validate (they manipulate an in-memory Counter, not paths or sqlite keys for INSERT). Reading a non-existent key from `Counter` returns 0 without creating an entry; `pop(key, None)` is also no-op for missing keys. Confirmed empirically — passing arbitrary strings to `release` does not grow `_in_use`. **Verdict: clean.**
+
+---
+
+### 2. Path safety — `relative_to(cache_root)` defends against in-cache symlink escape
+
+**Severity**: (informational — no finding)
+**What**: `_audio_path` (`src/ryzic/audio_cache.py:87-101`) constructs `cache_root / "audio" / video_id[:2] / f"{video_id}.{ext}"` then runs `final.resolve().relative_to(cache_root.resolve())`. `Path.resolve()` canonicalizes symlinks at check time. I exercised three escape vectors empirically:
+
+- **Symlink shard inside `audio/`** — `audio/dQ` symlink → `/elsewhere`. The `resolve().relative_to()` call raises `ValueError`, mapped to `InvalidVideoID("audio path … escapes cache_root …")`. Covered by `test_audio_path_rejects_traversal_via_symlink` (line 482).
+- **`cache_root` itself is a symlink** (e.g. `/var/cache/ryzic` → `/srv/audio-cache`). Both sides of `relative_to` resolve consistently to the canonical target; not flagged. Verified manually.
+- **`video_id` containing `..`** — rejected by `validate_video_id` BEFORE path construction; covered by `test_audio_path_validates_video_id_first` (line 496).
+
+`download()` (`src/ryzic/ytdlp.py:261-280`) duplicates the `relative_to` check on `tmp_path` before invoking yt-dlp; that's PR2's defense, but it's worth noting because PR3b's `_download_locked` builds `tmp_path` (line 183) without an explicit check — relying on the fact that `tmp_path = self._tmp_root / f"{validated_id}.partial"` is structurally in-bounds. The downstream `download()` re-checks. Belt-and-braces. **Verdict: clean.**
+
+There IS a residual TOCTOU window: `_audio_path` resolves the parent at line 98, then `final.parent.mkdir` runs at line 195, then `os.replace` runs at line 198. A co-resident attacker with write access inside `audio/{shard}/` could race the symlink between the check and the move. This is the **same threat model** as PR2's #8 (LOW, deferred to PR3b). The deploy-time mitigation is "0o700 on `cache_root`, owned by the bot UID"; an O_NOFOLLOW-based fix is out of scope. Filed as #6 below.
+
+---
+
+### 3. Orphan sweep TOCTOU — `mtime > 1h` guard is not bullet-proof for slow downloads
+
+**Severity**: LOW
+**What**: `sweep_orphans` (`src/ryzic/audio_cache.py:314-362`) treats a file as orphan only if its `mtime` is **older** than 1h, intending to skip files that a concurrent download has just landed. The race the guard targets is:
+
+1. Worker A calls `os.replace(tmp_path, final)` (line 198) — file appears in `audio/`.
+2. Sweep enumerates `audio/`, sees the file, no row in sqlite, mtime young → **skipped** (correct).
+3. Worker A inserts the row (line 205-220) — invariant restored.
+
+That works for fresh downloads. **But `os.replace` PRESERVES the source's mtime** (verified: `os.utime(src, (old, old)); os.replace(src, dst)` yields `dst.mtime == old`). If a yt-dlp download takes >1h (slow connection, large `max_filesize=500_000_000`, retries), `tmp_path`'s mtime is already >1h ago. After `os.replace` the file lands in `audio/` with that old mtime. If `sweep_orphans` runs in the **microsecond gap** between `os.replace` (line 198) and the `INSERT` commit (line 221), the sweep deletes the just-moved file. Worker A then proceeds with INSERT — leaving a row pointing at a now-missing file.
+
+The `_fast_lookup` path **handles** the resulting stale row (line 269-273: missing file is treated as miss, the lock-protected branch repairs by re-INSERT). So the worst-case is "next play of the same video re-downloads instead of hitting cache" — an availability blip, not corruption.
+
+**Where**: `src/ryzic/audio_cache.py:198,221` (the gap); `src/ryzic/audio_cache.py:341-353` (the guard).
+
+**Why it matters**: Extremely narrow. Requires (a) yt-dlp download taking >1h, (b) `sweep_orphans` invoked exactly in the gap. Operationally, sweeps run at startup only (per PR description). Not exploitable from a Discord-user URL.
+
+**Fix**: Either (a) `os.utime(tmp_path, None)` before `os.replace` to reset mtime, OR (b) have `_download_locked` write the row BEFORE `os.replace` (would require `INSERT` on the not-yet-final `rel_path` and an UPDATE post-replace — more complex). Cheapest: a single `os.utime(tmp_path, None)` between line 197 and 198. One-line hardening.
+
+---
+
+### 4. SQLite security — connection string, PRAGMAs, multi-instance contention
+
+**Severity**: LOW (multi-instance contention; not a single-instance finding)
+**What**: `aiosqlite.connect(self._db_path)` (line 136) takes a `pathlib.Path` — no URI parsing, no `?immutable=1` exploit vector, no `:memory:` ambiguity. PRAGMAs:
+
+- `journal_mode=WAL` — concurrent readers don't block the writer; tested explicitly in `test_open_sets_wal_pragmas`.
+- `synchronous=NORMAL` — durable enough for cache contents (re-downloadable on loss); standard for WAL.
+
+All SQL uses `?` placeholders (audited every `execute(`/`executescript(` call site at lines 139, 140, 141, 205-220, 265-267, 278-281, 287, 293-295, 309, 335). No string interpolation of user-controlled data into SQL. Schema CREATE statements are static. **Single-instance: clean.**
+
+**Multi-instance scenario** (the brief explicitly asked): two ryzic processes pointing at the same `cache_dir`. SQLite WAL allows concurrent readers, but **all writers serialize on a single exclusive lock**. With aiosqlite's default `busy_timeout=5000ms` (verified empirically — `aiosqlite.connect` uses sqlite3's stdlib default of 5000ms), a contended write waits up to 5s before raising `OperationalError("database is locked")`. Realistic INSERT/UPDATE finishes in milliseconds, so practical contention is rare; under heavy concurrent `/play` storms across both instances it could surface.
+
+There's a more concerning interaction with the `os.replace + INSERT` ordering. Process A:
+1. `os.replace(tmp, final)` — file in `audio/`
+2. `INSERT OR REPLACE` — **blocks for 5s waiting for B's lock, then `OperationalError`**
+3. `_download_locked` raises; the file is orphaned in `audio/`
+4. Eventually `sweep_orphans` cleans it (after 1h)
+
+So a multi-instance deploy has a real "orphan file accumulation under contention" failure mode, not corruption. Per-video locks (`_locks`) coordinate WITHIN a process; they do not coordinate ACROSS processes. Two instances would both download the same video to the same destination in the worst case — `os.replace` is atomic so the file content is consistent, but both sqlite rows compete.
+
+**Where**: `src/ryzic/audio_cache.py:136-142` (PRAGMAs), 198-221 (move-then-insert ordering).
+
+**Why it matters**: M1 plan does not call out multi-instance support as a goal. M1 §4 explicitly says the cache is "shared across all guilds" of one bot, not across bot instances. The deploy doc should warn against pointing two bots at the same `cache_dir`.
+
+**Fix**: Document the constraint in `M1.md` §4 and `.env.example` (e.g. "MUST be unique per ryzic instance — sqlite WAL serializes writers but does not coordinate `os.replace`-then-`INSERT` ordering across processes"). Optionally bump `busy_timeout` to e.g. 30000ms for resilience. Not blocking.
+
+---
+
+### 5. Disk fill — `_evict_to_fit` runs after every INSERT
+
+**Severity**: (informational — no finding)
+**What**: `_download_locked` (`src/ryzic/audio_cache.py:182-228`) always calls `await self._evict_to_fit()` (line 227) after `INSERT OR REPLACE`. The eviction loop:
+
+1. `SELECT COALESCE(SUM(bytes), 0) FROM entries` — total of recorded sizes.
+2. If `total <= max_bytes`, return (no work).
+3. `SELECT video_id, rel_path, bytes FROM entries ORDER BY last_used_ts ASC` — oldest first.
+4. For each candidate: skip if `_in_use[vid] > 0`; else `unlink(missing_ok=True)`, `DELETE`, decrement total.
+5. Stop when `total <= max_bytes`.
+
+Tested by `test_eviction_removes_oldest_first`, `test_eviction_skips_in_use_entries`, `test_just_inserted_file_not_evicted_due_to_pin`, `test_eviction_unlink_failure_does_not_drop_row`. The just-inserted entry is **pinned BEFORE** running eviction (line 226 → line 227), so even when its own size blows the cap (test at line 418-435 with `max_bytes=100` and a 1000-byte payload), it survives. This is the review §4 race fix and it's correctly implemented.
+
+`_in_use[video_id] += 1` on the fast-path hit (lines 168, 178) also correctly pins entries returned to the caller, so a concurrent eviction triggered by another download cannot delete a file that is in transit to Lavalink.
+
+`max_bytes` is enforced as bytes; `Config.cache_max_gb` (gigabytes, `_parse_positive_int(... default=5)`) is **not yet plumbed** into the cache (per the PR description's "Follow-ups" section — bootstrap wiring is deferred). When wired, the bootstrap code MUST multiply: `max_bytes = cfg.cache_max_gb * 1_000_000_000`. A future PR forgetting the multiplication would set the cap at 5 BYTES instead of 5 GB. Not a finding for THIS PR, but worth flagging as a watch-item for the bootstrap PR's review.
+
+`unlink` failures are logged at WARNING and the row is preserved (line 305-307) so the next eviction retries — important so a single permission glitch doesn't silently corrupt the index.
+
+One subtle gap: `_evict_to_fit` ignores files in `tmp/` AND any orphan files in `audio/` that the index doesn't know about (orphans are deleted by the separate `sweep_orphans`, which runs only at startup). So during runtime, orphan tmp files (e.g. from a crashed download) accumulate without bound until the next restart. See #7. **Verdict: cap-enforcement is clean; orphan-tmp accumulation is finding #7.**
+
+---
+
+### 6. Cache root is not validated to be a real directory at startup
+
+**Severity**: LOW (defense-in-depth; deferred from PR2 §8)
+**What**: PR2's security review (#8) flagged cache-directory symlink TOCTOU as "outside this PR's threat model, defer to M2 cache subsystem". This is M2's cache subsystem and the gap is unchanged. `AudioCache.open()` (lines 132-143) does:
+
+```python
+for d in (self._cache_root, self._audio_root, self._tmp_root):
+    d.mkdir(parents=True, exist_ok=True)
+```
+
+There is no `os.path.realpath` check that `cache_root` is a real, owned, 0o700 directory rather than a symlink to e.g. `/etc`. If a co-resident attacker can plant a symlink at `cache_root` BEFORE the bot starts, the bot's writes land at the symlink target.
+
+**Where**: `src/ryzic/audio_cache.py:132-143`.
+
+**Why it matters**: Same threat model as PR2 #8 — requires co-resident write access to the bot's data directory. The existing post-construction `relative_to` check (#2) handles symlinks INSIDE the cache; this would close the symlink-AT-the-cache-root gap.
+
+**Fix**: At the top of `open()`, add:
+
+```python
+if self._cache_root.is_symlink():
+    raise RuntimeError(f"cache_root {self._cache_root!s} must not be a symlink")
+# Or: refuse to start if cache_root.resolve() != cache_root.absolute()
+```
+
+Pair with a deploy-doc note that the cache directory should be owned by the bot UID with 0o700. Optionally check ownership/mode and warn. Not blocking.
+
+---
+
+### 7. `tmp/` orphan files are never swept
+
+**Severity**: LOW (availability — disk fill on long-running bots with crash patterns)
+**What**: `sweep_orphans` walks **only** `audio_root` (line 343 `audio_root.rglob("*")`). Files in `tmp/` are never enumerated. The download flow writes `tmp/{video_id}.partial`, then on success `os.replace`s it to `audio/`. On failure, line 187 calls `tmp_path.unlink(missing_ok=True)` — but only for `Exception` from `download(...)`.
+
+Failure modes that leak tmp files:
+
+- **Process crash mid-download** (SIGKILL, OOM, host reboot) — `tmp_path` survives indefinitely.
+- **Partial download where yt-dlp itself wrote a `.part` file and exited cleanly without an exception** — unlikely but the `unlink(missing_ok=True)` only targets `tmp_path` (the `.partial` name), not yt-dlp's own intermediate `.ytdl`/`.part` files in the same `tmp/` dir.
+
+Over months of uptime with a flaky network, `tmp/` could grow without bound. Not security per se — disk-fill DoS via persistent crash patterns.
+
+**Where**: `src/ryzic/audio_cache.py:343` (sweep walks `audio_root` only); `src/ryzic/audio_cache.py:182-188` (failure cleanup is local to one `tmp_path`).
+
+**Fix**: Extend `sweep_orphans` to ALSO walk `tmp_root`:
+
+```python
+tmp_root = cache_root / _TMP_SUBDIR
+if tmp_root.exists():
+    for file_path in tmp_root.iterdir():
+        if not file_path.is_file():
+            continue
+        try:
+            mtime = file_path.stat().st_mtime
+        except OSError:
+            continue
+        if mtime > cutoff:
+            continue
+        try:
+            file_path.unlink()
+            deleted += 1
+        except OSError:
+            _log.warning("orphan sweep failed to unlink tmp file %s", file_path, exc_info=True)
+```
+
+Same age guard reused. ~10 lines + one test. Not blocking.
+
+---
+
+### 8. Magic-byte ext detection — closed return set, no path injection
+
+**Severity**: (informational — no finding)
+**What**: `_detect_ext` (`src/ryzic/audio_cache.py:63-84`) returns one of `{"m4a", "opus", "webm", "mp3", "audio"}` — five hardcoded string literals. None contain `/`, `\`, `.`, NUL, or `..`. The function reads only the first 16 bytes and returns the constant matched by the first prefix branch. A crafted yt-dlp output (audio bytes whose first 8 bytes are `\x00\x00\x00\x18ftyp...`) would yield `"m4a"` regardless of the actual container — but `"m4a"` is a safe path component. Lavalink's `LocalAudioSourceManager` sniffs the body itself, so the on-disk suffix is decorative.
+
+The path is then constructed as `f"{video_id}.{ext}"` (line 95) — both pieces are constrained to safe character sets. The post-construction `relative_to` check (line 98) is the final guard. **Verdict: clean.** No way for a crafted download to inject a path component that breaks `relative_to`.
+
+---
+
+### 9. `release_many` cannot drive Counter negative; cannot un-pin uninvolved entries
+
+**Severity**: (informational — no finding)
+**What**: `release` (lines 230-245):
+
+```python
+if self._in_use[video_id] <= 0:
+    self._in_use.pop(video_id, None)
+    return
+self._in_use[video_id] -= 1
+if self._in_use[video_id] <= 0:
+    del self._in_use[video_id]
+```
+
+The first guard prevents the counter from going negative. `release_many` is just a loop calling `release` per id. Verified by `test_release_idempotent_after_zero` (line 316-319). Counter[unknown_key] returns 0 without creating an entry, and `pop(..., None)` is a no-op for missing keys, so the behavior of releasing a never-acquired id is harmless.
+
+The intra-coroutine atomicity holds because `release` is `async def` but contains no `await` — under asyncio's single-threaded scheduler, the body executes without interleaving. `release_many` iterates `for vid in video_ids` without yielding, which is fine for the bounded queue lengths in scope.
+
+**There is no auth boundary here.** A "malicious caller" implies an internal API consumer, which is also the implementer. The internal API doesn't need to defend against itself; the design defends against caller bugs (double-release / missing-release) rather than malice. **Verdict: clean.**
+
+One nit: a caller passing thousands of unique strings to `release_many` would briefly look up each in the Counter. Counter lookups don't materialize keys, so no growth. No DoS.
+
+---
+
+### 10. Tests do not leak files outside `tmp_path`; no real network
+
+**Severity**: (informational — no finding)
+**What**: `tests/test_audio_cache.py`:
+
+- `_fake_download` (line 47-57) and `_patch_download` (line 60-62) replace `ryzic.audio_cache.download` with a stub that writes deterministic bytes to `dest`. The original `ryzic.ytdlp.download` is never invoked from any cache test. Confirmed by reading every test — `download` is patched in every test that exercises a download path.
+- All cache instances are constructed with `tmp_path` (the pytest `tmp_path` fixture, function-scoped, auto-cleaned by pytest). No test writes outside `tmp_path`.
+- `test_audio_path_rejects_traversal_via_symlink` creates `cache_root / elsewhere` siblings under `tmp_path`. Both are inside the test's tmp dir.
+- No `requests`/`httpx`/`urllib.request`/`socket`/`aiohttp` import in `tests/test_audio_cache.py`. Confirmed by grep.
+
+The `test_eviction_unlink_failure_does_not_drop_row` test (line 438-474) monkey-patches `Path.unlink` globally for its `with patch.object(Path, "unlink", ...)` block. The patch's `flaky_unlink` only raises for paths matching `a.video_id` (`"aaaaaaaaaaa"` — 11 lowercase a's, definitively not a real filesystem path). Other tests in the same file are not affected because pytest-asyncio function-scoped fixtures recreate `tmp_path` per test. **Verdict: clean.**
+
+---
+
+### 11. Dependencies — aiosqlite was already pinned; no CVEs at the resolved version
+
+**Severity**: (informational — no finding)
+**What**: `aiosqlite>=0.20` was already declared in PR #1's `pyproject.toml` (audited in PR1 security review §8). PR #6 does not modify `pyproject.toml` or `uv.lock` (`git diff main..HEAD -- pyproject.toml uv.lock` produces empty output). The resolved version `aiosqlite-0.22.1` (uploaded 2025-12-23, well after the 2025 patch line) has no outstanding CVEs known as of cutoff Jan 2026. aiosqlite is a thin asyncio wrapper around the stdlib `sqlite3` module — its attack surface is the same as `sqlite3`'s, which inherits sqlite's well-tested input handling.
+
+The `aiosqlite.connect(path)` call uses a `pathlib.Path` argument; aiosqlite forwards to `sqlite3.connect`, which accepts a path string and opens the file with `O_RDWR|O_CREAT`. No URI-mode parsing (which would enable `?mode=memory&cache=shared` and similar), so an attacker who somehow controls `db_path` cannot trigger sqlite's URI-mode features. `db_path` is constructed as `cache_root / "index.sqlite"` from a config-supplied `cache_root`, not from user input — no injection vector. **Verdict: clean.**
+
+---
+
+## Summary
+
+| Severity | Count |
+| --- | ---: |
+| HIGH (merge-blocking) | 0 |
+| MEDIUM (fix soon) | 0 |
+| LOW (nit / hardening) | 4 |
+| Informational | 7 |
+
+The four LOWs:
+
+- **#3** — orphan sweep TOCTOU when an `os.replace`'d file inherits an old `mtime` (one-line `os.utime` fix; very narrow window).
+- **#4** — multi-instance sqlite contention not coordinated across processes (deploy-doc note + optional `busy_timeout` bump; M1 doesn't promise multi-instance).
+- **#6** — `cache_root` is not validated to be a real directory at startup (3-line `is_symlink` check; deferred from PR2 §8).
+- **#7** — `tmp/` orphan files are never swept (extend `sweep_orphans` ~10 lines + 1 test; availability concern over month-scale uptime).
+
+The brief's primary attack vectors — `video_id` charset bypass via traversal/unicode/encoding, in-cache symlink escape, sqlite injection, disk-fill via cap-enforcement gap, magic-byte path injection, `release_many` negative-counter, test-suite disk leakage — are **all defended**. The post-construction `Path.resolve().relative_to(cache_root.resolve())` is the load-bearing guard for path safety, and it is exercised by an explicit symlink-escape test. The "pin BEFORE evict" ordering (review §4 race) is correctly implemented and tested. SQL is fully parameterized; no string interpolation on user-controlled data anywhere.
+
+Coverage is 98% on the new module per the PR description; spot-checked a sample of branches and the 4 uncovered lines really are defensive `OSError` swallowing.
+
+## Verdict
+
+**clean** — no merge-blocking issues. The four LOWs are hardening opportunities worth opening as follow-up issues:
+
+- #3 & #6: cheap fixes, fold into the bootstrap PR (where `sweep_orphans` and `AudioCache.open()` get wired).
+- #4: deploy-doc warning before the first multi-instance deployment lands.
+- #7: 10-line extension to `sweep_orphans` next time the file is touched.
+
+The cache module is the most attack-adjacent component in M1 (it persists artifacts derived from arbitrary YouTube URLs), and the implementer has correctly threat-modeled the path-safety, eviction-race, and concurrent-download surfaces. The defense-in-depth posture (validate-then-construct-then-relative-to-check) means a single bug in any one layer is caught by the next.

--- a/docs/plans/PR6-simplify.md
+++ b/docs/plans/PR6-simplify.md
@@ -1,0 +1,525 @@
+# PR #6 Simplification Pass — `feat(cache): audio cache (sqlite-LRU + per-video lock)`
+
+**Branch:** `feat/audio-cache` -> `main`
+**Diff reviewed:** +956 LOC across 2 files (`src/ryzic/audio_cache.py` 362 LOC, `tests/test_audio_cache.py` 594 LOC).
+**Companion docs:** `docs/plans/M1-simplify.md` (locked plan-level cuts), `docs/plans/M1.md` §4 (audio cache spec) + §12 (PR3b boundary), prior `PR3-simplify.md` / `PR4-simplify.md` / `PR5-simplify.md` for tone calibration.
+
+This pass looks only for shapes that are more elaborate than M1 §4 justifies, under "three similar lines is better than a premature abstraction." It does **not** re-litigate decisions in `M1-simplify.md` (no sidecars, sqlite WAL, per-video locks deliberately leaked, `_in_use` Counter, orphan sweep with mtime guard, `release_many` for guild cleanup is in §4 spec). It does not critique correctness or security — those are other agents' lanes.
+
+Honest framing: PR6 is **mostly tight**. The core class (eviction loop, double-checked locking, atomic replace, fast lookup, sweep) is right-sized for a security-sensitive subsystem. The wins are clustered in two places: (1) `_detect_ext` is M1's biggest "do we need this?" question — the magic-byte sniff exists for a debugging aesthetic, not a runtime constraint, and `4 codecs × 6 LOC` of branches collapses if the answer is "no"; (2) the test file leans on hand-rolled scaffolding for things `pytest.parametrize` would express in half the lines. Realistic floor: **~40–80 LOC of source + ~50–80 LOC of tests**, ~10–15% of the PR. No structural rewrites; surface contract unchanged.
+
+---
+
+## Findings
+
+### S-1 — Drop `_detect_ext`; use a single `"audio"` extension everywhere
+
+**What to cut/collapse:** Delete `_detect_ext` (lines 53–73, 21 lines including docstring) and its callsite in `_download_locked` (line 199). Replace with the constant `_FALLBACK_EXT` directly:
+
+```python
+# In _download_locked, around line 199:
+final = _audio_path(self._cache_root, track.video_id, _FALLBACK_EXT)
+```
+
+Drop the per-codec branches; drop `_M4A_HEAD` / `_OPUS_HEAD` / `_WEBM_HEAD` magic byte constants from the test file (lines 28–30); drop the `test_detect_ext_recognizes_known_codecs` parameterized test (lines 8 cases) and `test_detect_ext_handles_unreadable_file` (lines ~470–490 in the test file).
+
+The PR description's own justification answers itself:
+
+> Lavalink's `LocalAudioSourceManager` sniffs the file body, so the on-disk suffix is decorative; we still want a consistent value for the sqlite `ext` column and easier debugging.
+
+**Where:** `src/ryzic/audio_cache.py` lines 39–44 (`_FALLBACK_EXT` declaration stays, comment trims), lines 53–73 (`_detect_ext` definition), line 199 (one call). `tests/test_audio_cache.py` lines 28–30, the entire `_detect_ext` test section (~30 LOC), and the `expected: "m4a"` field assertion in `test_get_or_download_miss_writes_file_and_row` (line 535 — change to `"audio"`).
+
+**Why safe:** The PR's own docstring concedes the on-disk suffix is **decorative** — Lavalink reads the file body to determine codec, and nothing in the bot's code path branches on `entries.ext`. The "easier debugging" argument is real but weak: the rare debugger case can `file <path>` once. The cost is 21 LOC of source + 4 magic-byte constants + 30 LOC of tests + a hidden coupling between `_detect_ext`'s branch coverage and `_fake_download`'s payload selection across the test suite (every eviction test had to use `_M4A_HEAD` to make `_detect_ext` choose the right ext, despite the tests not caring about ext at all).
+
+This is the single biggest "earned vs unearned complexity" call in the PR. The code reads well, but it's solving a problem that doesn't exist downstream. Per `M1-simplify.md` §10's "do less until someone asks" posture: when a future contributor needs the ext for debugging or cross-tool inspection, add it back as one branch + one test. Until then, this is yt-dlp-format-introspection that the spec didn't ask for.
+
+If the maintainer wants to keep *some* signal: keep `_FALLBACK_EXT = "audio"` as the column value, drop the sniffer.
+
+**Estimated LOC saved:** ~21 LOC src + ~30 LOC tests = **~50 LOC**, plus removes 3 magic-byte constants from the test fixture surface area.
+
+**Counter-argument considered and rejected:** "If a future PR adds a download-then-stream-to-Discord direct path, knowing the codec matters." That PR can also add the sniff in 8 lines. Building infrastructure for hypothetical future work is exactly what the M1 plan rule forbids.
+
+---
+
+### S-2 — `release_many` is a 2-line for-loop; let callers loop
+
+**What to cut/collapse:** `release_many` (lines 253–260, 8 lines including docstring) is:
+
+```python
+async def release_many(self, video_ids: Iterable[str]) -> None:
+    for vid in video_ids:
+        await self.release(vid)
+```
+
+Drop it; let `lavalink_glue.py` (PR5/PR6a future work) write:
+
+```python
+for vid in queue_video_ids:
+    await audio_cache.release(vid)
+```
+
+**Where:** `src/ryzic/audio_cache.py` lines 253–260. `tests/test_audio_cache.py` `test_release_many_decrements_each` (lines ~210–225, ~16 LOC) — drop entirely; the underlying `release` is already fully covered by `test_release_decrements_and_pops_at_zero` and `test_release_idempotent_after_zero`.
+
+**Why safe:** "Three similar lines vs premature abstraction." Currently zero callers (PR3b is cache-only; the consumers are future PRs). The helper exists *speculatively* per the PR description's "decisions worth flagging":
+
+> The per-guild cleanup hook stays guild-agnostic — cache iterates the `video_ids` it is given.
+
+— but the cache iterating vs the caller iterating is the same loop, in either spelling. A 2-line for-loop at the call site is more readable than `await cache.release_many(queue)` and saves the reader one indirection ("what does `release_many` do? oh, exactly what it sounds like"). The helper buys nothing the caller doesn't already have.
+
+Counter-argument: "What if `release_many` ever needs to do something more than the loop (batch-flush sqlite, single-pass `_in_use` mutation)?" — the cache currently has no batch-flush primitive; `release` is a memory-only mutation, so there's nothing to batch. If batching becomes necessary, the helper reappears with a non-trivial body and *earns* the name then.
+
+**Estimated LOC saved:** ~8 LOC src + ~16 LOC tests = **~24 LOC**.
+
+---
+
+### S-3 — Inline `sweep_orphans`'s separate connection; document why module-level
+
+**What to cut/collapse:** Nothing big. The module-level `sweep_orphans` placement is correct (M1 §4 specifies it's "on startup" and the PR description correctly notes "AudioCache.open() does NOT call sweep_orphans itself"); the separate aiosqlite connection is also correct because the cache may not yet be open at sweep time (or may be opened in a different lifecycle stage). **Keep the module-level shape.**
+
+But the in-function comment (lines 336–338) over-explains:
+
+```python
+# Open a separate short-lived connection: the sweep is invoked
+# at startup independently of :class:`AudioCache`, and SQLite
+# WAL allows concurrent readers without contention.
+```
+
+The "independently of AudioCache" part is the genuine WHY (placement justification). The "WAL allows concurrent readers" half restates a property the module docstring already implies and that's not load-bearing here — sweep is one-shot at startup, no concurrency to enable. Trim to:
+
+```python
+# Sweep runs at startup independently of any AudioCache instance;
+# open our own short-lived connection.
+```
+
+**Where:** `src/ryzic/audio_cache.py` lines 336–338.
+
+**Estimated LOC saved:** ~1–2 LOC. **Low conviction; cosmetic.**
+
+**Counter-considered cut and rejected:** "Make `sweep_orphans` a `@staticmethod` or `@classmethod` on `AudioCache` for namespace cohesion." The PR3b spec language ("on startup, walk audio/ directory…") doesn't bind it to the class instance, and the module-level shape lets a future CLI / cron invoke `python -c "from ryzic.audio_cache import sweep_orphans; ..."` without instantiating the cache. **Keep module-level.** Per `M1-simplify.md` §10's "demote classes to functions when they have no state" — the same logic argues for keeping a stateless function stateless.
+
+---
+
+### S-4 — `_fast_lookup` is read-only, but the wrapping is heavier than it needs to be
+
+**What to cut/collapse:** `_fast_lookup` (lines 262–280, 19 LOC including docstring) is the right shape — read-only, no mutation, returns `Path | None`. The 7-line docstring (lines 263–269) is real WHY (explains why we don't repair from this branch), so it stays.
+
+But the function's *interaction pattern* is the smell: every consumer (lines 161, 168, 182) does the same dance:
+
+```python
+hit = await self._fast_lookup(track.video_id)
+if hit is not None:
+    await self._touch(track.video_id)
+    self._in_use[track.video_id] += 1
+    return hit
+```
+
+This 4-line block appears verbatim **three times** in `get_or_download` (top-level, double-checked-locking re-check, and once on hit-after-lock). At three call sites, the "hit hookup" is the right unit to extract — not the `_fast_lookup` itself, but the *hit-finalization*:
+
+```python
+async def _finalize_hit(self, video_id: str, path: Path) -> Path:
+    """On a confirmed cache hit: touch LRU + pin + return."""
+    await self._touch(video_id)
+    self._in_use[video_id] += 1
+    return path
+```
+
+Then `get_or_download` becomes:
+
+```python
+async def get_or_download(self, track: TrackInfo) -> Path:
+    validate_video_id(track.video_id)
+    hit = await self._fast_lookup(track.video_id)
+    if hit is not None:
+        return await self._finalize_hit(track.video_id, hit)
+
+    lock = self._locks.setdefault(track.video_id, asyncio.Lock())
+    async with lock:
+        hit = await self._fast_lookup(track.video_id)
+        if hit is not None:
+            return await self._finalize_hit(track.video_id, hit)
+        return await self._download_locked(track)
+```
+
+**Where:** `src/ryzic/audio_cache.py` lines 158–186 (the `get_or_download` body); add `_finalize_hit` as a 3-line helper after `_fast_lookup`.
+
+**Why safe:** Three identical 3-line blocks ARE the "≥3 callers" threshold the maintainer's rule names. Extracting saves ~6 LOC net (3 × 4 lines duplicated → 3 × 1 line + 4-line helper) AND makes the double-checked-locking pattern's "what happens on hit" answer visible at the helper's name. Nothing changes about correctness — the order of operations is preserved (touch → pin → return). The `_fast_lookup` itself stays as-is.
+
+This is one of the few cases where the brief asks "is this earned?" and the honest answer is "the function it lives in *also* needs a small extraction to stop repeating itself."
+
+**Estimated LOC saved:** ~6 LOC src.
+
+---
+
+### S-5 — `_evict_to_fit`'s loop body is fine; cut one comment that narrates the obvious
+
+**What to cut/collapse:** `_evict_to_fit` (lines 290–317) is a clean 28-line function. The double-query (SUM first to early-exit, then full ORDER BY) is the right shape — the SUM is one row and avoids fetching candidates when not needed. The for-loop body is straightforward:
+
+```python
+for video_id, rel_path, size in candidates:
+    if total <= self._max_bytes:
+        break
+    if self._in_use.get(video_id, 0) > 0:
+        continue
+    file_path = self._cache_root / rel_path
+    try:
+        file_path.unlink(missing_ok=True)
+    except OSError:
+        _log.warning("eviction failed to unlink %s", file_path, exc_info=True)
+        continue
+    await conn.execute("DELETE FROM entries WHERE video_id = ?", (video_id,))
+    total -= int(size)
+```
+
+The brief asks "clean or convoluted?" — clean. **Keep as-is.** Each branch earns its place: the early-break is the loop's success criterion; the in-use skip is M1 §4's hard requirement; the OSError catch protects against the disk-on-fire test case (`test_eviction_unlink_failure_does_not_drop_row`); the row-DELETE only runs after unlink succeeds, preserving the "row stays so we can retry" invariant. Pulling any of these out would either lose semantic distinction or split a 12-line function into a 12-line function plus three named-but-trivial helpers.
+
+The one trim available: the `tmp_path.unlink(missing_ok=True)` comment in `_download_locked` (lines 202–203):
+
+```python
+# ``os.replace`` is atomic on the same filesystem — readers
+# never see a partial file at ``final``.
+os.replace(tmp_path, final)
+```
+
+This is a real WHY (atomicity is the load-bearing property), but the second sentence ("readers never see…") restates the first. Trim to one line:
+
+```python
+os.replace(tmp_path, final)  # atomic on the same FS — no partial reads
+```
+
+**Where:** `src/ryzic/audio_cache.py` lines 202–204.
+
+**Estimated LOC saved:** ~2 LOC. **Low conviction; cosmetic.**
+
+---
+
+### S-6 — PRAGMA bookkeeping / connection setup — `executescript` already batches
+
+**What to cut/collapse:** `open()` currently does:
+
+```python
+self._conn = await aiosqlite.connect(self._db_path)
+await self._conn.execute("PRAGMA journal_mode=WAL")
+await self._conn.execute("PRAGMA synchronous=NORMAL")
+await self._conn.executescript(_SCHEMA)
+await self._conn.commit()
+```
+
+The two PRAGMAs and the schema can be one `executescript`:
+
+```python
+self._conn = await aiosqlite.connect(self._db_path)
+await self._conn.executescript(
+    "PRAGMA journal_mode=WAL;\n"
+    "PRAGMA synchronous=NORMAL;\n"
+    + _SCHEMA
+)
+await self._conn.commit()
+```
+
+Or, if the caller prefers the PRAGMAs visible-not-buried, fold them into `_SCHEMA`'s string:
+
+```python
+_SCHEMA: Final = """
+PRAGMA journal_mode=WAL;
+PRAGMA synchronous=NORMAL;
+CREATE TABLE IF NOT EXISTS entries (
+  ...
+);
+CREATE INDEX IF NOT EXISTS entries_lru ON entries(last_used_ts);
+"""
+```
+
+The latter is cleaner — `_SCHEMA` becomes "everything to put the database in the desired state at startup," which is what the variable name already implies. The two `await self._conn.execute(...)` lines disappear.
+
+**Where:** `src/ryzic/audio_cache.py` lines 121–125 (`open` body) and lines 49–63 (`_SCHEMA` definition).
+
+**Why safe:** `aiosqlite.executescript` runs multiple statements in one round trip and commits on its own (modulo aiosqlite's autocommit handling — the explicit `commit()` afterward is harmless). PRAGMAs are statements; SQLite accepts them inside a multi-statement script the same as `CREATE TABLE`. The `test_open_sets_wal_pragmas` test (already in the suite) verifies the result, so any shape that produces the same pragmas-applied state passes unchanged.
+
+The one thing to verify in implementation: aiosqlite's `executescript` may not honor PRAGMA inside a multi-statement script with the same semantics as `execute` (some sqlite drivers strip PRAGMAs from scripts). If the test fails after the move, fall back to keeping the two `execute` lines and at least dropping the explicit `await self._conn.commit()` — `PRAGMA journal_mode=WAL` is auto-committed; `synchronous=NORMAL` is connection-scoped and doesn't need commit; only the `executescript` of `_SCHEMA` matters.
+
+**Estimated LOC saved:** ~3 LOC. **Medium conviction** — verify aiosqlite's PRAGMA-in-script behavior before committing the change.
+
+---
+
+### S-7 — Test parameterization: open-lifecycle quartet → one parameterized test
+
+**What to cut/collapse:** `test_open_creates_directories_and_schema`, `test_open_sets_wal_pragmas`, `test_open_is_idempotent_across_restarts`, `test_methods_raise_when_not_opened` are four separate functions probing four facets of `open` / `close`. Three of them (the first three) follow the same scaffold:
+
+```python
+c = AudioCache(tmp_path, max_bytes=10_000)
+await c.open()
+try:
+    # one assertion
+finally:
+    await c.close()
+```
+
+Three back-to-back, each with one assertion. Standard parameterization shape:
+
+```python
+@pytest.mark.parametrize(
+    ("check_name", "do_check"),
+    [
+        ("dirs_and_schema", _check_dirs_and_schema),
+        ("wal_pragma",      _check_wal_pragma),
+        ("idempotent_reopen", _check_idempotent_reopen),
+    ],
+)
+async def test_open_lifecycle(tmp_path, check_name, do_check):
+    c = AudioCache(tmp_path, max_bytes=10_000)
+    await c.open()
+    try:
+        await do_check(tmp_path, c)
+    finally:
+        await c.close()
+```
+
+…**but** this is one of those cases where parameterization makes the file *less* readable (named lambdas-as-fixtures, indirection between the parameter id and the actual assertion). The three tests are short enough that inline-function-per-case is also fine. **Recommend:** leave the open-lifecycle tests as-is; the duplication is structural, not behavioral, and the function names document what each pins.
+
+The `test_methods_raise_when_not_opened` is genuinely a different shape (no `open()` call), keep separate regardless.
+
+**Estimated LOC saved:** 0. **Recommend skipping** — parameterization here would be motion without progress. Test count noise is real but the four open-lifecycle tests already do four distinct jobs. (See S-8 for the parameterizations that do earn their keep.)
+
+---
+
+### S-8 — Eviction trio could parameterize the time-warp setup
+
+**What to cut/collapse:** `test_eviction_removes_oldest_first` and `test_eviction_skips_in_use_entries` (lines ~250–310) repeat the same time-warping pattern:
+
+```python
+with _patch_download(_bytes_payload(1000)):
+    path_a = await cache.get_or_download(a)
+    await cache.release(a.video_id)  # or NOT — that's the variant
+with (
+    patch("ryzic.audio_cache.time.time", return_value=time.time() + 10),
+    _patch_download(_bytes_payload(1000)),
+):
+    path_b = await cache.get_or_download(b)
+    await cache.release(b.video_id)
+with (
+    patch("ryzic.audio_cache.time.time", return_value=time.time() + 20),
+    _patch_download(_bytes_payload(1000)),
+):
+    path_c = await cache.get_or_download(c)
+```
+
+The two tests differ in **one line**: `release(a.video_id)` vs nothing. The assertion afterward differs (which file survived). A small helper extracts the time-warp + download:
+
+```python
+async def _add_track(cache, track, *, payload_bytes=1000, advance_seconds=0):
+    with (
+        patch("ryzic.audio_cache.time.time", return_value=time.time() + advance_seconds),
+        _patch_download(_bytes_payload(payload_bytes)),
+    ):
+        return await cache.get_or_download(track)
+```
+
+Each test then writes:
+
+```python
+path_a = await _add_track(cache, a)
+await cache.release(a.video_id)
+path_b = await _add_track(cache, b, advance_seconds=10)
+await cache.release(b.video_id)
+path_c = await _add_track(cache, c, advance_seconds=20)
+```
+
+**Where:** `tests/test_audio_cache.py` `test_eviction_removes_oldest_first` and `test_eviction_skips_in_use_entries` (lines ~250–340).
+
+**Why safe:** The `with patch(... time.time, return_value=time.time() + 10)` boilerplate is repeated **6+ times** in the eviction tests alone. The helper is a 5-line function that lives in the test module; both eviction tests shrink by ~5 LOC each, and a future test adding a third eviction scenario gets the same shape for free. Per the maintainer's "≥3 callers" rule — the time-warp + patched-download is a 6-caller pattern.
+
+**Estimated LOC saved:** ~10 LOC tests.
+
+---
+
+### S-9 — Drop `_fake_download(payload)` indirection; inline `_patch_download`
+
+**What to cut/collapse:** `_fake_download` (lines 84–95, 12 LOC) returns an async stub; `_patch_download` (lines 97–101, 5 LOC) wraps it in a `patch.object`. Two-layer indirection for what's a one-liner per call site:
+
+```python
+def _patch_download(payload: bytes = _M4A_HEAD * 8) -> Any:
+    async def _impl(url: str, dest: Path, *, cache_root: Path) -> None:
+        dest.write_bytes(payload)
+    return patch.object(audio_cache, "download", side_effect=_impl)
+```
+
+Drop `_fake_download` as a separate name; the inner `_impl` lives entirely inside `_patch_download`'s body. (S-1 cuts `_M4A_HEAD` too — the default becomes whatever non-empty bytes makes the test pass, e.g. `b"audio-bytes-stand-in"`.)
+
+**Where:** `tests/test_audio_cache.py` lines 84–101.
+
+**Why safe:** `_fake_download` has exactly one caller (`_patch_download`) and exists only for type symmetry with the production `download` function. Inlining loses no clarity — the closure shape is canonical for `side_effect`. Saves the named-but-trivial intermediate.
+
+**Estimated LOC saved:** ~6 LOC tests.
+
+---
+
+### S-10 — The 4 uncovered defensive `OSError` branches in `sweep_orphans` — drop the inner one
+
+**What to cut/collapse:** The PR description flags:
+
+> Coverage on the new module: **98%**. The 4 uncovered lines are defensive OSError branches in `sweep_orphans`.
+
+There are two `OSError` branches in `sweep_orphans`:
+
+1. **`mtime = file_path.stat().st_mtime`** (lines 355–358) — wrapped in try/except; on OSError, `continue` (skip this file).
+2. **`file_path.unlink()`** (lines 361–365) — wrapped in try/except; on OSError, log warning + continue.
+
+The brief asks: "defensive at internal boundary, drop?" Honest answer:
+
+- **Branch #2 (unlink failure)** has a parallel in `_evict_to_fit` (lines 312–314: also a logged-warning continue), and that one IS exercised by `test_eviction_unlink_failure_does_not_drop_row`. The cache subsystem has a consistent posture: "I/O failures during cleanup get logged and don't bring the system down." Sweep should match. **Keep #2; the audit trail matters when a cron-driven sweep silently fails.**
+- **Branch #1 (stat failure)** is the more defensive one. The file appeared in `rglob("*")` 3 lines earlier; for `stat()` to fail in those 3 lines requires concurrent deletion (another sweep, manual `rm`, or the cache's own evictor running at the same time). M1 §4 says sweep is invoked "on startup" — i.e. before `AudioCache.open()`, before any concurrent activity. The race window is real but operationally negligible; on the rare miss, the file gets re-considered next startup. **Drop the try/except** on `stat()`; let the OSError propagate. If the operator hits it, they get a clean traceback that points at the file. Saves 4 LOC.
+
+**Where:** `src/ryzic/audio_cache.py` lines 355–358.
+
+**Why safe:** Sweep is a startup-time, single-instance, best-effort cleanup. The stat-failure branch protects against a class of failures that doesn't happen in M1's deployment model (no parallel sweeps, no manual concurrent rm). The other OSError branch (unlink) protects against a different, real failure mode (read-only mount, permission rotation) and stays. Trimming the unreachable one matches the maintainer's "no half-finished features" — this defensive code never fires in practice and isn't part of any test.
+
+**Estimated LOC saved:** ~4 LOC src + drops the "98% coverage" footnote (becomes ~99%, which is its own reviewer-comfort win).
+
+---
+
+### S-11 — Comments narrating WHAT — small set, mostly already restrained
+
+**What to cut/collapse:** The source file is unusually disciplined about comments — most of what's there is real WHY (review-§4 race notes, double-checked locking, lock-leak rationale). The cuttable WHAT-narrators:
+
+- **Line 173–174** in `get_or_download`: `# Pins the entry via _in_use[video_id] += 1 BEFORE returning ...` is a docstring summary that restates what the next 4 lines visibly do. The "caller MUST release exactly once" half is real WHY and stays. Trim the first sentence; keep the contract.
+- **Line 179–180** in `get_or_download` lock branch: `# Double-checked locking — another coroutine may have finished the download while we waited on the lock.` — borderline; the term "double-checked locking" is the full WHY, but the next sentence narrates what "double-checked" means. **Borderline keep** for vocab-of-art clarity.
+- **Line 244–246** in `release`: `# Defensive: a double-release after the entry already hit zero (and was popped). Counter[key] returns 0 by default rather than raising; we simply ignore.` — this IS real WHY (explains the swallowed-no-op), keep.
+- **Line 326–327** in `sweep_orphans` docstring: `Returns the count deleted, primarily for tests.` — WHAT-restatement of the type signature. Cut "primarily for tests" (it's also the natural return for a CLI invocation).
+
+Also the per-class comments on lines 137–141 (`# Locks intentionally leaked: ...` and `# Counter (not set) ...`) are both real WHY referencing the simplify doc and review notes — **keep**.
+
+**Where:** small scattered cuts, ~4 LOC src across 3 sites.
+
+**Estimated LOC saved:** ~4 LOC. **Low conviction; cosmetic.**
+
+---
+
+### S-12 — `_audio_path`'s `relative_to` defense — keep as-is, but the test could be a doctest
+
+**What to cut/collapse:** Nothing structural. `_audio_path` (lines 76–91) is the right shape: `validate_video_id` early, `Path` construction, post-resolve `relative_to` check. The 4-line docstring is real WHY (defense-in-depth against future widening).
+
+The three tests (`test_audio_path_rejects_traversal_via_symlink`, `test_audio_path_validates_video_id_first`, `test_audio_path_layout`) cover three distinct properties — keep separate. **No cut.**
+
+**Estimated LOC saved:** 0.
+
+---
+
+### S-13 — `release` early-return uses `<= 0`, then immediately checks `<= 0` again
+
+**What to cut/collapse:** `release` (lines 236–251) is:
+
+```python
+async def release(self, video_id: str) -> None:
+    if self._in_use[video_id] <= 0:
+        self._in_use.pop(video_id, None)
+        return
+    self._in_use[video_id] -= 1
+    if self._in_use[video_id] <= 0:
+        del self._in_use[video_id]
+```
+
+The two `<= 0` checks are doing different things (early-return vs post-decrement cleanup), but the body could collapse to:
+
+```python
+async def release(self, video_id: str) -> None:
+    """Drop one in-use reference; remove the key when it hits zero."""
+    count = self._in_use[video_id] - 1
+    if count > 0:
+        self._in_use[video_id] = count
+    else:
+        # Counter[key] returns 0 by default for missing keys, so this
+        # also handles the double-release-after-zero case as a no-op.
+        self._in_use.pop(video_id, None)
+```
+
+Same semantics; one branch instead of two; the "Counter[key] returns 0" comment migrates next to the `pop` where it's load-bearing.
+
+**Where:** `src/ryzic/audio_cache.py` lines 236–251.
+
+**Why safe:** `Counter` access defaults to 0 for missing keys, so `self._in_use[video_id] - 1` is `-1` on a missing key — the `count > 0` branch correctly takes the else path, and `pop(..., None)` is a no-op on a missing key. Two distinct paths collapse to one. Net: ~3 LOC source + the docstring's "Defensive:" paragraph also collapses (the no-op is now self-documenting).
+
+**Estimated LOC saved:** ~5 LOC src.
+
+**Counter-note:** This is a pure-shape collapse and could mildly hurt readability for someone scanning for "what does `release` do on a double-release?" The current spelling makes the double-release branch explicit. Net: optional, low-conviction. If the test count flags `test_release_idempotent_after_zero` it's the right test to keep regardless.
+
+---
+
+### S-14 — Things considered and kept as-is
+
+These I considered cutting and decided not to.
+
+- **The `Counter[_in_use]` choice over `set` or `dict[str, int]`** — keep. M1 §4 spec calls it out (review §4: "Counter (not set) because the same video may be queued multiple times"). The default-zero semantics are load-bearing for `release`'s simplicity.
+- **`_locks` deliberately leaked** — keep. `M1-simplify.md` §10 keep-list locks this in.
+- **The `_FALLBACK_EXT = "audio"` constant** — keep even if S-1 lands. The `ext` column in sqlite still wants a value, and "audio" is the right one.
+- **`_ORPHAN_MIN_AGE_S` as 1 hour (Final constant)** — keep. The 4-line comment above it is real WHY (race-with-concurrent-download).
+- **`_DB_FILENAME` / `_AUDIO_SUBDIR` / `_TMP_SUBDIR` as `Final` constants** — keep. Three sites each, used in `__init__` and `sweep_orphans` and `_audio_path`. Earned. (Mirrors S-12's verdict in `PR5-simplify.md` rejecting `_PLAYLISTS_DIR` for the *opposite* reason — that one had only one production callsite.)
+- **`_require_conn` raising RuntimeError when `_conn is None`** — keep. The contract is "open before use" and surfacing the misuse with a friendly RuntimeError beats `AttributeError: 'NoneType' object has no attribute 'execute'` from inside a deeply nested async call.
+- **The double-checked locking in `get_or_download`** — keep. Canonical pattern for collapse-to-one-download under contention; the second `_fast_lookup` after lock acquisition is the price.
+- **Atomic `os.replace(tmp, final)` after download** — keep. Standard idiom; readers (the in-flight `_fast_lookup` from another coroutine) never see a half-written file at `final`.
+- **Module docstring** — keep. Every paragraph carries non-obvious WHY (the lifecycle, the in-memory state vs sqlite-as-durable-index distinction, the deliberate-no-TTL choice).
+- **`async def open` doing `mkdir(exist_ok=True)` for all three subdirs** — keep. One loop, one comment-free body, three real directories the cache requires.
+- **The `INSERT OR REPLACE INTO entries` SQL** — keep. The "OR REPLACE" is the load-bearing semantic for `test_stale_row_with_missing_file_is_repaired`.
+- **`_touch` as a separate async method** — keep. Three callers (top hit branch, lock-protected hit branch, hit-after-lock branch via S-4's `_finalize_hit`). Earns the name.
+- **Test file's `_track(...)` factory** — keep. Used by ~25 tests with per-test overrides; the factory pattern is the canonical pytest shape.
+- **`_read_one` / `_read_many` test helpers** — keep. Used by ~6 tests each; saves the `async with conn ... cur ... fetchone()` boilerplate.
+- **The path-traversal symlink test** — keep. The post-resolve `relative_to` defense IS the security boundary; the test pins it.
+- **The `test_concurrent_get_or_download_triggers_one_download` test** — keep. M1 §11 acceptance criterion #3 ("Two simultaneous /play for same URL → exactly one yt-dlp download"). Load-bearing for sign-off.
+- **`test_just_inserted_file_not_evicted_due_to_pin`** — keep. Regression for review §4 race; pinpoints a specific race condition; non-obvious from other eviction tests.
+- **`test_eviction_unlink_failure_does_not_drop_row`** — keep. Documents the "row stays, retry next time" contract.
+- **`# ---` ASCII section banners in the test file** — borderline. `PR5-simplify.md` S-8 cut these; `PR3-simplify.md` made the same call. For consistency: cut them here too (~12 LOC). But this is decoration-policy bikeshed; not in the top 3.
+
+---
+
+## Top 3 simplification wins by impact
+
+1. **S-1 — Drop `_detect_ext` magic-byte sniffing.** ~50 LOC (21 src + 30 tests + 4 magic-byte fixture constants). The PR's own docstring concedes the suffix is decorative; Lavalink reads the body. This is the single biggest "earned vs unearned" call in the PR — solves a problem (codec-aware on-disk layout for debugging) that the spec doesn't ask for. If a future contributor needs it, 8 lines + 1 test will bring it back.
+
+2. **S-2 + S-9 — Cut the speculative helpers (`release_many`, `_fake_download`).** Together ~30 LOC. Both have zero or one caller and exist for namespace tidiness rather than code reuse. The `release_many` cut is the more important one (it's a public API surface that consumers don't need); `_fake_download` is internal test scaffolding.
+
+3. **S-4 + S-8 — Targeted helper extractions where the duplication IS at threshold.** `_finalize_hit` (3-caller hit-finalization) saves ~6 LOC AND makes the double-checked locking cleaner; `_add_track` test helper saves ~10 LOC of repeated time-warp boilerplate. ~16 LOC together. The mirror of S-2: where extraction earns its keep, extract; where it doesn't, inline.
+
+---
+
+## Keep as-is
+
+- The class shape (`AudioCache` with sqlite + in-memory state) — earned per `M1-simplify.md` §10's class/function distinction.
+- `_evict_to_fit`'s loop body — clean; each branch earns its place; no extraction available without losing semantic distinction.
+- `_fast_lookup` as a read-only function — correct shape; the docstring's WHY is load-bearing.
+- `sweep_orphans` at module level (not a method) — correct per spec; lets future CLI/cron invoke without instantiating the cache.
+- `_audio_path`'s post-resolve `relative_to` defense — load-bearing security boundary.
+- The `release` body — could be collapsed (S-13) but the explicit double-release branch documents the contract; leave unless the maintainer prefers terseness.
+- The double-checked locking pattern in `get_or_download`.
+- Atomic `os.replace` after download.
+- All module-level `Final` constants (`_DB_FILENAME`, `_AUDIO_SUBDIR`, `_TMP_SUBDIR`, `_ORPHAN_MIN_AGE_S`, `_FALLBACK_EXT`).
+- The `INSERT OR REPLACE` for stale-row repair.
+- Test factory `_track(...)` and helpers `_read_one` / `_read_many`.
+- The 3 acceptance-pinning tests (concurrency, eviction-removes-oldest, eviction-skips-in-use) and the regression test for the just-inserted-file-pin race.
+- The 4-line comment above `_ORPHAN_MIN_AGE_S` (the WHY behind the magic 1h number).
+
+---
+
+## Total impact
+
+- **LOC saved (source):** ~40–50 (S-1: 21, S-2: 8, S-3: 1, S-4: −4 net after adding `_finalize_hit` helper but eliminating 3 duplicates of 4-line block ≈ 6 saved, S-5: 2, S-6: 3, S-10: 4, S-11: 4, S-13: 5).
+- **LOC saved (tests):** ~60–80 (S-1: 30, S-2: 16, S-8: 10, S-9: 6, plus banner trim ~12).
+- **Realistic merged total: ~100–130 LOC** out of +956, ~10–14%. Most of it is one judgment call (S-1: do we need ext sniffing?) plus standard "cut speculative helpers + parameterize repeated test setup" hygiene.
+- **Net file ratio:** PR drops from 362/594 (1:1.6) toward ~320/520 (1:1.6) — the test-to-source ratio stays roughly the same, which is the right answer: a security-sensitive cache subsystem with sqlite + concurrency + path safety + eviction earns its high test coverage.
+
+The brief's "test scaffolding (35 cases for 360 LOC source) — too rich?" diagnosis was *partly* right — the cache subsystem's surface (open/close, get/release, eviction with pinning, orphan sweep, path safety) genuinely needs heavy testing. The bloat is concentrated in the codec-detection branch (which S-1 dissolves entirely) and the eviction-test time-warp boilerplate (S-8). Other test groups (concurrent download, eviction acceptance, sweep age guard) are right-sized.
+
+The brief's "release_many vs callers calling release per video_id in a loop — earned helper?" diagnosis was right — not earned. The brief's "_fast_lookup read-only optimization — earned?" was wrong direction; the read-only design is correct, but the surrounding *call pattern* duplicates the "hit finalization" three times (S-4 catches the real smell). The brief's "_detect_ext — necessary?" is the load-bearing question; the answer is no, by the PR's own admission of decorative purpose.
+
+**Honest verdict:** PR6 is *mostly* tight, with one real "is this earned?" call (`_detect_ext`) and one real "speculative helper" call (`release_many`). The eviction loop, double-checked locking, atomic replace, and orphan sweep are all earned. No subsystem-level cuts; this is targeted polish + one judgment call on codec detection.
+
+---
+
+## Report
+
+(a) File saved at `/home/user/Projects/ryzic/docs/plans/PR6-simplify.md`.
+
+(b) Top 3:
+   1. S-1 — Drop `_detect_ext` magic-byte sniffing entirely (~50 LOC inc. tests + magic-byte fixture constants). PR's own docstring concedes the on-disk suffix is decorative since Lavalink sniffs the body.
+   2. S-2 + S-9 — Cut speculative helpers `release_many` and `_fake_download` (~30 LOC). Zero / one caller; the `release_many` 2-line for-loop belongs at the call site.
+   3. S-4 + S-8 — Targeted extractions where ≥3 callers genuinely duplicate: `_finalize_hit` collapses the touch+pin+return pattern in `get_or_download`; `_add_track` test helper absorbs the repeated time-warp + patched-download setup (~16 LOC).
+
+(c) Total LOC the PR could lose: **~100–130 LOC** out of +956, ~10–14%. One judgment call (codec detection) plus standard hygiene (cut speculative helpers, extract real duplication, parameterize repeated test setup). No structural rewrites; surface contract for `AudioCache` and `sweep_orphans` unchanged.


### PR DESCRIPTION
## Summary

Two related infra changes landing together as part of the migration to GitHub Issues for planning and management.

1. **Archive 18 PR review docs** (\`docs/plans/PR{N}-{review,security-review,simplify}.md\` for PRs #1–#6) as audit-trail artifacts. Future contributors can see the original critiques + how findings landed.
2. **Add issue templates** (\`.github/ISSUE_TEMPLATE/{bug_report,feature_request,chore}.yml\`) so structured forms appear when someone clicks \"New Issue\". Blank issues stay enabled.

## Why

Going forward, planning + management lives in GitHub Issues (#13 = M1, #8 = M2, etc.). The review docs are the closing-out batch of file-based review records; they belong in the repo for reference but the workflow now lives in issues.

## Test plan

- [x] Docs + GitHub config only; no code change.
- [x] All review files were on disk at PR-author time and reviewed before commit.
- [x] Issue template YAML validated locally (gh would reject malformed).