### PR TITLE
feat(commands): /play + ux + voice helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,11 @@ wheels/
 *.sqlite-wal
 *.sqlite-shm
 
+# Coverage tooling artefacts
+.coverage
+.coverage.*
+htmlcov/
+
 # Claude Code agent worktrees + task state
 .claude/
 

--- a/src/ryzic/audio_cache.py
+++ b/src/ryzic/audio_cache.py
@@ -300,6 +300,35 @@ class AudioCache:
             total -= int(size)
 
 
+# Module-level singleton: ``bot.py`` constructs the AudioCache once at
+# startup and registers it here so ``commands/play.py`` can pull it
+# without lugging it through lightbulb's DI container. Symmetric to
+# ``lavalink_glue.get_lavalink_client`` — a typed accessor returning
+# ``Optional`` keeps the "service not ready yet" path explicit at the
+# callsite rather than smothered behind a DI exception wrapper.
+_INSTANCE: AudioCache | None = None
+
+
+def set_audio_cache(cache: AudioCache | None) -> None:
+    """Install (or clear) the process-wide :class:`AudioCache` singleton.
+
+    Call once after :meth:`AudioCache.open` succeeds; pass ``None`` from
+    the shutdown path so a residual instance with a closed connection
+    cannot leak into the next test.
+    """
+    global _INSTANCE
+    _INSTANCE = cache
+
+
+def get_audio_cache() -> AudioCache | None:
+    """Return the active :class:`AudioCache`, or ``None`` before bootstrap.
+
+    Commands map ``None`` to the same friendly error as a missing
+    lavalink client: ``"Audio service is down. Try again in a minute."``
+    """
+    return _INSTANCE
+
+
 async def sweep_orphans(cache_root: Path) -> int:
     """Delete tracked-but-unreferenced audio files and stale tmp files older than 1h.
 

--- a/src/ryzic/bot.py
+++ b/src/ryzic/bot.py
@@ -12,10 +12,6 @@ from . import audio_cache, config, lavalink_glue
 
 _log = logging.getLogger(__name__)
 
-# 1 GiB in bytes — keeps the LRU cap arithmetic in a single place so the
-# eviction loop and the env-var docs read the same units.
-_BYTES_PER_GB = 1024**3
-
 
 def _build_client(bot: hikari.GatewayBot, cfg: config.Config) -> lightbulb.Client:
     client = lightbulb.client_from_app(
@@ -43,7 +39,7 @@ async def _bootstrap_audio_cache(cfg: config.Config) -> audio_cache.AudioCache:
     have left partial files in ``tmp/`` and orphaned audio files
     whose sqlite rows never made it to disk. Cheap once per boot.
     """
-    cache = audio_cache.AudioCache(cfg.cache_dir, max_bytes=cfg.cache_max_gb * _BYTES_PER_GB)
+    cache = audio_cache.AudioCache(cfg.cache_dir, max_bytes=cfg.cache_max_gb * 1024**3)
     await cache.open()
     deleted = await audio_cache.sweep_orphans(cfg.cache_dir)
     if deleted:

--- a/src/ryzic/bot.py
+++ b/src/ryzic/bot.py
@@ -8,9 +8,13 @@ import dotenv
 import hikari
 import lightbulb
 
-from . import config, lavalink_glue
+from . import audio_cache, config, lavalink_glue
 
 _log = logging.getLogger(__name__)
+
+# 1 GiB in bytes — keeps the LRU cap arithmetic in a single place so the
+# eviction loop and the env-var docs read the same units.
+_BYTES_PER_GB = 1024**3
 
 
 def _build_client(bot: hikari.GatewayBot, cfg: config.Config) -> lightbulb.Client:
@@ -32,6 +36,22 @@ def _build_client(bot: hikari.GatewayBot, cfg: config.Config) -> lightbulb.Clien
     return client
 
 
+async def _bootstrap_audio_cache(cfg: config.Config) -> audio_cache.AudioCache:
+    """Open the audio cache + run the orphan sweep before the bot serves traffic.
+
+    The sweep runs unconditionally on startup: a previous crash may
+    have left partial files in ``tmp/`` and orphaned audio files
+    whose sqlite rows never made it to disk. Cheap once per boot.
+    """
+    cache = audio_cache.AudioCache(cfg.cache_dir, max_bytes=cfg.cache_max_gb * _BYTES_PER_GB)
+    await cache.open()
+    deleted = await audio_cache.sweep_orphans(cfg.cache_dir)
+    if deleted:
+        _log.info("startup orphan sweep removed %d files", deleted)
+    audio_cache.set_audio_cache(cache)
+    return cache
+
+
 def main() -> None:
     dotenv.load_dotenv()
     cfg = config.load()
@@ -49,14 +69,27 @@ def main() -> None:
     client = _build_client(bot, cfg)
     lavalink_glue.register_listeners(bot, cfg)
 
+    cache: audio_cache.AudioCache | None = None
+
     async def _on_starting(_: hikari.StartingEvent) -> None:
+        nonlocal cache
+        # Audio cache must be ready BEFORE /play runs — start it before
+        # syncing the slash commands so a fast user invocation can
+        # never race the bootstrap.
+        cache = await _bootstrap_audio_cache(cfg)
         # Extensions register commands; commands are synced inside
         # ``client.start``, so load before starting.
-        await client.load_extensions("ryzic.commands.lltest")
+        await client.load_extensions("ryzic.commands.lltest", "ryzic.commands.play")
         await client.start()
 
+    async def _on_stopping(_: hikari.StoppingEvent) -> None:
+        await client.stop()
+        if cache is not None:
+            audio_cache.set_audio_cache(None)
+            await cache.close()
+
     bot.subscribe(hikari.StartingEvent, _on_starting)
-    bot.subscribe(hikari.StoppingEvent, client.stop)
+    bot.subscribe(hikari.StoppingEvent, _on_stopping)
 
     bot.run()
 

--- a/src/ryzic/commands/play.py
+++ b/src/ryzic/commands/play.py
@@ -1,28 +1,13 @@
 """``/play`` slash command (M1 §3).
 
-Single source of truth for all the URL → playback wiring. The handler:
+Single source of truth for all the URL → playback wiring. Friendly
+error sentences come VERBATIM from the wrapper exceptions (M1 §6
+fixed those to be user-presentable); we never re-translate them.
 
-1. Defers the response (public, since success embeds are public).
-2. Validates the URL via :func:`ryzic.url_validator.is_supported_url`.
-3. Detects whether the URL is a playlist (``list=`` query param) and
-   resolves metadata via either :func:`ryzic.ytdlp.resolve_track` or
-   :func:`ryzic.playlist_cache.fetch_with_fallback` accordingly.
-4. Verifies voice prerequisites: invoker is in a voice channel, the
-   channel is not a stage, the bot is not pinned in another channel,
-   the lavalink + audio cache singletons are bootstrapped, the queue
-   has capacity for the new tracks.
-5. Connects via ``bot.update_voice_state`` and waits for the voice
-   handshake (handled by ``lavalink_glue.wait_for_voice_ready``) before
-   touching the player.
-6. Per track: downloads via :class:`ryzic.audio_cache.AudioCache`,
-   loads via Lavalink's ``LocalAudioSourceManager``, calls
-   ``player.add``. Releases the audio cache pin on load failure so
-   eviction stays unblocked.
-7. Calls ``player.play()`` only when the player wasn't already playing.
-
-All friendly error sentences come VERBATIM from the wrapper exceptions
-(M1 §6 fixed those to be user-presentable). The handler never rewrites
-them; that contract keeps the failure surface understandable.
+Order of operations is deliberately load-then-connect: voice is only
+joined once we have a playable track. Otherwise a yt-dlp / Lavalink
+load failure leaves the bot squatting in voice with no auto-leave
+arming (only ``QueueEndEvent`` arms it, and nothing ever played).
 """
 
 from __future__ import annotations
@@ -51,6 +36,12 @@ _QUEUE_CAP: int = 500
 # command-side guard exists so we can map "the gateway never confirmed"
 # to a friendly ephemeral rather than an opaque ``RuntimeError``.
 _VOICE_READY_TIMEOUT_S: float = 5.0
+
+# M1 §3: a single user-facing string covers every "the audio plumbing
+# isn't ready" failure (missing cache, missing lavalink client, no
+# available nodes, voice handshake timeout). Users don't distinguish
+# the layers — and a single string keeps the failure surface small.
+_AUDIO_SERVICE_DOWN: str = "Audio service is down. Try again in a minute."
 
 
 @loader.command
@@ -101,18 +92,41 @@ async def _handle_play(ctx: lightbulb.Context, url: str) -> None:
     # missing client. Both surface as the same friendly message — users
     # don't care which layer is asleep.
     if cache is None or ll_client is None or not ll_client.node_manager.available_nodes:
+        await ctx.respond(_AUDIO_SERVICE_DOWN, ephemeral=True)
+        return
+
+    bot = cast(hikari.GatewayBot, ctx.client.app)
+    user_state = bot.cache.get_voice_state(guild_id, ctx.user.id)
+    if user_state is None or user_state.channel_id is None:
+        await ctx.respond("Join a voice channel first.", ephemeral=True)
+        return
+    user_channel_id = int(user_state.channel_id)
+
+    user_channel = bot.cache.get_guild_channel(user_channel_id)
+    # ``get_guild_channel`` returns ``None`` if the channel isn't in
+    # the cache (e.g. recently created). Treating an unknown channel
+    # type as "not stage" preserves the old behaviour rather than
+    # blocking legitimate /play attempts on cold caches.
+    if user_channel is not None and user_channel.type == hikari.ChannelType.GUILD_STAGE:
         await ctx.respond(
-            "Audio service is down. Try again in a minute.",
+            "Stage channels aren't supported. Use a regular voice channel.",
             ephemeral=True,
         )
         return
 
-    bot = cast(hikari.GatewayBot, ctx.client.app)
-    voice_check = _check_voice_state(bot, guild_id, ctx.user.id)
-    if isinstance(voice_check, str):
-        await ctx.respond(voice_check, ephemeral=True)
-        return
-    user_channel_id = voice_check
+    me = bot.get_me()
+    if me is not None:
+        bot_state = bot.cache.get_voice_state(guild_id, me.id)
+        if (
+            bot_state is not None
+            and bot_state.channel_id is not None
+            and int(bot_state.channel_id) != user_channel_id
+        ):
+            await ctx.respond(
+                f"I'm already playing in <#{int(bot_state.channel_id)}>. Join that channel.",
+                ephemeral=True,
+            )
+            return
 
     # Track the channel before the long async work below so a
     # TrackException firing mid-load posts back to the right place.
@@ -124,39 +138,6 @@ async def _handle_play(ctx: lightbulb.Context, url: str) -> None:
         await _play_single(ctx, url, cache, ll_client, bot, guild_id, user_channel_id)
 
 
-def _check_voice_state(bot: hikari.GatewayBot, guild_id: int, user_id: int) -> int | str:
-    """Return the user's voice channel id, or an ephemeral error string.
-
-    Encodes all the precondition checks that don't depend on the
-    yt-dlp resolution: user must be in voice, the channel must be
-    non-stage, and the bot (if already in voice) must be in the
-    same channel.
-    """
-    user_state = bot.cache.get_voice_state(guild_id, user_id)
-    if user_state is None or user_state.channel_id is None:
-        return "Join a voice channel first."
-
-    user_channel_id = int(user_state.channel_id)
-    user_channel = bot.cache.get_guild_channel(user_channel_id)
-    # ``get_guild_channel`` returns ``None`` if the channel isn't in
-    # the cache (e.g. recently created). Treating an unknown channel
-    # type as "not stage" preserves the old behaviour rather than
-    # blocking legitimate /play attempts on cold caches.
-    if user_channel is not None and user_channel.type == hikari.ChannelType.GUILD_STAGE:
-        return "Stage channels aren't supported. Use a regular voice channel."
-
-    me = bot.get_me()
-    if me is not None:
-        bot_state = bot.cache.get_voice_state(guild_id, me.id)
-        if (
-            bot_state is not None
-            and bot_state.channel_id is not None
-            and int(bot_state.channel_id) != user_channel_id
-        ):
-            return f"I'm already playing in <#{int(bot_state.channel_id)}>. Join that channel."
-    return user_channel_id
-
-
 def _is_playlist_url(url: str) -> bool:
     """Detect whether ``url`` carries a YouTube playlist id (``list=`` query)."""
     try:
@@ -164,20 +145,6 @@ def _is_playlist_url(url: str) -> bool:
     except ValueError:
         return False
     return "list" in parse_qs(parsed.query)
-
-
-async def _connect_and_wait(
-    bot: hikari.GatewayBot,
-    guild_id: int,
-    channel_id: int,
-) -> bool:
-    """Drive ``update_voice_state`` and block on the lavalink handshake.
-
-    Returns ``False`` on handshake timeout — the caller maps that to a
-    friendly ephemeral.
-    """
-    await bot.update_voice_state(guild_id, channel_id, self_deaf=True)
-    return await lavalink_glue.wait_for_voice_ready(guild_id, timeout=_VOICE_READY_TIMEOUT_S)
 
 
 async def _load_one(
@@ -223,15 +190,7 @@ async def _load_one(
         await cache.release(track_info.video_id)
         _log.warning("lavalink returned no tracks for %s", path)
         return None
-    track = result.tracks[0]
-    if isinstance(track, lavalink.DeferredAudioTrack):
-        # ``LocalAudioSourceManager`` shouldn't ever surface deferred
-        # tracks, but the union return type covers it; the Lavalink
-        # encoded payload is what player.add ultimately needs.
-        await cache.release(track_info.video_id)
-        _log.warning("lavalink unexpectedly returned a DeferredAudioTrack for %s", path)
-        return None
-    return track
+    return result.tracks[0]
 
 
 async def _play_single(
@@ -258,19 +217,21 @@ async def _play_single(
         )
         return
 
-    if not await _connect_and_wait(bot, guild_id, channel_id):
-        await ctx.respond(
-            "Couldn't connect to the voice channel. Try again in a moment.",
-            ephemeral=True,
-        )
-        return
-
+    # Load BEFORE connecting to voice — otherwise a load failure leaves
+    # the bot dangling in voice with no auto-leave (the timer only arms
+    # on QueueEndEvent, which needs a successful play).
     audio_track = await _load_one(cache, ll_client, track_info)
     if audio_track is None:
         await ctx.respond(
             "Could not load that track. Try a different URL.",
             ephemeral=True,
         )
+        return
+
+    await bot.update_voice_state(guild_id, channel_id, self_deaf=True)
+    if not await lavalink_glue.wait_for_voice_ready(guild_id, timeout=_VOICE_READY_TIMEOUT_S):
+        await cache.release(track_info.video_id)
+        await ctx.respond(_AUDIO_SERVICE_DOWN, ephemeral=True)
         return
 
     was_playing = player.is_playing
@@ -321,32 +282,44 @@ async def _play_playlist(
         )
         return
 
-    if not await _connect_and_wait(bot, guild_id, channel_id):
-        await ctx.respond(
-            "Couldn't connect to the voice channel. Try again in a moment.",
-            ephemeral=True,
-        )
-        return
+    # Load the first track BEFORE connecting to voice — otherwise a
+    # playlist where every entry fails leaves the bot dangling in voice
+    # (auto-leave only arms on QueueEndEvent, never reached here).
+    # Search forward for the first loadable entry to keep the friendly
+    # error semantically equivalent to the post-loop "all-fail" path.
+    first_index = -1
+    first_audio_track: lavalink.AudioTrack | None = None
+    for i, entry in enumerate(info.entries):
+        first_audio_track = await _load_one(cache, ll_client, entry)
+        if first_audio_track is not None:
+            first_index = i
+            break
 
-    was_playing = player.is_playing
-    enqueued = 0
-    for entry in info.entries:
-        audio_track = await _load_one(cache, ll_client, entry)
-        if audio_track is None:
-            continue
-        player.add(track=audio_track, requester=ctx.user.id)
-        enqueued += 1
-        if enqueued == 1 and not was_playing:
-            # Start playback as soon as the first track is enqueued so
-            # the user hears music while we keep loading the rest.
-            await player.play()
-
-    if enqueued == 0:
+    if first_audio_track is None:
         await ctx.respond(
             "Could not load any tracks from that playlist.",
             ephemeral=True,
         )
         return
+
+    await bot.update_voice_state(guild_id, channel_id, self_deaf=True)
+    if not await lavalink_glue.wait_for_voice_ready(guild_id, timeout=_VOICE_READY_TIMEOUT_S):
+        await cache.release(info.entries[first_index].video_id)
+        await ctx.respond(_AUDIO_SERVICE_DOWN, ephemeral=True)
+        return
+
+    was_playing = player.is_playing
+    player.add(track=first_audio_track, requester=ctx.user.id)
+    if not was_playing:
+        await player.play()
+    enqueued = 1
+
+    for entry in info.entries[first_index + 1 :]:
+        audio_track = await _load_one(cache, ll_client, entry)
+        if audio_track is None:
+            continue
+        player.add(track=audio_track, requester=ctx.user.id)
+        enqueued += 1
 
     cache_is_stale = used_cache and playlist_cache.is_stale(fetched_at)
     embed = ux.build_queued_playlist_embed(

--- a/src/ryzic/commands/play.py
+++ b/src/ryzic/commands/play.py
@@ -1,0 +1,371 @@
+"""``/play`` slash command (M1 §3).
+
+Single source of truth for all the URL → playback wiring. The handler:
+
+1. Defers the response (public, since success embeds are public).
+2. Validates the URL via :func:`ryzic.url_validator.is_supported_url`.
+3. Detects whether the URL is a playlist (``list=`` query param) and
+   resolves metadata via either :func:`ryzic.ytdlp.resolve_track` or
+   :func:`ryzic.playlist_cache.fetch_with_fallback` accordingly.
+4. Verifies voice prerequisites: invoker is in a voice channel, the
+   channel is not a stage, the bot is not pinned in another channel,
+   the lavalink + audio cache singletons are bootstrapped, the queue
+   has capacity for the new tracks.
+5. Connects via ``bot.update_voice_state`` and waits for the voice
+   handshake (handled by ``lavalink_glue.wait_for_voice_ready``) before
+   touching the player.
+6. Per track: downloads via :class:`ryzic.audio_cache.AudioCache`,
+   loads via Lavalink's ``LocalAudioSourceManager``, calls
+   ``player.add``. Releases the audio cache pin on load failure so
+   eviction stays unblocked.
+7. Calls ``player.play()`` only when the player wasn't already playing.
+
+All friendly error sentences come VERBATIM from the wrapper exceptions
+(M1 §6 fixed those to be user-presentable). The handler never rewrites
+them; that contract keeps the failure surface understandable.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import cast
+from urllib.parse import parse_qs, urlparse
+
+import hikari
+import lavalink
+import lightbulb
+
+from .. import audio_cache, lavalink_glue, playlist_cache, ux, ytdlp
+from ..errors import FetchFailed, InvalidVideoID
+from ..url_validator import is_supported_url
+
+_log = logging.getLogger(__name__)
+
+loader = lightbulb.Loader()
+
+# Per M1 §3: cap the per-guild queue at 500 tracks. Enforced before
+# ``player.add`` so a giant playlist cannot silently displace the cap.
+_QUEUE_CAP: int = 500
+
+# Voice handshake timeout — also enforced inside lavalink_glue, but the
+# command-side guard exists so we can map "the gateway never confirmed"
+# to a friendly ephemeral rather than an opaque ``RuntimeError``.
+_VOICE_READY_TIMEOUT_S: float = 5.0
+
+
+@loader.command
+class Play(
+    lightbulb.SlashCommand,
+    name="play",
+    description="Queue a YouTube track or playlist URL.",
+    # ``contexts=[GUILD]`` is the lightbulb v3 / Discord-API replacement
+    # for the v2 ``dm_enabled=False``: the command is hidden from DMs
+    # at the slash-command picker level. The guild_id None guard inside
+    # the handler is the defense-in-depth layer for misconfigurations.
+    contexts=[hikari.ApplicationContextType.GUILD],
+):
+    url = lightbulb.string(
+        "url",
+        "YouTube video or playlist URL.",
+        min_length=1,
+        max_length=500,
+    )
+
+    @lightbulb.invoke
+    async def invoke(self, ctx: lightbulb.Context) -> None:
+        await ctx.defer()
+        await _handle_play(ctx, self.url)
+
+
+async def _handle_play(ctx: lightbulb.Context, url: str) -> None:
+    """Run the full /play flow. Errors are caught and rendered ephemerally.
+
+    Pulled out of the command class so tests can drive the same logic
+    without going through lightbulb's invocation machinery.
+    """
+    guild_id = ctx.guild_id
+    if guild_id is None:
+        # ``contexts=[GUILD]`` should already prevent this, but if a
+        # future re-registration drops the constraint we fail safe.
+        await ctx.respond("Run /play in a server.", ephemeral=True)
+        return
+
+    if not is_supported_url(url):
+        await ctx.respond("Only YouTube URLs are supported.", ephemeral=True)
+        return
+
+    cache = audio_cache.get_audio_cache()
+    ll_client = lavalink_glue.get_lavalink_client()
+    # Empty ``available_nodes`` distinguishes "lavalink client constructed
+    # but socket isn't open yet" (early boot, server restart) from a fully
+    # missing client. Both surface as the same friendly message — users
+    # don't care which layer is asleep.
+    if cache is None or ll_client is None or not ll_client.node_manager.available_nodes:
+        await ctx.respond(
+            "Audio service is down. Try again in a minute.",
+            ephemeral=True,
+        )
+        return
+
+    bot = cast(hikari.GatewayBot, ctx.client.app)
+    voice_check = _check_voice_state(bot, guild_id, ctx.user.id)
+    if isinstance(voice_check, str):
+        await ctx.respond(voice_check, ephemeral=True)
+        return
+    user_channel_id = voice_check
+
+    # Track the channel before the long async work below so a
+    # TrackException firing mid-load posts back to the right place.
+    lavalink_glue.last_play_channel[guild_id] = int(ctx.channel_id)
+
+    if _is_playlist_url(url):
+        await _play_playlist(ctx, url, cache, ll_client, bot, guild_id, user_channel_id)
+    else:
+        await _play_single(ctx, url, cache, ll_client, bot, guild_id, user_channel_id)
+
+
+def _check_voice_state(bot: hikari.GatewayBot, guild_id: int, user_id: int) -> int | str:
+    """Return the user's voice channel id, or an ephemeral error string.
+
+    Encodes all the precondition checks that don't depend on the
+    yt-dlp resolution: user must be in voice, the channel must be
+    non-stage, and the bot (if already in voice) must be in the
+    same channel.
+    """
+    user_state = bot.cache.get_voice_state(guild_id, user_id)
+    if user_state is None or user_state.channel_id is None:
+        return "Join a voice channel first."
+
+    user_channel_id = int(user_state.channel_id)
+    user_channel = bot.cache.get_guild_channel(user_channel_id)
+    # ``get_guild_channel`` returns ``None`` if the channel isn't in
+    # the cache (e.g. recently created). Treating an unknown channel
+    # type as "not stage" preserves the old behaviour rather than
+    # blocking legitimate /play attempts on cold caches.
+    if user_channel is not None and user_channel.type == hikari.ChannelType.GUILD_STAGE:
+        return "Stage channels aren't supported. Use a regular voice channel."
+
+    me = bot.get_me()
+    if me is not None:
+        bot_state = bot.cache.get_voice_state(guild_id, me.id)
+        if (
+            bot_state is not None
+            and bot_state.channel_id is not None
+            and int(bot_state.channel_id) != user_channel_id
+        ):
+            return f"I'm already playing in <#{int(bot_state.channel_id)}>. Join that channel."
+    return user_channel_id
+
+
+def _is_playlist_url(url: str) -> bool:
+    """Detect whether ``url`` carries a YouTube playlist id (``list=`` query)."""
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    return "list" in parse_qs(parsed.query)
+
+
+async def _connect_and_wait(
+    bot: hikari.GatewayBot,
+    guild_id: int,
+    channel_id: int,
+) -> bool:
+    """Drive ``update_voice_state`` and block on the lavalink handshake.
+
+    Returns ``False`` on handshake timeout — the caller maps that to a
+    friendly ephemeral.
+    """
+    await bot.update_voice_state(guild_id, channel_id, self_deaf=True)
+    return await lavalink_glue.wait_for_voice_ready(guild_id, timeout=_VOICE_READY_TIMEOUT_S)
+
+
+async def _load_one(
+    cache: audio_cache.AudioCache,
+    ll_client: lavalink.Client,
+    track_info: ytdlp.TrackInfo,
+) -> lavalink.AudioTrack | None:
+    """Download ``track_info`` and ask Lavalink for its AudioTrack.
+
+    Returns ``None`` on any failure (yt-dlp error, lavalink LOAD_FAILED,
+    lavalink EMPTY). Releases the audio cache pin on lavalink failure
+    so a transient load problem cannot permanently block eviction
+    (M1 §4 release contract).
+    """
+    try:
+        path = await cache.get_or_download(track_info)
+    except (FetchFailed, InvalidVideoID) as exc:
+        _log.warning("yt-dlp download failed for %s: %s", track_info.url, exc)
+        return None
+
+    nodes = list(ll_client.node_manager.nodes)
+    if not nodes:
+        await cache.release(track_info.video_id)
+        _log.warning("no lavalink nodes available; dropping %s", track_info.url)
+        return None
+
+    try:
+        result = await nodes[0].get_tracks(str(path))
+    except Exception:
+        await cache.release(track_info.video_id)
+        _log.exception("lavalink get_tracks failed for %s", path)
+        return None
+
+    if result.load_type == lavalink.server.LoadType.ERROR:
+        await cache.release(track_info.video_id)
+        _log.warning(
+            "lavalink load error for %s: %s",
+            path,
+            result.error if result.error else "unknown",
+        )
+        return None
+    if not result.tracks:
+        await cache.release(track_info.video_id)
+        _log.warning("lavalink returned no tracks for %s", path)
+        return None
+    track = result.tracks[0]
+    if isinstance(track, lavalink.DeferredAudioTrack):
+        # ``LocalAudioSourceManager`` shouldn't ever surface deferred
+        # tracks, but the union return type covers it; the Lavalink
+        # encoded payload is what player.add ultimately needs.
+        await cache.release(track_info.video_id)
+        _log.warning("lavalink unexpectedly returned a DeferredAudioTrack for %s", path)
+        return None
+    return track
+
+
+async def _play_single(
+    ctx: lightbulb.Context,
+    url: str,
+    cache: audio_cache.AudioCache,
+    ll_client: lavalink.Client,
+    bot: hikari.GatewayBot,
+    guild_id: int,
+    channel_id: int,
+) -> None:
+    """Resolve + enqueue a single track URL."""
+    try:
+        track_info = await ytdlp.resolve_track(url, cache_root=cache.cache_root)
+    except FetchFailed as exc:
+        await ctx.respond(_friendly_message(exc), ephemeral=True)
+        return
+
+    player = ll_client.player_manager.create(guild_id=guild_id)
+    if len(player.queue) + 1 > _QUEUE_CAP:
+        await ctx.respond(
+            f"Queue is full ({len(player.queue)}/{_QUEUE_CAP}). Wait for some tracks to finish.",
+            ephemeral=True,
+        )
+        return
+
+    if not await _connect_and_wait(bot, guild_id, channel_id):
+        await ctx.respond(
+            "Couldn't connect to the voice channel. Try again in a moment.",
+            ephemeral=True,
+        )
+        return
+
+    audio_track = await _load_one(cache, ll_client, track_info)
+    if audio_track is None:
+        await ctx.respond(
+            "Could not load that track. Try a different URL.",
+            ephemeral=True,
+        )
+        return
+
+    was_playing = player.is_playing
+    queue_len_before = len(player.queue)
+    player.add(track=audio_track, requester=ctx.user.id)
+    if not was_playing:
+        await player.play()
+
+    # ``position`` is 1-indexed; new track sits at queue_len_before + 1
+    # when something was already playing, otherwise it's been pulled
+    # out of the queue and is the current track ("playing now").
+    embed = ux.build_queued_track_embed(
+        track_info,
+        position=queue_len_before + 1,
+        playing_now=not was_playing,
+    )
+    await ctx.respond(embed=embed)
+
+
+async def _play_playlist(
+    ctx: lightbulb.Context,
+    url: str,
+    cache: audio_cache.AudioCache,
+    ll_client: lavalink.Client,
+    bot: hikari.GatewayBot,
+    guild_id: int,
+    channel_id: int,
+) -> None:
+    """Resolve playlist metadata, enqueue every track, then respond."""
+    try:
+        info, fetched_at, used_cache = await playlist_cache.fetch_with_fallback(
+            url, cache_root=cache.cache_root
+        )
+    except FetchFailed as exc:
+        await ctx.respond(_friendly_message(exc), ephemeral=True)
+        return
+
+    if not info.entries:
+        await ctx.respond("That playlist is empty or private.", ephemeral=True)
+        return
+
+    player = ll_client.player_manager.create(guild_id=guild_id)
+    incoming = len(info.entries)
+    if len(player.queue) + incoming > _QUEUE_CAP:
+        await ctx.respond(
+            f"Queue is full ({len(player.queue)}/{_QUEUE_CAP}). Wait for some tracks to finish.",
+            ephemeral=True,
+        )
+        return
+
+    if not await _connect_and_wait(bot, guild_id, channel_id):
+        await ctx.respond(
+            "Couldn't connect to the voice channel. Try again in a moment.",
+            ephemeral=True,
+        )
+        return
+
+    was_playing = player.is_playing
+    enqueued = 0
+    for entry in info.entries:
+        audio_track = await _load_one(cache, ll_client, entry)
+        if audio_track is None:
+            continue
+        player.add(track=audio_track, requester=ctx.user.id)
+        enqueued += 1
+        if enqueued == 1 and not was_playing:
+            # Start playback as soon as the first track is enqueued so
+            # the user hears music while we keep loading the rest.
+            await player.play()
+
+    if enqueued == 0:
+        await ctx.respond(
+            "Could not load any tracks from that playlist.",
+            ephemeral=True,
+        )
+        return
+
+    cache_is_stale = used_cache and playlist_cache.is_stale(fetched_at)
+    embed = ux.build_queued_playlist_embed(
+        info,
+        requester=ctx.user.username,
+        used_cache=used_cache,
+        fetched_at=fetched_at if used_cache else None,
+        cache_is_stale=cache_is_stale,
+        failed_count=incoming - enqueued,
+    )
+    await ctx.respond(embed=embed)
+
+
+def _friendly_message(exc: FetchFailed) -> str:
+    """Return the first arg of ``exc`` as a user-facing string.
+
+    yt-dlp errors are pre-mapped to friendly sentences inside
+    :mod:`ryzic.ytdlp` (M1 §6); we never re-translate them here.
+    """
+    if exc.args and isinstance(exc.args[0], str) and exc.args[0]:
+        return exc.args[0]
+    return "Could not load that URL."

--- a/src/ryzic/lavalink_glue.py
+++ b/src/ryzic/lavalink_glue.py
@@ -50,7 +50,7 @@ import hikari
 import lavalink
 from lavalink.common import VoiceServerUpdatePayload, VoiceStateUpdatePayload
 
-from . import config
+from . import audio_cache, config
 
 _log = logging.getLogger(__name__)
 
@@ -178,6 +178,30 @@ def _track_title(track: lavalink.AudioTrack | None) -> str:
     return track.title if track is not None else "<unknown>"
 
 
+async def _release_track(track: lavalink.AudioTrack | None) -> None:
+    """Drop the audio cache pin for ``track`` if a cache + identifier exist.
+
+    No-ops when the cache hasn't been bootstrapped yet (test harnesses
+    without a cache, early shutdown order) or when the track has no
+    identifier (Lavalink occasionally surfaces ``None`` after a
+    failed-decode TrackEndEvent — release would do nothing useful).
+    """
+    if track is None:
+        return
+    cache = audio_cache.get_audio_cache()
+    if cache is None:
+        return
+    identifier = getattr(track, "identifier", None)
+    if not identifier:
+        return
+    try:
+        await cache.release(identifier)
+    except Exception:
+        # Releasing should never raise; log + swallow rather than letting
+        # the lavalink event hook take down the player loop.
+        _log.exception("failed to release audio cache entry %s", identifier)
+
+
 def _safe_error_text(text: str | None) -> str:
     """Sanitise server-supplied error text before posting to a public channel.
 
@@ -220,12 +244,7 @@ class EventHandler:
             _track_title(event.track),
             event.reason,
         )
-        # NOTE (PR6a wires this up): release audio cache reference for the
-        # finished track. Hook shape:
-        #   if track is not None:
-        #       await audio_cache.release(track.identifier)
-        # PR3b's audio_cache module does not exist yet, so importing it here
-        # would create a circular dependency on an unwritten file.
+        await _release_track(event.track)
 
         # NEVER call player.play() here; the default player auto-advances
         # the queue and a manual play() races into Lavalink.py#153.
@@ -241,8 +260,7 @@ class EventHandler:
             event.severity,
             event.cause,
         )
-        # TODO(PR6a): await audio_cache.release(track.identifier) on the
-        # ended track — same rationale as TrackEndEvent.
+        await _release_track(event.track)
         # ``event.cause`` is a JVM stack trace; ``message`` is a short cause
         # description. Prefer ``message`` and never the full ``cause`` —
         # both are sanitised regardless.

--- a/src/ryzic/lavalink_glue.py
+++ b/src/ryzic/lavalink_glue.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from pathlib import Path
 from typing import cast
 
 import hikari
@@ -95,8 +96,14 @@ async def wait_for_voice_ready(guild_id: int, timeout: float = VOICE_READY_TIMEO
     timeout. Callers should treat ``False`` as "abort the play attempt and
     surface a friendly error" rather than retrying — the gateway timed out,
     not a transient race.
+
+    The event is cleared up-front so a stale "ready" from a prior session
+    cannot return True instantly: a channel move from A → B (both non-None)
+    leaves the old event set, but lavalink.py won't see the new
+    VOICE_SERVER_UPDATE for B until the setter re-fires.
     """
     event = _voice_ready_events.setdefault(guild_id, asyncio.Event())
+    event.clear()
     try:
         await asyncio.wait_for(event.wait(), timeout=timeout)
     except TimeoutError:
@@ -194,12 +201,18 @@ async def _release_track(track: lavalink.AudioTrack | None) -> None:
     identifier = getattr(track, "identifier", None)
     if not identifier:
         return
+    # ``LocalAudioSourceManager`` populates ``AudioTrackInfo.identifier``
+    # with the file path we passed to ``node.get_tracks(...)`` — e.g.
+    # ``/var/cache/ryzic/audio/dQ/dQw4w9WgXcQ.audio``. The cache pins
+    # by ``video_id``, so we strip the path components to recover it
+    # (file stem == video_id by construction in ``audio_cache._audio_path``).
+    video_id = Path(identifier).stem
     try:
-        await cache.release(identifier)
+        await cache.release(video_id)
     except Exception:
         # Releasing should never raise; log + swallow rather than letting
         # the lavalink event hook take down the player loop.
-        _log.exception("failed to release audio cache entry %s", identifier)
+        _log.exception("failed to release audio cache entry %s", video_id)
 
 
 def _safe_error_text(text: str | None) -> str:

--- a/src/ryzic/ux.py
+++ b/src/ryzic/ux.py
@@ -1,0 +1,169 @@
+"""Embed builders + safe-formatting helpers for slash command responses.
+
+Per M1 §3, every embed must defend against two failure modes:
+
+1. **Markdown injection.** Track titles and uploader names come from
+   yt-dlp; a hostile string can include ``**bold**``, ``[anchor](url)``,
+   or backtick fences that derail the embed format. :func:`escape_markdown`
+   backslash-escapes the Discord-relevant control chars before any string
+   is interpolated into a markdown template.
+
+2. **Discord length limits.** Description ≤ 4096, footer ≤ 2048,
+   field ≤ 1024. :func:`safe_truncate` clips at a code-point boundary
+   (``str`` slicing is already code-point safe in Python 3) and appends
+   ``…`` so users see that something was cut.
+
+The builders deliberately produce *unmodified* :class:`hikari.Embed`
+instances rather than dict payloads — the caller forwards them to
+:meth:`lightbulb.Context.respond` directly. Strings that don't appear in
+an embed (the one-shot ephemerals like ``"Join a voice channel first."``)
+live at the call site for locality of reference (M1 §3 cross-cutting).
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+import hikari
+
+from .ytdlp import PlaylistInfo, TrackInfo
+
+# Discord embed limits. Description and footer caps come from
+# https://discord.com/developers/docs/resources/message#embed-object-embed-limits.
+EMBED_DESCRIPTION_MAX: Final = 4096
+EMBED_FOOTER_MAX: Final = 2048
+EMBED_FIELD_VALUE_MAX: Final = 1024
+EMBED_TITLE_MAX: Final = 256
+
+# Backslash-escape every Discord markdown control char so user-supplied
+# strings cannot break out of templating. The ``\`` itself is escaped
+# first to avoid double-escaping characters added afterward.
+_MARKDOWN_CHARS: Final = ("\\", "[", "]", "(", ")", "*", "_", "~", "`", "|", ">")
+
+# Single ellipsis char rather than three dots — cheaper byte cost vs the
+# 4096-char ceiling.
+_ELLIPSIS: Final = "…"
+
+
+def escape_markdown(s: str) -> str:
+    """Backslash-escape Discord markdown control chars in ``s``.
+
+    Covers ``\\ [ ] ( ) * _ ~ ` | >``. Block-quote ``>`` is included
+    because it activates at line start, and titles can contain newlines.
+    """
+    out = s
+    for ch in _MARKDOWN_CHARS:
+        out = out.replace(ch, "\\" + ch)
+    return out
+
+
+def safe_truncate(s: str, max_chars: int) -> str:
+    """Truncate ``s`` to at most ``max_chars`` code points, appending ``…`` if cut.
+
+    ``max_chars`` must allow at least one character for the ellipsis; a
+    nonpositive value returns the empty string. Python ``str`` slicing
+    operates on Unicode code points, so multi-byte characters are not
+    split mid-sequence.
+    """
+    if max_chars <= 0:
+        return ""
+    if len(s) <= max_chars:
+        return s
+    if max_chars == 1:
+        return _ELLIPSIS
+    return s[: max_chars - 1] + _ELLIPSIS
+
+
+def format_duration(ms: int) -> str:
+    """Format ``ms`` as ``"M:SS"`` or ``"H:MM:SS"`` for h ≥ 1.
+
+    Negative durations are clamped to zero — Lavalink occasionally
+    surfaces negative positions during a seek/replace race.
+    """
+    if ms < 0:
+        ms = 0
+    total_seconds = ms // 1000
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours:
+        return f"{hours}:{minutes:02d}:{seconds:02d}"
+    return f"{minutes}:{seconds:02d}"
+
+
+def build_queued_track_embed(track: TrackInfo, position: int, *, playing_now: bool) -> hikari.Embed:
+    """Build the embed for a single-track ``/play`` success (M1 §3).
+
+    ``position`` is 1-indexed within the queue. ``playing_now`` swaps
+    the trailing ``"position N in queue"`` for ``"playing now"`` when
+    the queue was empty and the player was idle.
+    """
+    title = safe_truncate(escape_markdown(track.title), EMBED_DESCRIPTION_MAX // 2)
+    uploader = safe_truncate(escape_markdown(track.uploader), EMBED_FOOTER_MAX // 4)
+    description = safe_truncate(f"[**{title}**]({track.url})", EMBED_DESCRIPTION_MAX)
+    duration = format_duration(track.duration_ms)
+    if playing_now:
+        footer = f"by {uploader} · {duration} · playing now"
+    else:
+        footer = f"by {uploader} · {duration} · position {position} in queue"
+    embed = hikari.Embed(title="Queued", description=description)
+    embed.set_footer(safe_truncate(footer, EMBED_FOOTER_MAX))
+    return embed
+
+
+def build_queued_playlist_embed(
+    playlist: PlaylistInfo,
+    requester: str,
+    *,
+    used_cache: bool,
+    fetched_at: int | None,
+    cache_is_stale: bool,
+    failed_count: int = 0,
+) -> hikari.Embed:
+    """Build the embed for a playlist ``/play`` success (M1 §3).
+
+    ``used_cache`` switches to the "offline metadata" title and footer.
+    ``cache_is_stale`` only matters when ``used_cache`` is True; it
+    upgrades the warning message to mention the snapshot's age.
+    ``fetched_at`` is required when ``used_cache`` is True so the footer
+    can render a timestamp the user can act on.
+
+    ``failed_count`` appends the partial-failure footer line per M1 §3
+    when some entries couldn't be loaded; the offline-metadata fallback
+    already implies this so the line is suppressed there.
+    """
+    title = safe_truncate(escape_markdown(playlist.title), EMBED_TITLE_MAX)
+    track_count = len(playlist.entries)
+    total_ms = sum(track.duration_ms for track in playlist.entries)
+    duration = format_duration(total_ms)
+    description = safe_truncate(
+        f"**{title}** — {track_count} tracks ({duration})",
+        EMBED_DESCRIPTION_MAX,
+    )
+    if used_cache:
+        embed_title = "Queued playlist (offline metadata)"
+        when = "earlier" if fetched_at is None else _format_timestamp(fetched_at)
+        # Stale snapshots get a slightly louder mention so users notice
+        # entries may have rotated; the fallback path itself is the same.
+        suffix = " (snapshot is over 24h old)" if cache_is_stale else ""
+        footer = (
+            f"yt-dlp could not refresh; using cache from {when}{suffix}. "
+            f"Tracks may fail individually."
+        )
+    else:
+        embed_title = "Queued playlist"
+        footer = f"requested by {requester}"
+        if failed_count > 0:
+            footer = f"{footer} · {failed_count} tracks could not be loaded"
+    embed = hikari.Embed(title=embed_title, description=description)
+    embed.set_footer(safe_truncate(footer, EMBED_FOOTER_MAX))
+    return embed
+
+
+def _format_timestamp(unix_seconds: int) -> str:
+    """Format ``unix_seconds`` as a Discord timestamp tag.
+
+    Discord renders ``<t:1234567890:R>`` as a relative timestamp
+    ("3 hours ago") localised to the viewer's timezone — far better than
+    a server-side ``strftime`` we'd have to apologise for.
+    """
+    return f"<t:{unix_seconds}:R>"

--- a/src/ryzic/voice_check.py
+++ b/src/ryzic/voice_check.py
@@ -1,0 +1,66 @@
+"""Voice-channel guard for commands that mutate playback (M1 §3 cross-cutting).
+
+``/skip``, ``/pause``, ``/resume``, and ``/leave`` all share the same
+prelude: bail unless the invoker is in the bot's voice channel.
+:func:`ensure_same_voice` centralises the check so the rule is applied
+identically and the failure message is consistent.
+
+The function returns the bot's voice-channel id on success so the caller
+doesn't have to re-derive it; ``None`` means "I already responded with
+an ephemeral; abort the handler".
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import hikari
+import lightbulb
+
+
+async def ensure_same_voice(ctx: lightbulb.Context) -> int | None:
+    """Verify the invoker shares the bot's voice channel.
+
+    Sends an ephemeral and returns ``None`` on failure (DM, bot not in
+    voice, user not in voice, user in a different channel). Returns the
+    bot's voice channel id on success.
+
+    The lookup is cache-only (no REST round-trip): every voice state is
+    pushed through the gateway, and ``GUILD_VOICE_STATES`` is in the
+    intent set requested by ``bot.py``.
+    """
+    guild_id = ctx.guild_id
+    if guild_id is None:
+        # Defense in depth: ``dm_enabled=False`` at registration time
+        # already blocks DMs, but a future re-registration mistake
+        # shouldn't crash the handler.
+        await ctx.respond("Run this in a server.", ephemeral=True)
+        return None
+
+    # ``Client.app`` is typed as ``RESTAware`` to support the REST-only
+    # client path. We construct the ``GatewayEnabledClient`` flavour in
+    # ``bot.py`` so the gateway-only attributes (``cache``, ``get_me``)
+    # are always present at runtime; the cast is purely for ty.
+    bot = cast(hikari.GatewayBot, ctx.client.app)
+    me = bot.get_me()
+    if me is None:
+        await ctx.respond(
+            "Bot is still starting up. Try again in a moment.",
+            ephemeral=True,
+        )
+        return None
+
+    bot_state = bot.cache.get_voice_state(guild_id, me.id)
+    if bot_state is None or bot_state.channel_id is None:
+        await ctx.respond("I'm not in a voice channel.", ephemeral=True)
+        return None
+
+    user_state = bot.cache.get_voice_state(guild_id, ctx.user.id)
+    if user_state is None or user_state.channel_id != bot_state.channel_id:
+        await ctx.respond(
+            f"Join <#{bot_state.channel_id}> to use this.",
+            ephemeral=True,
+        )
+        return None
+
+    return int(bot_state.channel_id)

--- a/tests/test_audio_cache.py
+++ b/tests/test_audio_cache.py
@@ -642,3 +642,23 @@ async def test_download_refreshes_mtime_after_replace(tmp_path: Path) -> None:
         assert path.stat().st_mtime > old_mtime + 100
     finally:
         await cache.close()
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton accessor
+# ---------------------------------------------------------------------------
+
+
+async def test_singleton_round_trip(tmp_path: Path) -> None:
+    # Set/get/clear contract: PR6a's /play depends on
+    # ``get_audio_cache()`` returning the bot.py-installed instance.
+    assert audio_cache.get_audio_cache() is None
+    cache = AudioCache(tmp_path, max_bytes=10_000)
+    await cache.open()
+    try:
+        audio_cache.set_audio_cache(cache)
+        assert audio_cache.get_audio_cache() is cache
+        audio_cache.set_audio_cache(None)
+        assert audio_cache.get_audio_cache() is None
+    finally:
+        await cache.close()

--- a/tests/test_lavalink_bridge.py
+++ b/tests/test_lavalink_bridge.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, cast
 
 import hikari
@@ -193,9 +194,13 @@ async def test_voice_state_listener_tracks_own_user_even_when_client_missing() -
     still has to mark the guild ready, otherwise PR6a's first /play after a
     reconnect will time out.
     """
+    # Park the waiter first; the setter must wake it up even with no
+    # lavalink client installed.
+    wait_task = asyncio.create_task(lavalink_glue.wait_for_voice_ready(111, timeout=1.0))
+    await asyncio.sleep(0)
     event = _make_voice_state_event(user_id=42, bot_user_id=42, channel_id=999)
     await lavalink_glue._on_voice_state_update(event)
-    assert await lavalink_glue.wait_for_voice_ready(111, timeout=0.05) is True
+    assert await wait_task is True
 
 
 async def test_voice_server_listener_forwards_when_client_present() -> None:
@@ -254,12 +259,14 @@ async def test_voice_state_listener_sets_voice_ready_event_for_bot_user() -> Non
     fake_client = _FakeLavalinkClient()
     lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, fake_client))
 
+    # Park the waiter first (mirrors the real flow: ``/play`` calls
+    # ``update_voice_state`` then immediately waits), then fire the
+    # bot's own VOICE_STATE_UPDATE; the waiter must complete.
+    wait_task = asyncio.create_task(lavalink_glue.wait_for_voice_ready(111, timeout=1.0))
+    await asyncio.sleep(0)
     event = _make_voice_state_event(user_id=42, bot_user_id=42, channel_id=999)
     await lavalink_glue._on_voice_state_update(event)
-
-    # ``wait_for_voice_ready`` should now resolve immediately.
-    ok = await lavalink_glue.wait_for_voice_ready(111, timeout=0.05)
-    assert ok is True
+    assert await wait_task is True
 
 
 async def test_voice_state_listener_does_not_set_event_for_other_users() -> None:
@@ -274,18 +281,17 @@ async def test_voice_state_listener_does_not_set_event_for_other_users() -> None
 
 
 async def test_voice_state_listener_resets_event_when_bot_disconnects() -> None:
-    """If the bot leaves, the next ``/play`` must wait again — clear the event."""
+    """If the bot leaves, the per-guild event entry is removed."""
     fake_client = _FakeLavalinkClient()
     lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, fake_client))
 
     join_event = _make_voice_state_event(user_id=42, bot_user_id=42, channel_id=999)
     await lavalink_glue._on_voice_state_update(join_event)
-    assert await lavalink_glue.wait_for_voice_ready(111, timeout=0.05) is True
+    assert 111 in lavalink_glue._voice_ready_events
 
     leave_event = _make_voice_state_event(user_id=42, bot_user_id=42, channel_id=None)
     await lavalink_glue._on_voice_state_update(leave_event)
-
-    assert await lavalink_glue.wait_for_voice_ready(111, timeout=0.05) is False
+    assert 111 not in lavalink_glue._voice_ready_events
 
 
 async def test_wait_for_voice_ready_returns_false_on_timeout() -> None:
@@ -310,6 +316,38 @@ async def test_wait_for_voice_ready_resolves_when_join_arrives_after_wait_starts
     join_event = _make_voice_state_event(user_id=42, bot_user_id=42, channel_id=999)
     await lavalink_glue._on_voice_state_update(join_event)
 
+    assert await wait_task is True
+
+
+async def test_wait_for_voice_ready_clears_stale_event_after_channel_move() -> None:
+    """A non-disconnect move (A → B) leaves the prior event set; clear it.
+
+    Regression for MEDIUM-2: ``_voice_ready_events`` is reset only on
+    disconnect (channel_id None). A bot dragged to another channel by an
+    admin or a /play after a /leave race must not return True instantly
+    on a stale event — lavalink.py needs the new VOICE_SERVER_UPDATE
+    before it can play to the new channel.
+    """
+    fake_client = _FakeLavalinkClient()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, fake_client))
+
+    # Synthesise the prior session: an event was created and set by an
+    # earlier own-VoiceStateUpdate for channel A. The entry persists
+    # until the bot disconnects (channel_id None), which has not
+    # happened — a move from A to B leaves it set.
+    stale = asyncio.Event()
+    stale.set()
+    lavalink_glue._voice_ready_events[111] = stale
+
+    # The next ``wait_for_voice_ready`` must NOT return True instantly
+    # on the stale event — it must block until the next own-state lands.
+    assert await lavalink_glue.wait_for_voice_ready(111, timeout=0.05) is False
+
+    # When the new own-state arrives, the waiter wakes up.
+    wait_task = asyncio.create_task(lavalink_glue.wait_for_voice_ready(111, timeout=1.0))
+    await asyncio.sleep(0)
+    join_b = _make_voice_state_event(user_id=42, bot_user_id=42, channel_id=888)
+    await lavalink_glue._on_voice_state_update(join_b)
     assert await wait_task is True
 
 
@@ -575,7 +613,12 @@ class _ExceptionEvent:
 
 
 async def test_track_end_releases_audio_cache_pin() -> None:
-    """The TrackEnd hook MUST drop the audio cache refcount."""
+    """The TrackEnd hook MUST drop the audio cache refcount.
+
+    ``LocalAudioSourceManager`` sets ``AudioTrack.identifier`` to the
+    on-disk path; the release handler must recover the ``video_id``
+    from the path stem so the per-video pin actually decrements.
+    """
     from ryzic import audio_cache
 
     fake = _RecordingCache()
@@ -583,10 +626,11 @@ async def test_track_end_releases_audio_cache_pin() -> None:
     try:
         bot = _FakeApp()
         handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+        path = "/var/cache/ryzic/audio/vi/vid67890.audio"
         await handler.on_track_end(
             cast(
                 lavalink.TrackEndEvent,
-                _EndEvent(track=_IdTrack(identifier="vid67890"), player=_PlayerWithGuild()),
+                _EndEvent(track=_IdTrack(identifier=path), player=_PlayerWithGuild()),
             )
         )
         assert fake.released == ["vid67890"]
@@ -604,10 +648,11 @@ async def test_track_exception_also_releases_audio_cache_pin() -> None:
         bot = _FakeApp()
         lavalink_glue.last_play_channel[111] = 999
         handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+        path = "/var/cache/ryzic/audio/fa/failed01.audio"
         await handler.on_track_exception(
             cast(
                 lavalink.TrackExceptionEvent,
-                _ExceptionEvent(track=_IdTrack(identifier="failed01"), player=_PlayerWithGuild()),
+                _ExceptionEvent(track=_IdTrack(identifier=path), player=_PlayerWithGuild()),
             )
         )
         assert fake.released == ["failed01"]
@@ -641,3 +686,38 @@ async def test_release_swallows_exceptions(caplog: pytest.LogCaptureFixture) -> 
         assert any("failed to release" in r.message for r in caplog.records)
     finally:
         audio_cache.set_audio_cache(None)
+
+
+async def test_release_with_path_identifier_decrements_real_cache_pin(
+    tmp_path: Path,
+) -> None:
+    """Drive a real ``AudioCache`` to confirm path-stem extraction lands on the right key.
+
+    Regression for HIGH-1: ``LocalAudioSourceManager`` populates
+    ``AudioTrack.identifier`` with the on-disk path. Pinning happens by
+    ``video_id`` (in ``get_or_download``); release must extract the
+    same key from the path or eviction is permanently skipped.
+    """
+    from ryzic import audio_cache
+    from ryzic.audio_cache import AudioCache
+
+    cache = AudioCache(tmp_path, max_bytes=10_000_000)
+    await cache.open()
+    audio_cache.set_audio_cache(cache)
+    try:
+        video_id = "dQw4w9WgXcQ"
+        # Simulate the ``get_or_download`` pin without doing the actual
+        # download (we're testing release semantics, not download).
+        cache._in_use[video_id] += 1
+        assert cache._in_use[video_id] == 1
+
+        # Path that ``LocalAudioSourceManager`` would surface as the
+        # AudioTrack identifier for this cached file.
+        path = str(tmp_path / "audio" / video_id[:2] / f"{video_id}.audio")
+        await lavalink_glue._release_track(cast(lavalink.AudioTrack, _IdTrack(identifier=path)))
+
+        # Counter must return to zero (key removed by ``release``).
+        assert video_id not in cache._in_use
+    finally:
+        audio_cache.set_audio_cache(None)
+        await cache.close()

--- a/tests/test_lavalink_bridge.py
+++ b/tests/test_lavalink_bridge.py
@@ -530,3 +530,114 @@ def test_is_valid_discord_endpoint_allowlist() -> None:
     assert lavalink_glue._is_valid_discord_endpoint("evil.discord.media.attacker.com") is False
     assert lavalink_glue._is_valid_discord_endpoint(None) is False
     assert lavalink_glue._is_valid_discord_endpoint("") is False
+
+
+# ---------------------------------------------------------------------------
+# Audio cache release wiring (PR6a)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingCache:
+    """Captures release() calls so tests can assert the integration."""
+
+    def __init__(self) -> None:
+        self.released: list[str] = []
+
+    async def release(self, video_id: str) -> None:
+        self.released.append(video_id)
+
+
+@dataclass
+class _IdTrack:
+    title: str = "song"
+    identifier: str = "abc12345"
+
+
+@dataclass
+class _PlayerWithGuild:
+    guild_id: int = 111
+
+
+@dataclass
+class _EndEvent:
+    track: _IdTrack | None
+    player: _PlayerWithGuild
+    reason: str = "FINISHED"
+
+
+@dataclass
+class _ExceptionEvent:
+    track: _IdTrack | None
+    player: _PlayerWithGuild
+    message: str | None = "boom"
+    cause: str = "<jvm trace>"
+    severity: str = "FAULT"
+
+
+async def test_track_end_releases_audio_cache_pin() -> None:
+    """The TrackEnd hook MUST drop the audio cache refcount."""
+    from ryzic import audio_cache
+
+    fake = _RecordingCache()
+    audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
+    try:
+        bot = _FakeApp()
+        handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+        await handler.on_track_end(
+            cast(
+                lavalink.TrackEndEvent,
+                _EndEvent(track=_IdTrack(identifier="vid67890"), player=_PlayerWithGuild()),
+            )
+        )
+        assert fake.released == ["vid67890"]
+    finally:
+        audio_cache.set_audio_cache(None)
+
+
+async def test_track_exception_also_releases_audio_cache_pin() -> None:
+    """LOAD_FAILED still has to release; otherwise the file pins forever."""
+    from ryzic import audio_cache
+
+    fake = _RecordingCache()
+    audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
+    try:
+        bot = _FakeApp()
+        lavalink_glue.last_play_channel[111] = 999
+        handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+        await handler.on_track_exception(
+            cast(
+                lavalink.TrackExceptionEvent,
+                _ExceptionEvent(track=_IdTrack(identifier="failed01"), player=_PlayerWithGuild()),
+            )
+        )
+        assert fake.released == ["failed01"]
+    finally:
+        audio_cache.set_audio_cache(None)
+
+
+async def test_release_is_noop_without_cache_singleton() -> None:
+    """Tests / startup ordering must tolerate a missing cache."""
+    # No singleton installed; calling _release_track must not raise.
+    await lavalink_glue._release_track(cast(lavalink.AudioTrack, _IdTrack()))
+
+
+async def test_release_is_noop_for_none_track() -> None:
+    """``TrackEnd`` carries Optional[AudioTrack]; ``None`` must short-circuit."""
+    await lavalink_glue._release_track(None)
+
+
+async def test_release_swallows_exceptions(caplog: pytest.LogCaptureFixture) -> None:
+    """A misbehaving cache must not take down the player loop."""
+    from ryzic import audio_cache
+
+    class _BoomCache:
+        async def release(self, video_id: str) -> None:
+            raise RuntimeError("kaboom")
+
+    audio_cache.set_audio_cache(cast(audio_cache.AudioCache, _BoomCache()))
+    try:
+        with caplog.at_level("ERROR", logger="ryzic.lavalink_glue"):
+            await lavalink_glue._release_track(cast(lavalink.AudioTrack, _IdTrack()))
+        assert any("failed to release" in r.message for r in caplog.records)
+    finally:
+        audio_cache.set_audio_cache(None)

--- a/tests/test_play_command.py
+++ b/tests/test_play_command.py
@@ -151,15 +151,12 @@ class _FakeNodeManager:
 
 @dataclass
 class _FakeAudioTrack:
-    """Slim AudioTrack-shape — enough that ``isinstance`` against
-    ``DeferredAudioTrack`` returns False (it does because we're not it)."""
+    """Slim AudioTrack stand-in — covers the duck shape ``player.add`` reads."""
 
     title: str = "Some Song"
     identifier: str = "abc123"
     duration: int = 213_000
     uri: str = "https://example.com/x"
-
-    # These satisfy lavalink's `AudioTrack` duck shape minimally.
 
 
 @dataclass
@@ -515,12 +512,23 @@ async def test_single_track_queue_full_rejects(cache: Any) -> None:
 
 
 async def test_voice_handshake_timeout_returns_friendly_error(cache: Any) -> None:
+    """Handshake timeout maps to the spec'd "audio service down" string.
+
+    The track must already be loaded by the time we connect (load-first
+    order, MEDIUM-1) so the test wires up the full happy load path then
+    fails on the handshake.
+    """
     bot = _bot_in_voice_with(user_channel_id=999)
     ctx = _FakeContext(bot)
-    ll, _node = _ll_with_one_node()
+    ll, node = _ll_with_one_node()
     lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
 
     track = _track()
+    audio_track = _FakeAudioTrack(title=track.title, identifier=track.video_id)
+    node.get_tracks_results.append(
+        _FakeLoadResult(load_type=lavalink.server.LoadType.TRACK, tracks=[audio_track])
+    )
+    release_mock = AsyncMock()
     with (
         patch.object(play_module.ytdlp, "resolve_track", AsyncMock(return_value=track)),
         patch.object(
@@ -528,6 +536,7 @@ async def test_voice_handshake_timeout_returns_friendly_error(cache: Any) -> Non
             "get_or_download",
             AsyncMock(return_value=Path("/var/cache/x")),
         ),
+        patch.object(audio_cache.AudioCache, "release", release_mock),
         patch.object(
             lavalink_glue,
             "wait_for_voice_ready",
@@ -538,16 +547,28 @@ async def test_voice_handshake_timeout_returns_friendly_error(cache: Any) -> Non
             cast(lightbulb.Context, ctx),
             "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         )
-    assert "Couldn't connect" in str(ctx.responses[0][0])
+    assert ctx.responses[0][0] == "Audio service is down. Try again in a minute."
+    # The pin acquired by get_or_download must be released because we
+    # never enqueued the track (handshake failed).
+    release_mock.assert_awaited_once_with(track.video_id)
 
 
-async def test_lavalink_returns_no_tracks_releases_pin(cache: Any) -> None:
+@pytest.mark.parametrize(
+    "load_result",
+    [
+        _FakeLoadResult.empty(),
+        _FakeLoadResult(load_type=lavalink.server.LoadType.ERROR, tracks=[], error="boom"),
+    ],
+    ids=["empty", "load-error"],
+)
+async def test_lavalink_load_failure_releases_pin(cache: Any, load_result: _FakeLoadResult) -> None:
+    """Both EMPTY and ERROR load types must drop the cache pin (M1 §4)."""
     bot = _bot_in_voice_with(user_channel_id=999)
     ctx = _FakeContext(bot)
     ll, node = _ll_with_one_node()
     lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
     track = _track()
-    node.get_tracks_results.append(_FakeLoadResult.empty())
+    node.get_tracks_results.append(load_result)
 
     with (
         patch.object(play_module.ytdlp, "resolve_track", AsyncMock(return_value=track)),
@@ -556,11 +577,7 @@ async def test_lavalink_returns_no_tracks_releases_pin(cache: Any) -> None:
             "get_or_download",
             AsyncMock(return_value=Path("/var/cache/x")),
         ),
-        patch.object(
-            audio_cache.AudioCache,
-            "release",
-            AsyncMock(),
-        ) as release_mock,
+        patch.object(audio_cache.AudioCache, "release", AsyncMock()) as release_mock,
         patch.object(
             lavalink_glue,
             "wait_for_voice_ready",
@@ -571,45 +588,8 @@ async def test_lavalink_returns_no_tracks_releases_pin(cache: Any) -> None:
             cast(lightbulb.Context, ctx),
             "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         )
-    # The cache pin acquired by the (mocked) get_or_download must be
-    # released on Lavalink load failure (M1 §4 release contract).
     release_mock.assert_awaited_once_with(track.video_id)
     assert "Could not load that track" in str(ctx.responses[0][0])
-
-
-async def test_lavalink_load_error_releases_pin(cache: Any) -> None:
-    bot = _bot_in_voice_with(user_channel_id=999)
-    ctx = _FakeContext(bot)
-    ll, node = _ll_with_one_node()
-    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
-    track = _track()
-    node.get_tracks_results.append(
-        _FakeLoadResult(load_type=lavalink.server.LoadType.ERROR, tracks=[], error="boom"),
-    )
-
-    with (
-        patch.object(play_module.ytdlp, "resolve_track", AsyncMock(return_value=track)),
-        patch.object(
-            audio_cache.AudioCache,
-            "get_or_download",
-            AsyncMock(return_value=Path("/var/cache/x")),
-        ),
-        patch.object(
-            audio_cache.AudioCache,
-            "release",
-            AsyncMock(),
-        ) as release_mock,
-        patch.object(
-            lavalink_glue,
-            "wait_for_voice_ready",
-            AsyncMock(return_value=True),
-        ),
-    ):
-        await play_module._handle_play(
-            cast(lightbulb.Context, ctx),
-            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-        )
-    release_mock.assert_awaited_once_with(track.video_id)
 
 
 # ---------------------------------------------------------------------------
@@ -624,6 +604,9 @@ async def test_lavalink_load_error_releases_pin(cache: Any) -> None:
         ("https://www.youtube.com/playlist?list=PL123", True),
         ("https://www.youtube.com/watch?v=abc&list=PL123", True),
         ("https://youtu.be/abc?si=xyz", False),
+        # parse_qs accepts arbitrary strings; the helper must not blow up.
+        ("not://a-url", False),
+        ("", False),
     ],
 )
 def test_is_playlist_url(url: str, expected: bool) -> None:
@@ -819,22 +802,35 @@ async def test_playlist_yt_dlp_total_failure_returns_friendly(cache: Any) -> Non
 
 
 async def test_playlist_voice_handshake_timeout(cache: Any) -> None:
+    """Handshake timeout maps to the spec'd "audio service down" string."""
     bot = _bot_in_voice_with(user_channel_id=999)
     ctx = _FakeContext(bot)
-    ll, _ = _ll_with_one_node()
+    ll, node = _ll_with_one_node()
     lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
 
+    entry = _track()
     info = PlaylistInfo(
         playlist_id="PL12345abcde",
         title="will-time-out",
-        entries=[_track()],
+        entries=[entry],
     )
+    audio_track = _FakeAudioTrack(title=entry.title, identifier=entry.video_id)
+    node.get_tracks_results.append(
+        _FakeLoadResult(load_type=lavalink.server.LoadType.TRACK, tracks=[audio_track])
+    )
+    release_mock = AsyncMock()
     with (
         patch.object(
             play_module.playlist_cache,
             "fetch_with_fallback",
             AsyncMock(return_value=(info, 1234567890, False)),
         ),
+        patch.object(
+            audio_cache.AudioCache,
+            "get_or_download",
+            AsyncMock(return_value=Path("/var/cache/x")),
+        ),
+        patch.object(audio_cache.AudioCache, "release", release_mock),
         patch.object(
             lavalink_glue,
             "wait_for_voice_ready",
@@ -845,7 +841,8 @@ async def test_playlist_voice_handshake_timeout(cache: Any) -> None:
             cast(lightbulb.Context, ctx),
             "https://www.youtube.com/playlist?list=PL12345abcde",
         )
-    assert "Couldn't connect" in str(ctx.responses[0][0])
+    assert ctx.responses[0][0] == "Audio service is down. Try again in a minute."
+    release_mock.assert_awaited_once_with(entry.video_id)
 
 
 async def test_load_one_handles_node_get_tracks_exception(cache: Any) -> None:
@@ -907,12 +904,6 @@ async def test_yt_dlp_download_failure_per_track_drops_track(cache: Any) -> None
             "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         )
     assert "Could not load that track" in str(ctx.responses[0][0])
-
-
-def test_is_playlist_url_handles_garbage() -> None:
-    # parse_qs accepts arbitrary strings; the helper must not blow up.
-    assert play_module._is_playlist_url("not://a-url") is False
-    assert play_module._is_playlist_url("") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_play_command.py
+++ b/tests/test_play_command.py
@@ -1,0 +1,931 @@
+"""Tests for ``ryzic.commands.play``.
+
+The /play handler glues together yt-dlp, the audio cache, lavalink,
+and Discord. We mock each collaborator at its module boundary so each
+test exercises a single decision branch:
+
+* URL validation, playlist URL detection, friendly error mapping.
+* Voice precondition checks (DM, no voice, stage channel, bot in
+  another channel).
+* Audio service availability (cache singleton, lavalink client +
+  available nodes).
+* Queue-cap enforcement.
+* Voice handshake timeout.
+* Per-track load failures + cache release contract.
+* Embed plumbing for both the single-track and playlist branches.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
+
+import hikari
+import lavalink
+import lightbulb
+import pytest
+
+from ryzic import audio_cache, lavalink_glue
+from ryzic.commands import play as play_module
+from ryzic.errors import FetchFailed
+from ryzic.ytdlp import PlaylistInfo, TrackInfo
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeUser:
+    id: int
+    username: str = "alice"
+
+
+@dataclass
+class _FakeVoiceState:
+    channel_id: int | None
+
+
+@dataclass
+class _FakeChannel:
+    type: hikari.ChannelType
+
+
+class _FakeCache:
+    def __init__(
+        self,
+        states: dict[tuple[int, int], _FakeVoiceState | None] | None = None,
+        channels: dict[int, _FakeChannel] | None = None,
+    ) -> None:
+        self._states = states or {}
+        self._channels = channels or {}
+
+    def get_voice_state(self, guild_id: int, user_id: int) -> _FakeVoiceState | None:
+        return self._states.get((guild_id, user_id))
+
+    def get_guild_channel(self, channel_id: int) -> _FakeChannel | None:
+        return self._channels.get(channel_id)
+
+
+class _FakeBot:
+    """``hikari.GatewayBot`` slim stand-in covering exactly the surface /play uses."""
+
+    def __init__(
+        self,
+        bot_user_id: int = 10,
+        states: dict[tuple[int, int], _FakeVoiceState | None] | None = None,
+        channels: dict[int, _FakeChannel] | None = None,
+    ) -> None:
+        self._me = _FakeUser(bot_user_id)
+        self.cache = _FakeCache(states, channels)
+        self.update_voice_state_calls: list[tuple[int, int | None]] = []
+
+    def get_me(self) -> _FakeUser:
+        return self._me
+
+    async def update_voice_state(
+        self,
+        guild_id: int,
+        channel_id: int | None,
+        *,
+        self_deaf: bool = False,
+    ) -> None:
+        self.update_voice_state_calls.append((guild_id, channel_id))
+
+
+class _FakeLightbulbClient:
+    def __init__(self, app: _FakeBot) -> None:
+        self.app = app
+
+
+class _FakeContext:
+    def __init__(
+        self,
+        bot: _FakeBot,
+        guild_id: int | None = 111,
+        user_id: int = 222,
+        channel_id: int = 555,
+    ) -> None:
+        self.guild_id = guild_id
+        self.user = _FakeUser(user_id)
+        self.channel_id = channel_id
+        self.client = _FakeLightbulbClient(bot)
+        self.responses: list[tuple[Any, dict[str, Any]]] = []
+        self.deferred = False
+
+    async def defer(self) -> None:
+        self.deferred = True
+
+    async def respond(self, content: Any = None, **kwargs: Any) -> None:
+        self.responses.append((content, kwargs))
+
+
+@dataclass
+class _FakeNode:
+    available: bool = True
+    name: str = "test"
+    region: str = "us"
+    get_tracks_results: list[Any] = field(default_factory=list)
+    get_tracks_calls: list[str] = field(default_factory=list)
+
+    async def get_tracks(self, query: str) -> Any:
+        self.get_tracks_calls.append(query)
+        if self.get_tracks_results:
+            result = self.get_tracks_results.pop(0)
+            if isinstance(result, Exception):
+                raise result
+            return result
+        return _FakeLoadResult.empty()
+
+
+class _FakeNodeManager:
+    def __init__(self, nodes: list[_FakeNode]) -> None:
+        self.nodes = nodes
+
+    @property
+    def available_nodes(self) -> list[_FakeNode]:
+        return [n for n in self.nodes if n.available]
+
+
+@dataclass
+class _FakeAudioTrack:
+    """Slim AudioTrack-shape — enough that ``isinstance`` against
+    ``DeferredAudioTrack`` returns False (it does because we're not it)."""
+
+    title: str = "Some Song"
+    identifier: str = "abc123"
+    duration: int = 213_000
+    uri: str = "https://example.com/x"
+
+    # These satisfy lavalink's `AudioTrack` duck shape minimally.
+
+
+@dataclass
+class _FakeLoadResult:
+    load_type: lavalink.server.LoadType
+    tracks: list[Any]
+    error: Any | None = None
+
+    @classmethod
+    def empty(cls) -> _FakeLoadResult:
+        return cls(load_type=lavalink.server.LoadType.EMPTY, tracks=[])
+
+
+class _FakePlayer:
+    def __init__(self, guild_id: int) -> None:
+        self.guild_id = guild_id
+        self.queue: list[Any] = []
+        self.is_playing: bool = False
+        self.play_called: int = 0
+        self.added: list[tuple[Any, int]] = []
+
+    def add(self, track: Any, requester: int = 0, index: Any = None) -> None:
+        self.queue.append(track)
+        self.added.append((track, requester))
+
+    async def play(self) -> None:
+        self.play_called += 1
+        # Mimic lavalink: pop one off the queue + start it.
+        if self.queue:
+            self.queue.pop(0)
+        self.is_playing = True
+
+
+class _FakePlayerManager:
+    def __init__(self) -> None:
+        self.players: dict[int, _FakePlayer] = {}
+
+    def create(self, guild_id: int, **kwargs: Any) -> _FakePlayer:
+        if guild_id not in self.players:
+            self.players[guild_id] = _FakePlayer(guild_id)
+        return self.players[guild_id]
+
+
+class _FakeLavalinkClient:
+    def __init__(self, nodes: list[_FakeNode] | None = None) -> None:
+        self.node_manager = _FakeNodeManager(nodes if nodes is not None else [_FakeNode()])
+        self.player_manager = _FakePlayerManager()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> None:
+    """Wipe the audio cache + lavalink singletons between tests."""
+    audio_cache.set_audio_cache(None)
+    lavalink_glue._reset_state_for_test()
+    lavalink_glue._set_lavalink_client_for_test(None)
+
+
+@pytest.fixture
+async def cache(tmp_path: Path) -> Any:
+    c = audio_cache.AudioCache(tmp_path, max_bytes=10_000_000)
+    await c.open()
+    audio_cache.set_audio_cache(c)
+    try:
+        yield c
+    finally:
+        audio_cache.set_audio_cache(None)
+        await c.close()
+
+
+def _bot_in_voice_with(
+    user_channel_id: int,
+    bot_channel_id: int | None = None,
+    user_id: int = 222,
+    bot_user_id: int = 10,
+    channel_type: hikari.ChannelType = hikari.ChannelType.GUILD_VOICE,
+) -> _FakeBot:
+    states: dict[tuple[int, int], _FakeVoiceState | None] = {
+        (111, user_id): _FakeVoiceState(channel_id=user_channel_id),
+    }
+    if bot_channel_id is not None:
+        states[(111, bot_user_id)] = _FakeVoiceState(channel_id=bot_channel_id)
+    channels = {user_channel_id: _FakeChannel(type=channel_type)}
+    return _FakeBot(bot_user_id=bot_user_id, states=states, channels=channels)
+
+
+def _track(video_id: str = "dQw4w9WgXcQ") -> TrackInfo:
+    return TrackInfo(
+        video_id=video_id,
+        url=f"https://www.youtube.com/watch?v={video_id}",
+        title="Test Track",
+        uploader="Tester",
+        duration_ms=180_000,
+    )
+
+
+def _ll_with_one_node() -> tuple[_FakeLavalinkClient, _FakeNode]:
+    node = _FakeNode()
+    return _FakeLavalinkClient(nodes=[node]), node
+
+
+# ---------------------------------------------------------------------------
+# URL validation + DM rejection
+# ---------------------------------------------------------------------------
+
+
+async def test_dm_invocation_returns_friendly_error() -> None:
+    bot = _FakeBot()
+    ctx = _FakeContext(bot, guild_id=None)
+    await play_module._handle_play(cast(lightbulb.Context, ctx), "https://www.youtube.com/")
+    assert ctx.responses[0][0] == "Run /play in a server."
+    assert ctx.responses[0][1].get("ephemeral") is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://www.example.com/watch?v=abc",
+        "http://www.youtube.com/watch?v=abc",  # not https
+        "ftp://youtube.com/x",
+        "not-a-url",
+    ],
+)
+async def test_unsupported_url_rejected_before_io(url: str) -> None:
+    bot = _FakeBot()
+    ctx = _FakeContext(bot)
+    await play_module._handle_play(cast(lightbulb.Context, ctx), url)
+    assert ctx.responses[0][0] == "Only YouTube URLs are supported."
+
+
+# ---------------------------------------------------------------------------
+# Audio service availability
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_audio_cache_maps_to_audio_service_down() -> None:
+    bot = _FakeBot()
+    ctx = _FakeContext(bot)
+    # No audio_cache singleton installed.
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, _FakeLavalinkClient()))
+    await play_module._handle_play(
+        cast(lightbulb.Context, ctx),
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    )
+    assert ctx.responses[0][0] == "Audio service is down. Try again in a minute."
+
+
+async def test_missing_lavalink_client_maps_to_audio_service_down(cache: Any) -> None:
+    bot = _FakeBot()
+    ctx = _FakeContext(bot)
+    # No lavalink client installed.
+    await play_module._handle_play(
+        cast(lightbulb.Context, ctx),
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    )
+    assert ctx.responses[0][0] == "Audio service is down. Try again in a minute."
+
+
+async def test_no_available_nodes_maps_to_audio_service_down(cache: Any) -> None:
+    bot = _FakeBot()
+    ctx = _FakeContext(bot)
+    ll = _FakeLavalinkClient(nodes=[_FakeNode(available=False)])
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+    await play_module._handle_play(
+        cast(lightbulb.Context, ctx),
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    )
+    assert ctx.responses[0][0] == "Audio service is down. Try again in a minute."
+
+
+# ---------------------------------------------------------------------------
+# Voice precondition checks
+# ---------------------------------------------------------------------------
+
+
+async def test_user_not_in_voice_returns_friendly_error(cache: Any) -> None:
+    bot = _FakeBot()
+    ctx = _FakeContext(bot)
+    ll, _ = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+    await play_module._handle_play(
+        cast(lightbulb.Context, ctx),
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    )
+    assert ctx.responses[0][0] == "Join a voice channel first."
+
+
+async def test_user_in_stage_channel_rejected(cache: Any) -> None:
+    bot = _bot_in_voice_with(user_channel_id=999, channel_type=hikari.ChannelType.GUILD_STAGE)
+    ctx = _FakeContext(bot)
+    ll, _ = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+    await play_module._handle_play(
+        cast(lightbulb.Context, ctx),
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    )
+    assert ctx.responses[0][0] == "Stage channels aren't supported. Use a regular voice channel."
+
+
+async def test_bot_in_different_channel_rejected_with_mention(cache: Any) -> None:
+    bot = _bot_in_voice_with(user_channel_id=999, bot_channel_id=888)
+    ctx = _FakeContext(bot)
+    ll, _ = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+    await play_module._handle_play(
+        cast(lightbulb.Context, ctx),
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    )
+    assert ctx.responses[0][0] == "I'm already playing in <#888>. Join that channel."
+
+
+# ---------------------------------------------------------------------------
+# yt-dlp friendly error mapping (verbatim from FetchFailed.args[0])
+# ---------------------------------------------------------------------------
+
+
+async def test_friendly_yt_dlp_error_passes_through_verbatim(cache: Any) -> None:
+    bot = _bot_in_voice_with(user_channel_id=999)
+    ctx = _FakeContext(bot)
+    ll, _ = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+
+    msg = "That video is age-restricted and can't be played."
+    with patch.object(
+        play_module.ytdlp,
+        "resolve_track",
+        side_effect=FetchFailed(msg),
+    ):
+        await play_module._handle_play(
+            cast(lightbulb.Context, ctx),
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        )
+    assert ctx.responses[0][0] == msg
+
+
+async def test_friendly_message_falls_back_when_args_empty() -> None:
+    assert play_module._friendly_message(FetchFailed()) == "Could not load that URL."
+
+
+# ---------------------------------------------------------------------------
+# Single-track happy + edge paths
+# ---------------------------------------------------------------------------
+
+
+async def test_single_track_success_idle_plays_now(cache: Any) -> None:
+    bot = _bot_in_voice_with(user_channel_id=999)
+    ctx = _FakeContext(bot)
+    ll, node = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+    track = _track()
+    audio_track = _FakeAudioTrack(title=track.title, identifier=track.video_id)
+    node.get_tracks_results.append(
+        _FakeLoadResult(load_type=lavalink.server.LoadType.TRACK, tracks=[audio_track])
+    )
+
+    with (
+        patch.object(play_module.ytdlp, "resolve_track", AsyncMock(return_value=track)),
+        patch.object(
+            audio_cache.AudioCache,
+            "get_or_download",
+            AsyncMock(return_value=Path("/var/cache/x")),
+        ),
+        # Pretend the voice handshake completed instantly.
+        patch.object(
+            lavalink_glue,
+            "wait_for_voice_ready",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        await play_module._handle_play(
+            cast(lightbulb.Context, ctx),
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        )
+
+    assert bot.update_voice_state_calls == [(111, 999)]
+    player = ll.player_manager.players[111]
+    assert player.play_called == 1
+    assert len(player.added) == 1
+    embed = ctx.responses[0][1]["embed"]
+    assert isinstance(embed, hikari.Embed)
+    assert embed.title == "Queued"
+    assert "playing now" in (embed.footer.text if embed.footer else "")
+    # /play also seeded the last_play_channel for the EventHandler
+    # error reporter to land in the right text channel.
+    assert lavalink_glue.last_play_channel.get(111) == 555
+
+
+async def test_single_track_success_with_existing_queue_shows_position(cache: Any) -> None:
+    bot = _bot_in_voice_with(user_channel_id=999)
+    ctx = _FakeContext(bot)
+    ll, node = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+    # Pre-fill the player queue + mark it as already playing.
+    player = ll.player_manager.create(guild_id=111)
+    player.queue = [_FakeAudioTrack(title="prev")]
+    player.is_playing = True
+
+    track = _track()
+    audio_track = _FakeAudioTrack(title=track.title, identifier=track.video_id)
+    node.get_tracks_results.append(
+        _FakeLoadResult(load_type=lavalink.server.LoadType.TRACK, tracks=[audio_track])
+    )
+
+    with (
+        patch.object(play_module.ytdlp, "resolve_track", AsyncMock(return_value=track)),
+        patch.object(
+            audio_cache.AudioCache,
+            "get_or_download",
+            AsyncMock(return_value=Path("/var/cache/x")),
+        ),
+        patch.object(
+            lavalink_glue,
+            "wait_for_voice_ready",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        await play_module._handle_play(
+            cast(lightbulb.Context, ctx),
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        )
+
+    embed = ctx.responses[0][1]["embed"]
+    # Was 1 in queue, now 2 → footer says "position 2 in queue".
+    assert "position 2 in queue" in (embed.footer.text if embed.footer else "")
+    # Did not call play() again because the player was already playing.
+    assert player.play_called == 0
+
+
+async def test_single_track_queue_full_rejects(cache: Any) -> None:
+    bot = _bot_in_voice_with(user_channel_id=999)
+    ctx = _FakeContext(bot)
+    ll, _ = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+    player = ll.player_manager.create(guild_id=111)
+    player.queue = [_FakeAudioTrack(title=f"t{i}") for i in range(500)]
+
+    track = _track()
+    with patch.object(play_module.ytdlp, "resolve_track", AsyncMock(return_value=track)):
+        await play_module._handle_play(
+            cast(lightbulb.Context, ctx),
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        )
+
+    msg = ctx.responses[0][0]
+    assert isinstance(msg, str)
+    assert msg.startswith("Queue is full (500/500)")
+    # Did NOT connect to voice (cap check happens first).
+    assert bot.update_voice_state_calls == []
+
+
+async def test_voice_handshake_timeout_returns_friendly_error(cache: Any) -> None:
+    bot = _bot_in_voice_with(user_channel_id=999)
+    ctx = _FakeContext(bot)
+    ll, _node = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+
+    track = _track()
+    with (
+        patch.object(play_module.ytdlp, "resolve_track", AsyncMock(return_value=track)),
+        patch.object(
+            audio_cache.AudioCache,
+            "get_or_download",
+            AsyncMock(return_value=Path("/var/cache/x")),
+        ),
+        patch.object(
+            lavalink_glue,
+            "wait_for_voice_ready",
+            AsyncMock(return_value=False),
+        ),
+    ):
+        await play_module._handle_play(
+            cast(lightbulb.Context, ctx),
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        )
+    assert "Couldn't connect" in str(ctx.responses[0][0])
+
+
+async def test_lavalink_returns_no_tracks_releases_pin(cache: Any) -> None:
+    bot = _bot_in_voice_with(user_channel_id=999)
+    ctx = _FakeContext(bot)
+    ll, node = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+    track = _track()
+    node.get_tracks_results.append(_FakeLoadResult.empty())
+
+    with (
+        patch.object(play_module.ytdlp, "resolve_track", AsyncMock(return_value=track)),
+        patch.object(
+            audio_cache.AudioCache,
+            "get_or_download",
+            AsyncMock(return_value=Path("/var/cache/x")),
+        ),
+        patch.object(
+            audio_cache.AudioCache,
+            "release",
+            AsyncMock(),
+        ) as release_mock,
+        patch.object(
+            lavalink_glue,
+            "wait_for_voice_ready",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        await play_module._handle_play(
+            cast(lightbulb.Context, ctx),
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        )
+    # The cache pin acquired by the (mocked) get_or_download must be
+    # released on Lavalink load failure (M1 §4 release contract).
+    release_mock.assert_awaited_once_with(track.video_id)
+    assert "Could not load that track" in str(ctx.responses[0][0])
+
+
+async def test_lavalink_load_error_releases_pin(cache: Any) -> None:
+    bot = _bot_in_voice_with(user_channel_id=999)
+    ctx = _FakeContext(bot)
+    ll, node = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+    track = _track()
+    node.get_tracks_results.append(
+        _FakeLoadResult(load_type=lavalink.server.LoadType.ERROR, tracks=[], error="boom"),
+    )
+
+    with (
+        patch.object(play_module.ytdlp, "resolve_track", AsyncMock(return_value=track)),
+        patch.object(
+            audio_cache.AudioCache,
+            "get_or_download",
+            AsyncMock(return_value=Path("/var/cache/x")),
+        ),
+        patch.object(
+            audio_cache.AudioCache,
+            "release",
+            AsyncMock(),
+        ) as release_mock,
+        patch.object(
+            lavalink_glue,
+            "wait_for_voice_ready",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        await play_module._handle_play(
+            cast(lightbulb.Context, ctx),
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        )
+    release_mock.assert_awaited_once_with(track.video_id)
+
+
+# ---------------------------------------------------------------------------
+# Playlist URL detection + playlist branch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://www.youtube.com/watch?v=abc", False),
+        ("https://www.youtube.com/playlist?list=PL123", True),
+        ("https://www.youtube.com/watch?v=abc&list=PL123", True),
+        ("https://youtu.be/abc?si=xyz", False),
+    ],
+)
+def test_is_playlist_url(url: str, expected: bool) -> None:
+    assert play_module._is_playlist_url(url) is expected
+
+
+async def test_playlist_success(cache: Any) -> None:
+    bot = _bot_in_voice_with(user_channel_id=999)
+    ctx = _FakeContext(bot)
+    ll, node = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+
+    entries = [_track(video_id=f"vid{i:08d}") for i in range(3)]
+    info = PlaylistInfo(playlist_id="PL12345abcde", title="My PL", entries=entries)
+    audio_tracks = [_FakeAudioTrack(title=t.title, identifier=t.video_id) for t in entries]
+    for at in audio_tracks:
+        node.get_tracks_results.append(
+            _FakeLoadResult(load_type=lavalink.server.LoadType.TRACK, tracks=[at])
+        )
+
+    with (
+        patch.object(
+            play_module.playlist_cache,
+            "fetch_with_fallback",
+            AsyncMock(return_value=(info, 1234567890, False)),
+        ),
+        patch.object(
+            audio_cache.AudioCache,
+            "get_or_download",
+            AsyncMock(return_value=Path("/var/cache/x")),
+        ),
+        patch.object(
+            lavalink_glue,
+            "wait_for_voice_ready",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        await play_module._handle_play(
+            cast(lightbulb.Context, ctx),
+            "https://www.youtube.com/playlist?list=PL12345abcde",
+        )
+
+    embed = ctx.responses[0][1]["embed"]
+    assert embed.title == "Queued playlist"
+    assert "3 tracks" in (embed.description or "")
+    player = ll.player_manager.players[111]
+    assert len(player.added) == 3
+    # play() called exactly once (after first track enqueued).
+    assert player.play_called == 1
+
+
+async def test_playlist_offline_fallback_uses_cache_embed(cache: Any) -> None:
+    bot = _bot_in_voice_with(user_channel_id=999)
+    ctx = _FakeContext(bot)
+    ll, node = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+
+    entry = _track()
+    info = PlaylistInfo(playlist_id="PL12345abcde", title="Cached", entries=[entry])
+    node.get_tracks_results.append(
+        _FakeLoadResult(
+            load_type=lavalink.server.LoadType.TRACK,
+            tracks=[_FakeAudioTrack(title=entry.title, identifier=entry.video_id)],
+        )
+    )
+
+    with (
+        patch.object(
+            play_module.playlist_cache,
+            "fetch_with_fallback",
+            AsyncMock(return_value=(info, 1234567890, True)),
+        ),
+        patch.object(
+            audio_cache.AudioCache,
+            "get_or_download",
+            AsyncMock(return_value=Path("/var/cache/x")),
+        ),
+        patch.object(
+            lavalink_glue,
+            "wait_for_voice_ready",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        await play_module._handle_play(
+            cast(lightbulb.Context, ctx),
+            "https://www.youtube.com/playlist?list=PL12345abcde",
+        )
+
+    embed = ctx.responses[0][1]["embed"]
+    assert embed.title == "Queued playlist (offline metadata)"
+
+
+async def test_playlist_empty_returns_friendly(cache: Any) -> None:
+    bot = _bot_in_voice_with(user_channel_id=999)
+    ctx = _FakeContext(bot)
+    ll, _ = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+
+    info = PlaylistInfo(playlist_id="PL12345abcde", title="empty", entries=[])
+    with patch.object(
+        play_module.playlist_cache,
+        "fetch_with_fallback",
+        AsyncMock(return_value=(info, 1234567890, False)),
+    ):
+        await play_module._handle_play(
+            cast(lightbulb.Context, ctx),
+            "https://www.youtube.com/playlist?list=PL12345abcde",
+        )
+    assert ctx.responses[0][0] == "That playlist is empty or private."
+
+
+async def test_playlist_queue_overflow_rejects(cache: Any) -> None:
+    bot = _bot_in_voice_with(user_channel_id=999)
+    ctx = _FakeContext(bot)
+    ll, _ = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+    player = ll.player_manager.create(guild_id=111)
+    # 499 already queued + 2 incoming would breach the 500 cap.
+    player.queue = [_FakeAudioTrack() for _ in range(499)]
+
+    info = PlaylistInfo(
+        playlist_id="PL12345abcde",
+        title="overflow",
+        entries=[_track("aaa12345"), _track("bbb12345")],
+    )
+    with patch.object(
+        play_module.playlist_cache,
+        "fetch_with_fallback",
+        AsyncMock(return_value=(info, 1234567890, False)),
+    ):
+        await play_module._handle_play(
+            cast(lightbulb.Context, ctx),
+            "https://www.youtube.com/playlist?list=PL12345abcde",
+        )
+    assert "Queue is full" in str(ctx.responses[0][0])
+
+
+async def test_playlist_all_tracks_fail_returns_friendly(cache: Any) -> None:
+    bot = _bot_in_voice_with(user_channel_id=999)
+    ctx = _FakeContext(bot)
+    ll, node = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+
+    info = PlaylistInfo(
+        playlist_id="PL12345abcde",
+        title="all-fail",
+        entries=[_track("aaa12345"), _track("bbb12345")],
+    )
+    # Both lavalink loads return EMPTY → both tracks fail.
+    node.get_tracks_results.extend([_FakeLoadResult.empty(), _FakeLoadResult.empty()])
+
+    with (
+        patch.object(
+            play_module.playlist_cache,
+            "fetch_with_fallback",
+            AsyncMock(return_value=(info, 1234567890, False)),
+        ),
+        patch.object(
+            audio_cache.AudioCache,
+            "get_or_download",
+            AsyncMock(return_value=Path("/var/cache/x")),
+        ),
+        patch.object(audio_cache.AudioCache, "release", AsyncMock()),
+        patch.object(
+            lavalink_glue,
+            "wait_for_voice_ready",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        await play_module._handle_play(
+            cast(lightbulb.Context, ctx),
+            "https://www.youtube.com/playlist?list=PL12345abcde",
+        )
+    assert "Could not load any tracks" in str(ctx.responses[0][0])
+
+
+async def test_playlist_yt_dlp_total_failure_returns_friendly(cache: Any) -> None:
+    bot = _bot_in_voice_with(user_channel_id=999)
+    ctx = _FakeContext(bot)
+    ll, _ = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+
+    with patch.object(
+        play_module.playlist_cache,
+        "fetch_with_fallback",
+        AsyncMock(side_effect=FetchFailed("That playlist is private.")),
+    ):
+        await play_module._handle_play(
+            cast(lightbulb.Context, ctx),
+            "https://www.youtube.com/playlist?list=PL12345abcde",
+        )
+    assert ctx.responses[0][0] == "That playlist is private."
+
+
+async def test_playlist_voice_handshake_timeout(cache: Any) -> None:
+    bot = _bot_in_voice_with(user_channel_id=999)
+    ctx = _FakeContext(bot)
+    ll, _ = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+
+    info = PlaylistInfo(
+        playlist_id="PL12345abcde",
+        title="will-time-out",
+        entries=[_track()],
+    )
+    with (
+        patch.object(
+            play_module.playlist_cache,
+            "fetch_with_fallback",
+            AsyncMock(return_value=(info, 1234567890, False)),
+        ),
+        patch.object(
+            lavalink_glue,
+            "wait_for_voice_ready",
+            AsyncMock(return_value=False),
+        ),
+    ):
+        await play_module._handle_play(
+            cast(lightbulb.Context, ctx),
+            "https://www.youtube.com/playlist?list=PL12345abcde",
+        )
+    assert "Couldn't connect" in str(ctx.responses[0][0])
+
+
+async def test_load_one_handles_node_get_tracks_exception(cache: Any) -> None:
+    """A get_tracks() exception must release the cache pin and return None."""
+    bot = _bot_in_voice_with(user_channel_id=999)
+    ctx = _FakeContext(bot)
+    ll, node = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+    track = _track()
+    # Queue an exception in the node's response stack — the load helper
+    # must release the cache pin and surface the friendly error.
+    node.get_tracks_results.append(RuntimeError("boom"))
+
+    with (
+        patch.object(play_module.ytdlp, "resolve_track", AsyncMock(return_value=track)),
+        patch.object(
+            audio_cache.AudioCache,
+            "get_or_download",
+            AsyncMock(return_value=Path("/var/cache/x")),
+        ),
+        patch.object(audio_cache.AudioCache, "release", AsyncMock()) as release_mock,
+        patch.object(
+            lavalink_glue,
+            "wait_for_voice_ready",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        await play_module._handle_play(
+            cast(lightbulb.Context, ctx),
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        )
+    release_mock.assert_awaited_once_with(track.video_id)
+    assert "Could not load that track" in str(ctx.responses[0][0])
+
+
+async def test_yt_dlp_download_failure_per_track_drops_track(cache: Any) -> None:
+    """A per-track audio_cache failure must NOT release (download didn't pin)."""
+    bot = _bot_in_voice_with(user_channel_id=999)
+    ctx = _FakeContext(bot)
+    ll, _ = _ll_with_one_node()
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, ll))
+    track = _track()
+
+    with (
+        patch.object(play_module.ytdlp, "resolve_track", AsyncMock(return_value=track)),
+        patch.object(
+            audio_cache.AudioCache,
+            "get_or_download",
+            AsyncMock(side_effect=FetchFailed("download bonk")),
+        ),
+        patch.object(
+            lavalink_glue,
+            "wait_for_voice_ready",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        await play_module._handle_play(
+            cast(lightbulb.Context, ctx),
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        )
+    assert "Could not load that track" in str(ctx.responses[0][0])
+
+
+def test_is_playlist_url_handles_garbage() -> None:
+    # parse_qs accepts arbitrary strings; the helper must not blow up.
+    assert play_module._is_playlist_url("not://a-url") is False
+    assert play_module._is_playlist_url("") is False
+
+
+# ---------------------------------------------------------------------------
+# Loader plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_loader_registered_play_command() -> None:
+    # Smoke check: the module exposes a Loader holding the Play command.
+    # The metaclass populates _command_data with the right name.
+    assert play_module.Play._command_data.name == "play"
+    assert play_module.Play._command_data.description.startswith("Queue")
+    # 1 string option named url, 1-500 chars.
+    opt = play_module.Play._command_data.options["url"]
+    assert opt.min_length == 1
+    assert opt.max_length == 500

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -1,0 +1,248 @@
+"""Tests for embed builders + safe-formatting helpers."""
+
+from __future__ import annotations
+
+import hikari
+import pytest
+
+from ryzic import ux
+from ryzic.ytdlp import PlaylistInfo, TrackInfo
+
+
+def _track(**overrides: object) -> TrackInfo:
+    base: dict[str, object] = {
+        "video_id": "dQw4w9WgXcQ",
+        "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        "title": "Never Gonna Give You Up",
+        "uploader": "Rick Astley",
+        "duration_ms": 213_000,
+    }
+    base.update(overrides)
+    return TrackInfo(**base)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# escape_markdown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("plain", "plain"),
+        ("[link](url)", "\\[link\\]\\(url\\)"),
+        ("**bold**", "\\*\\*bold\\*\\*"),
+        ("`code`", "\\`code\\`"),
+        ("under_score", "under\\_score"),
+        ("~strike~", "\\~strike\\~"),
+        ("|spoil|", "\\|spoil\\|"),
+        ("> quote", "\\> quote"),
+    ],
+)
+def test_escape_markdown(raw: str, expected: str) -> None:
+    assert ux.escape_markdown(raw) == expected
+
+
+def test_escape_markdown_handles_pre_existing_backslashes() -> None:
+    # The escape pass adds ``\\`` to existing ``\``; subsequent chars
+    # are not double-escaped because we replace ``\`` first.
+    assert ux.escape_markdown("a\\b*c") == "a\\\\b\\*c"
+
+
+# ---------------------------------------------------------------------------
+# safe_truncate
+# ---------------------------------------------------------------------------
+
+
+def test_safe_truncate_no_op_under_limit() -> None:
+    assert ux.safe_truncate("hi", 10) == "hi"
+
+
+def test_safe_truncate_exact_limit_no_ellipsis() -> None:
+    assert ux.safe_truncate("12345", 5) == "12345"
+
+
+def test_safe_truncate_inserts_ellipsis_when_cut() -> None:
+    assert ux.safe_truncate("123456789", 5) == "1234…"
+
+
+def test_safe_truncate_handles_unicode_codepoint_safely() -> None:
+    # Multi-byte but single-codepoint glyphs (emoji + accent).
+    s = "🎵café"  # 5 codepoints
+    assert ux.safe_truncate(s, 4) == "🎵ca…"
+
+
+def test_safe_truncate_zero_max_returns_empty() -> None:
+    assert ux.safe_truncate("hi", 0) == ""
+
+
+def test_safe_truncate_negative_max_returns_empty() -> None:
+    assert ux.safe_truncate("hi", -5) == ""
+
+
+def test_safe_truncate_one_char_returns_ellipsis_only() -> None:
+    assert ux.safe_truncate("hello", 1) == "…"
+
+
+# ---------------------------------------------------------------------------
+# format_duration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("ms", "expected"),
+    [
+        (0, "0:00"),
+        (1_000, "0:01"),
+        (45_000, "0:45"),
+        (60_000, "1:00"),
+        (213_000, "3:33"),
+        (3_600_000, "1:00:00"),
+        (3_725_000, "1:02:05"),
+    ],
+)
+def test_format_duration(ms: int, expected: str) -> None:
+    assert ux.format_duration(ms) == expected
+
+
+def test_format_duration_clamps_negative() -> None:
+    assert ux.format_duration(-1234) == "0:00"
+
+
+# ---------------------------------------------------------------------------
+# build_queued_track_embed
+# ---------------------------------------------------------------------------
+
+
+def test_track_embed_playing_now() -> None:
+    embed = ux.build_queued_track_embed(_track(), position=1, playing_now=True)
+    assert isinstance(embed, hikari.Embed)
+    assert embed.title == "Queued"
+    assert embed.description is not None
+    assert "Never Gonna Give You Up" in embed.description
+    assert "https://www.youtube.com/watch?v=dQw4w9WgXcQ" in embed.description
+    assert embed.footer is not None
+    assert "Rick Astley" in (embed.footer.text or "")
+    assert "playing now" in (embed.footer.text or "")
+    assert "3:33" in (embed.footer.text or "")
+
+
+def test_track_embed_position_in_queue() -> None:
+    embed = ux.build_queued_track_embed(_track(), position=4, playing_now=False)
+    assert embed.footer is not None
+    text = embed.footer.text or ""
+    assert "position 4 in queue" in text
+
+
+def test_track_embed_escapes_markdown_in_title_and_uploader() -> None:
+    embed = ux.build_queued_track_embed(
+        _track(title="evil **bold** [link](url)", uploader="hax_or"),
+        position=1,
+        playing_now=False,
+    )
+    assert embed.description is not None
+    # Both ``**`` and ``[`` get escaped — neither bold nor a markdown link
+    # can render in the embed body.
+    assert "**bold**" not in embed.description
+    assert "[link](url)" not in embed.description
+    assert "\\*\\*bold\\*\\*" in embed.description
+    assert embed.footer is not None
+    assert "hax\\_or" in (embed.footer.text or "")
+
+
+# ---------------------------------------------------------------------------
+# build_queued_playlist_embed
+# ---------------------------------------------------------------------------
+
+
+def _playlist(entries: list[TrackInfo] | None = None) -> PlaylistInfo:
+    return PlaylistInfo(
+        playlist_id="PLabcdefghij",
+        title="My Playlist",
+        entries=entries if entries is not None else [_track()],
+    )
+
+
+def test_playlist_embed_live_path() -> None:
+    embed = ux.build_queued_playlist_embed(
+        _playlist([_track(duration_ms=60_000), _track(duration_ms=180_000)]),
+        requester="alice",
+        used_cache=False,
+        fetched_at=None,
+        cache_is_stale=False,
+    )
+    assert embed.title == "Queued playlist"
+    assert embed.description is not None
+    assert "My Playlist" in embed.description
+    assert "2 tracks" in embed.description
+    # 60_000 + 180_000 = 240_000ms = 4:00
+    assert "4:00" in embed.description
+    assert embed.footer is not None
+    assert "alice" in (embed.footer.text or "")
+
+
+def test_playlist_embed_partial_failure_appends_footer_line() -> None:
+    embed = ux.build_queued_playlist_embed(
+        _playlist([_track(), _track()]),
+        requester="alice",
+        used_cache=False,
+        fetched_at=None,
+        cache_is_stale=False,
+        failed_count=3,
+    )
+    assert embed.footer is not None
+    assert "3 tracks could not be loaded" in (embed.footer.text or "")
+
+
+def test_playlist_embed_no_partial_footer_when_zero_failed() -> None:
+    embed = ux.build_queued_playlist_embed(
+        _playlist(),
+        requester="alice",
+        used_cache=False,
+        fetched_at=None,
+        cache_is_stale=False,
+        failed_count=0,
+    )
+    assert embed.footer is not None
+    assert "could not be loaded" not in (embed.footer.text or "")
+
+
+def test_playlist_embed_offline_metadata() -> None:
+    embed = ux.build_queued_playlist_embed(
+        _playlist(),
+        requester="alice",
+        used_cache=True,
+        fetched_at=1234567890,
+        cache_is_stale=False,
+    )
+    assert embed.title == "Queued playlist (offline metadata)"
+    assert embed.footer is not None
+    text = embed.footer.text or ""
+    assert "yt-dlp could not refresh" in text
+    assert "<t:1234567890:R>" in text
+    assert "Tracks may fail individually" in text
+
+
+def test_playlist_embed_offline_stale_warning() -> None:
+    embed = ux.build_queued_playlist_embed(
+        _playlist(),
+        requester="alice",
+        used_cache=True,
+        fetched_at=1,
+        cache_is_stale=True,
+    )
+    assert embed.footer is not None
+    assert "snapshot is over 24h old" in (embed.footer.text or "")
+
+
+def test_playlist_embed_escapes_markdown_in_title() -> None:
+    embed = ux.build_queued_playlist_embed(
+        PlaylistInfo(playlist_id="PLabcdefghij", title="**hax**", entries=[_track()]),
+        requester="alice",
+        used_cache=False,
+        fetched_at=None,
+        cache_is_stale=False,
+    )
+    assert embed.description is not None
+    assert "**hax**" not in embed.description
+    assert "\\*\\*hax\\*\\*" in embed.description

--- a/tests/test_voice_check.py
+++ b/tests/test_voice_check.py
@@ -1,0 +1,131 @@
+"""Tests for ``ryzic.voice_check.ensure_same_voice``.
+
+We mock the slim subset of ``hikari.GatewayBot`` + ``lightbulb.Context``
+needed by the helper. The real classes carry too many slots to
+construct in-process; the helper only touches ``cache.get_voice_state``,
+``get_me``, ``ctx.guild_id``, ``ctx.user``, and ``ctx.respond``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, cast
+
+import lightbulb
+
+from ryzic import voice_check
+
+
+@dataclass
+class _FakeUser:
+    id: int
+
+
+@dataclass
+class _FakeVoiceState:
+    channel_id: int | None
+
+
+class _FakeCache:
+    def __init__(self, states: Mapping[tuple[int, int], _FakeVoiceState | None]) -> None:
+        self._states = states
+
+    def get_voice_state(self, guild_id: int, user_id: int) -> _FakeVoiceState | None:
+        return self._states.get((guild_id, user_id))
+
+
+class _FakeApp:
+    def __init__(
+        self,
+        bot_user_id: int | None,
+        states: Mapping[tuple[int, int], _FakeVoiceState | None],
+    ) -> None:
+        self._me = _FakeUser(bot_user_id) if bot_user_id is not None else None
+        self.cache = _FakeCache(states)
+
+    def get_me(self) -> _FakeUser | None:
+        return self._me
+
+
+class _FakeClient:
+    def __init__(self, app: _FakeApp) -> None:
+        self.app = app
+
+
+class _FakeContext:
+    def __init__(
+        self,
+        guild_id: int | None,
+        user_id: int,
+        bot_user_id: int | None,
+        states: Mapping[tuple[int, int], _FakeVoiceState | None],
+    ) -> None:
+        self.guild_id = guild_id
+        self.user = _FakeUser(user_id)
+        self.client = _FakeClient(_FakeApp(bot_user_id, states))
+        self.responses: list[tuple[Any, dict[str, Any]]] = []
+
+    async def respond(self, content: Any = None, **kwargs: Any) -> None:
+        self.responses.append((content, kwargs))
+
+
+def _ctx(**kwargs: Any) -> lightbulb.Context:
+    return cast(lightbulb.Context, _FakeContext(**kwargs))
+
+
+async def test_returns_none_in_dm() -> None:
+    ctx = _FakeContext(guild_id=None, user_id=1, bot_user_id=10, states={})
+    assert await voice_check.ensure_same_voice(cast(lightbulb.Context, ctx)) is None
+    assert ctx.responses[0][0] == "Run this in a server."
+    assert ctx.responses[0][1].get("ephemeral") is True
+
+
+async def test_returns_none_when_bot_user_missing() -> None:
+    ctx = _FakeContext(guild_id=111, user_id=1, bot_user_id=None, states={})
+    assert await voice_check.ensure_same_voice(cast(lightbulb.Context, ctx)) is None
+    assert "starting up" in str(ctx.responses[0][0])
+
+
+async def test_returns_none_when_bot_not_in_voice() -> None:
+    ctx = _FakeContext(guild_id=111, user_id=1, bot_user_id=10, states={})
+    assert await voice_check.ensure_same_voice(cast(lightbulb.Context, ctx)) is None
+    assert ctx.responses[0][0] == "I'm not in a voice channel."
+
+
+async def test_returns_none_when_user_in_different_channel() -> None:
+    states = {
+        (111, 10): _FakeVoiceState(channel_id=999),  # bot in 999
+        (111, 1): _FakeVoiceState(channel_id=888),  # user in 888
+    }
+    ctx = _FakeContext(guild_id=111, user_id=1, bot_user_id=10, states=states)
+    assert await voice_check.ensure_same_voice(cast(lightbulb.Context, ctx)) is None
+    # Direction matters: the rejection mentions the BOT's channel.
+    assert "<#999>" in str(ctx.responses[0][0])
+
+
+async def test_returns_none_when_user_not_in_voice() -> None:
+    states = {(111, 10): _FakeVoiceState(channel_id=999)}
+    ctx = _FakeContext(guild_id=111, user_id=1, bot_user_id=10, states=states)
+    assert await voice_check.ensure_same_voice(cast(lightbulb.Context, ctx)) is None
+    assert "<#999>" in str(ctx.responses[0][0])
+
+
+async def test_returns_channel_id_on_match() -> None:
+    states = {
+        (111, 10): _FakeVoiceState(channel_id=999),
+        (111, 1): _FakeVoiceState(channel_id=999),
+    }
+    ctx = _FakeContext(guild_id=111, user_id=1, bot_user_id=10, states=states)
+    assert await voice_check.ensure_same_voice(cast(lightbulb.Context, ctx)) == 999
+    assert ctx.responses == []
+
+
+async def test_bot_state_with_none_channel_treated_as_disconnected() -> None:
+    states = {
+        (111, 10): _FakeVoiceState(channel_id=None),
+        (111, 1): _FakeVoiceState(channel_id=999),
+    }
+    ctx = _FakeContext(guild_id=111, user_id=1, bot_user_id=10, states=states)
+    assert await voice_check.ensure_same_voice(cast(lightbulb.Context, ctx)) is None
+    assert ctx.responses[0][0] == "I'm not in a voice channel."


### PR DESCRIPTION
## Summary

Implements PR6a from `docs/plans/M1.md`: the `/play` slash command, the embed/safety helpers (`ux.py`), and the voice-channel guard (`voice_check.py`) consumed by the PR6b commands.

- `/play <url>`: defers public, validates URL via `is_supported_url`, detects playlist vs single-track, resolves via `ytdlp.resolve_track` or `playlist_cache.fetch_with_fallback`, enforces 500-track per-guild cap, drives `bot.update_voice_state` → `wait_for_voice_ready` → per-track `audio_cache.get_or_download` → `node.get_tracks` → `player.add` → `player.play()` (only if not already playing). Friendly error sentences are forwarded **verbatim** from `FetchFailed.args[0]`.
- All embeds escape Discord markdown via `escape_markdown` and are length-clipped via `safe_truncate`. Single-track + playlist embeds match the M1 §3 wording (including offline-metadata + partial-failure footers).
- `voice_check.ensure_same_voice` reads from the gateway voice-state cache only (no REST round-trip).
- Wires `audio_cache.release()` into `TrackEndEvent` and `TrackExceptionEvent` (replaces the PR3 TODOs); the helper swallows exceptions so a misbehaving cache cannot crash the player loop.
- `bot.py` now bootstraps the `AudioCache` (open + sweep orphans + register singleton), loads the `play` extension, and closes the cache on shutdown.

## Spec compliance (M1 §3)

- DM rejection: command registered with `contexts=[GUILD]` (lightbulb v3 / Discord-API replacement for v2 `dm_enabled=False`); guild-id None guard inside the handler is the defense-in-depth.
- Audio service down: `cache is None`, `ll_client is None`, OR `available_nodes` empty → `"Audio service is down. Try again in a minute."`
- Stage channel: `channel.type == GUILD_STAGE` → `"Stage channels aren't supported. Use a regular voice channel."`
- Bot in different channel: `"I'm already playing in <#{other_id}>. Join that channel."`
- Queue overflow: `"Queue is full ({n}/500). Wait for some tracks to finish."`
- `/play` while paused: enqueues only (we never call `player.set_pause(False)`).
- `last_play_channel[guild_id]` is set at handler start so `TrackException` posts to the right channel.

## Test plan

- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run ty check`
- [x] `uv run pytest -q` — 255 passed, 1 deselected (integration)
- [x] Coverage on new code: 96% (`commands/play.py` 94%, `ux.py` 100%, `voice_check.py` 100%)
- [ ] Manual smoke: `/play <youtube>` happy path in a test guild
- [ ] Manual smoke: `/play <playlist>` happy path
- [ ] Manual smoke: `/play <stage-channel>` rejected
- [ ] Manual smoke: queue cap, livestream rejection, age-restricted error