### PR TITLE
docs(semver,contributing): align bump table with feat: → minor pre-1.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,10 @@ Thanks for taking the time. This file documents the workflow we expect for chang
 
 ## Commits
 
-ryzic uses [Conventional Commits](https://www.conventionalcommits.org/). The commit type drives the version bump that [release-please](https://github.com/googleapis/release-please) cuts. Pre-1.0, the mapping is intentionally conservative — see [SEMVER.md](SEMVER.md) for rationale:
+ryzic uses [Conventional Commits](https://www.conventionalcommits.org/). The commit type drives the version bump that [release-please](https://github.com/googleapis/release-please) cuts. See [SEMVER.md](SEMVER.md) for the pre-1.0 caveats:
 
 - `fix:` → patch release.
-- `feat:` → patch release pre-1.0, minor release post-1.0.
+- `feat:` → minor release.
 - `feat!:` (or any commit with a `BREAKING CHANGE:` footer) → minor release pre-1.0, major release post-1.0.
 - `chore:`, `docs:`, `test:`, `refactor:`, `ci:` → no release.
 
@@ -29,7 +29,11 @@ Before-merge gates (run as separate review passes on substantial PRs):
 
 ## Where the design lives
 
-The M1 plan and per-PR review notes live under [docs/plans/](docs/plans/). `M1.md` is the source of truth for behavior, env vars, and module layout; the `PR{n}-review.md` / `PR{n}-security-review.md` / `PR{n}-simplify.md` files capture review output for each implementation PR. Reference them when proposing follow-ups so reviewers have context.
+The M1 plan and the pre-implementation plan reviews live under [docs/plans/](docs/plans/). `M1.md` is the source of truth for behavior, env vars, and module layout; `M1-review.md` and `M1-simplify.md` capture the pre-implementation correctness/security/UX critique and KISS pass.
+
+Per-PR review output (`/review`, `/security-review`, `/simplify`) is posted as PR comments on the GitHub PR — not committed to the repo. Reference the merged PR for any context on the review verdicts behind a given change.
+
+Forward-looking planning lives in GitHub Issues. See [#13](https://github.com/VeryLongOrgNameSuchWow/ryzic/issues/13) (M1 epic) and [#8](https://github.com/VeryLongOrgNameSuchWow/ryzic/issues/8) (M2 epic).
 
 ## What we won't merge
 

--- a/SEMVER.md
+++ b/SEMVER.md
@@ -4,13 +4,13 @@ ryzic follows [Semantic Versioning 2.0.0](https://semver.org/) with the pre-1.0 
 
 ## Pre-1.0 (`0.x.y`)
 
-While the major version is `0`, **minor bumps may contain breaking changes**. release-please is configured with `bump-minor-pre-major: true` and `bump-patch-for-minor-pre-major: true`, so the pre-1.0 commit-to-bump mapping is intentionally conservative:
+While the major version is `0`, **minor bumps may contain breaking changes**. release-please uses the standard `release-type: python` mapping pre-1.0:
 
 - `fix:` → patch (`0.x.Y+1`)
-- `feat:` → patch (`0.x.Y+1`)
-- `feat!:` / `BREAKING CHANGE:` → minor (`0.MINOR+1.0`) rather than a major bump
+- `feat:` → minor (`0.MINOR+1.0`)
+- `feat!:` / `BREAKING CHANGE:` → minor pre-1.0 rather than a major bump (the major version stays at `0` until the bot is declared stable; the loud "this might break you" signal is the minor bump itself)
 
-Holding `feat:` to a patch keeps `0.x` cheap to iterate on while reserving minor bumps for the loud "this might break you" signal pre-1.0. Post-1.0 the standard SemVer mapping applies (`feat:` → minor, `feat!:` → major).
+Post-1.0, the standard SemVer mapping applies (`feat:` → minor, `feat!:` → major).
 
 If stability matters to you before v1.0, **pin to an exact version** (`ryzic==0.4.2`) and read [CHANGELOG.md](CHANGELOG.md) before upgrading. The CHANGELOG calls out breaking changes with a `BREAKING CHANGE:` footer.
 


### PR DESCRIPTION
## Summary

#19 dropped \`bump-minor-pre-major\` and \`bump-patch-for-minor-pre-major\` from \`release-please-config.json\`. release-please now uses the default \`release-type: python\` mapping where \`feat:\` cuts a minor pre-1.0 (not a patch). \`SEMVER.md\` + \`CONTRIBUTING.md\` were written before #19 and still describe the OLD mapping.

This PR updates both docs to match the actual config.

## Changes

- \`SEMVER.md\`: rewrite the \"Pre-1.0\" bump table to \`feat:\` → minor; drop the \"Holding feat: to a patch keeps 0.x cheap\" paragraph (no longer applicable); drop the now-stale \`bump-minor-pre-major: true\` / \`bump-patch-for-minor-pre-major: true\` config references.
- \`CONTRIBUTING.md\`: update bump table; rewrite \"Where the design lives\" to remove references to the per-PR \`PR{n}-*.md\` files (deleted in #19) and point at PR comments + GitHub Issues for forward-looking planning.

## Test plan

- [x] Docs only.
- [x] Markdown renders.