### PR TITLE
fix(release-please): re-add bump-minor-pre-major to honor SEMVER.md pre-1.0 promise

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,8 @@
   "packages": {
     ".": {
       "package-name": "ryzic",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
## Summary

Restores `bump-minor-pre-major: true` in `release-please-config.json`. Without it, the default `release-type: python` mapping treats `feat!:` as a major bump, which would cut `v1.0.0` on the first breaking change — directly contradicting `SEMVER.md`'s pre-1.0 contract.

PR #19 dropped this flag; PR #20 then patched `SEMVER.md` to match the new `feat: → minor` mapping that comes from dropping the *second* (`bump-patch-for-minor-pre-major`) flag, but missed that the *first* flag was load-bearing for the documented `feat!: → minor pre-1.0` promise.

## Resulting bump table (now matches SEMVER.md verbatim)

| commit | bump |
|---|---|
| `fix:` | patch |
| `feat:` | minor |
| `feat!:` / `BREAKING CHANGE:` | minor (pre-1.0) |

Closes #26.

## Test plan

- [x] CI green (no behavioral change to test code)
- [ ] First `feat!:` after this lands cuts a minor, not a major (will manually verify on next breaking change — out of band)