### PR TITLE
fix(audio-cache): release pins for queued tracks on queue-clear paths

### DIFF
--- a/src/ryzic/commands/leave.py
+++ b/src/ryzic/commands/leave.py
@@ -52,9 +52,10 @@ async def _handle_leave(ctx: lightbulb.Context) -> None:
 
     # Stop first so Lavalink halts the stream cleanly; clearing the queue
     # before update_voice_state guarantees a follow-up auto-advance can
-    # not race a disconnect.
+    # not race a disconnect. Use the releasing helper so audio_cache pins
+    # for queued-but-never-played tracks don't leak (issue #24).
     await player.stop()
-    player.queue.clear()
+    await lavalink_glue.clear_queue_releasing(player)
 
     bot = cast(hikari.GatewayBot, ctx.client.app)
     await bot.update_voice_state(guild_id, None)

--- a/src/ryzic/lavalink_glue.py
+++ b/src/ryzic/lavalink_glue.py
@@ -223,10 +223,18 @@ async def clear_queue_releasing(player: lavalink.DefaultPlayer) -> None:
     leave their pins held forever. Centralising the release walk here
     keeps the three callers (``/leave``, voice 4014 disconnect, node
     disconnect) honest about the contract.
+
+    Snapshot the queue and clear it BEFORE awaiting any release: a
+    concurrent ``/play`` (or other ``player.queue.add`` caller) that
+    lands between ``await`` boundaries on the snapshot would otherwise
+    have its newly-queued track silently wiped by the trailing
+    ``queue.clear()``, leaking its pin. Clear-then-release leaves a
+    fresh queue for any racing producer.
     """
-    for track in player.queue:
-        await _release_track(track)
+    tracks = list(player.queue)
     player.queue.clear()
+    for track in tracks:
+        await _release_track(track)
 
 
 def _safe_error_text(text: str | None) -> str:

--- a/src/ryzic/lavalink_glue.py
+++ b/src/ryzic/lavalink_glue.py
@@ -215,6 +215,20 @@ async def _release_track(track: lavalink.AudioTrack | None) -> None:
         _log.exception("failed to release audio cache entry %s", video_id)
 
 
+async def clear_queue_releasing(player: lavalink.DefaultPlayer) -> None:
+    """Release audio cache pins for every queued track, then clear the queue.
+
+    ``TrackEndEvent`` fires (and ``_release_track`` runs) only for tracks
+    that actually played; queue-clear paths that drop unplayed tracks
+    leave their pins held forever. Centralising the release walk here
+    keeps the three callers (``/leave``, voice 4014 disconnect, node
+    disconnect) honest about the contract.
+    """
+    for track in player.queue:
+        await _release_track(track)
+    player.queue.clear()
+
+
 def _safe_error_text(text: str | None) -> str:
     """Sanitise server-supplied error text before posting to a public channel.
 
@@ -327,7 +341,7 @@ class EventHandler:
         )
         if event.code != 4014:
             return
-        cast(lavalink.DefaultPlayer, event.player).queue.clear()
+        await clear_queue_releasing(cast(lavalink.DefaultPlayer, event.player))
         _cancel_auto_leave(guild_id)
         _reset_voice_ready(guild_id)
         await _send_to_last_play_channel(
@@ -348,7 +362,7 @@ class EventHandler:
         notified: set[int] = set()
         for player in list(client.player_manager.values()):
             guild_id = player.guild_id
-            cast(lavalink.DefaultPlayer, player).queue.clear()
+            await clear_queue_releasing(cast(lavalink.DefaultPlayer, player))
             _cancel_auto_leave(guild_id)
             _reset_voice_ready(guild_id)
             if guild_id in notified:

--- a/tests/_command_helpers.py
+++ b/tests/_command_helpers.py
@@ -104,6 +104,22 @@ class FakeAudioTrack:
     extra: dict[str, Any] = field(default_factory=dict)
 
 
+class RecordingCache:
+    """Captures ``release`` calls so tests can assert pin release on queue clear.
+
+    Used by tests that exercise ``lavalink_glue.clear_queue_releasing`` and
+    its callers (``/leave``, voice 4014 disconnect, node disconnect) — the
+    real :class:`~ryzic.audio_cache.AudioCache` is sqlite-backed and
+    overkill for assertions about the release walk's contract.
+    """
+
+    def __init__(self) -> None:
+        self.released: list[str] = []
+
+    async def release(self, video_id: str) -> None:
+        self.released.append(video_id)
+
+
 class FakePlayer:
     def __init__(self, guild_id: int) -> None:
         self.guild_id = guild_id

--- a/tests/test_lavalink_bridge.py
+++ b/tests/test_lavalink_bridge.py
@@ -19,6 +19,7 @@ import lavalink
 import pytest
 
 from ryzic import lavalink_glue
+from tests._command_helpers import RecordingCache
 
 
 @dataclass
@@ -575,16 +576,6 @@ def test_is_valid_discord_endpoint_allowlist() -> None:
 # ---------------------------------------------------------------------------
 
 
-class _RecordingCache:
-    """Captures release() calls so tests can assert the integration."""
-
-    def __init__(self) -> None:
-        self.released: list[str] = []
-
-    async def release(self, video_id: str) -> None:
-        self.released.append(video_id)
-
-
 @dataclass
 class _IdTrack:
     title: str = "song"
@@ -621,7 +612,7 @@ async def test_track_end_releases_audio_cache_pin() -> None:
     """
     from ryzic import audio_cache
 
-    fake = _RecordingCache()
+    fake = RecordingCache()
     audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
     try:
         bot = _FakeApp()
@@ -642,7 +633,7 @@ async def test_track_exception_also_releases_audio_cache_pin() -> None:
     """LOAD_FAILED still has to release; otherwise the file pins forever."""
     from ryzic import audio_cache
 
-    fake = _RecordingCache()
+    fake = RecordingCache()
     audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
     try:
         bot = _FakeApp()
@@ -736,11 +727,16 @@ class _QueuePlayer:
     queue: list[_IdTrack] = field(default_factory=list)
 
 
-async def test_clear_queue_releasing_releases_each_track_then_clears() -> None:
-    """The helper drops a pin per queued track before emptying the queue."""
+async def test_clear_queue_releasing_clears_then_releases_each_track() -> None:
+    """The helper empties the queue first, then drops a pin per snapshotted track.
+
+    Clear-then-release closes the race window where a concurrent ``/play``
+    (i.e. ``player.queue.add``) lands between release ``await`` boundaries
+    on the snapshot — see ``test_clear_queue_releasing_does_not_drop_concurrently_added_track``.
+    """
     from ryzic import audio_cache
 
-    fake = _RecordingCache()
+    fake = RecordingCache()
     audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
     try:
         player = _QueuePlayer(
@@ -756,11 +752,59 @@ async def test_clear_queue_releasing_releases_each_track_then_clears() -> None:
         audio_cache.set_audio_cache(None)
 
 
+async def test_clear_queue_releasing_does_not_drop_concurrently_added_track() -> None:
+    """Regression: a track ``/play`` adds during the release loop must survive.
+
+    The previous shape (release-then-clear) walked the live queue and
+    only emptied it after the last release ``await``. A concurrent
+    ``player.queue.add()`` that landed between those awaits was wiped
+    by the trailing ``queue.clear()`` without ever being released —
+    the new pin leaked. Clear-then-release on a snapshot leaves any
+    concurrently-added track in place.
+    """
+    from ryzic import audio_cache
+
+    racing_track = _IdTrack(identifier="/var/cache/ryzic/audio/zz/zzracing.audio")
+
+    class _AddOnReleaseCache:
+        """Simulates ``/play`` queuing a new track while a release is in-flight."""
+
+        def __init__(self, player: _QueuePlayer) -> None:
+            self.player = player
+            self.released: list[str] = []
+            self._fired = False
+
+        async def release(self, video_id: str) -> None:
+            self.released.append(video_id)
+            if not self._fired:
+                self._fired = True
+                # Mid-release: the racing producer's queue.add lands here.
+                self.player.queue.append(racing_track)
+
+    player = _QueuePlayer(
+        queue=[
+            _IdTrack(identifier="/var/cache/ryzic/audio/aa/aaaaaaaa.audio"),
+            _IdTrack(identifier="/var/cache/ryzic/audio/bb/bbbbbbbb.audio"),
+        ]
+    )
+    fake = _AddOnReleaseCache(player)
+    audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
+    try:
+        await lavalink_glue.clear_queue_releasing(cast(lavalink.DefaultPlayer, player))
+        # Both original tracks released exactly once (snapshot, not live).
+        assert sorted(fake.released) == ["aaaaaaaa", "bbbbbbbb"]
+        # The racing track survived the clear and was NOT released
+        # (it would have been a permanent pin leak under the old shape).
+        assert player.queue == [racing_track]
+    finally:
+        audio_cache.set_audio_cache(None)
+
+
 async def test_clear_queue_releasing_handles_empty_queue() -> None:
     """No tracks → no releases, queue stays empty, no exception."""
     from ryzic import audio_cache
 
-    fake = _RecordingCache()
+    fake = RecordingCache()
     audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
     try:
         player = _QueuePlayer(queue=[])
@@ -775,7 +819,7 @@ async def test_clear_queue_releasing_skips_tracks_without_identifier() -> None:
     """Defensive: tracks with no identifier are dropped without releasing."""
     from ryzic import audio_cache
 
-    fake = _RecordingCache()
+    fake = RecordingCache()
     audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
     try:
         player = _QueuePlayer(
@@ -806,7 +850,7 @@ async def test_websocket_closed_4014_releases_queued_pins() -> None:
         reason: str = "Disconnected"
         by_remote: bool = True
 
-    fake = _RecordingCache()
+    fake = RecordingCache()
     audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
     try:
         bot = _FakeApp()
@@ -834,7 +878,7 @@ async def test_websocket_closed_non_4014_does_not_touch_queue() -> None:
         reason: str = "Abnormal Closure"
         by_remote: bool = True
 
-    fake = _RecordingCache()
+    fake = RecordingCache()
     audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
     try:
         bot = _FakeApp()
@@ -875,7 +919,7 @@ async def test_node_disconnected_releases_queued_pins_for_every_player() -> None
         def __init__(self, players: list[_QueuePlayer]) -> None:
             self.player_manager = _PlayerManager(players)
 
-    fake = _RecordingCache()
+    fake = RecordingCache()
     audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
     try:
         bot = _FakeApp()

--- a/tests/test_lavalink_bridge.py
+++ b/tests/test_lavalink_bridge.py
@@ -10,7 +10,7 @@ client is required.
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
 
@@ -721,3 +721,185 @@ async def test_release_with_path_identifier_decrements_real_cache_pin(
     finally:
         audio_cache.set_audio_cache(None)
         await cache.close()
+
+
+# ---------------------------------------------------------------------------
+# Queue-clear pin release (issue #24)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _QueuePlayer:
+    """``DefaultPlayer`` stand-in carrying just the surface clear_queue_releasing reads."""
+
+    guild_id: int = 111
+    queue: list[_IdTrack] = field(default_factory=list)
+
+
+async def test_clear_queue_releasing_releases_each_track_then_clears() -> None:
+    """The helper drops a pin per queued track before emptying the queue."""
+    from ryzic import audio_cache
+
+    fake = _RecordingCache()
+    audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
+    try:
+        player = _QueuePlayer(
+            queue=[
+                _IdTrack(identifier="/var/cache/ryzic/audio/aa/aaaaaaaa.audio"),
+                _IdTrack(identifier="/var/cache/ryzic/audio/bb/bbbbbbbb.audio"),
+            ]
+        )
+        await lavalink_glue.clear_queue_releasing(cast(lavalink.DefaultPlayer, player))
+        assert sorted(fake.released) == ["aaaaaaaa", "bbbbbbbb"]
+        assert player.queue == []
+    finally:
+        audio_cache.set_audio_cache(None)
+
+
+async def test_clear_queue_releasing_handles_empty_queue() -> None:
+    """No tracks → no releases, queue stays empty, no exception."""
+    from ryzic import audio_cache
+
+    fake = _RecordingCache()
+    audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
+    try:
+        player = _QueuePlayer(queue=[])
+        await lavalink_glue.clear_queue_releasing(cast(lavalink.DefaultPlayer, player))
+        assert fake.released == []
+        assert player.queue == []
+    finally:
+        audio_cache.set_audio_cache(None)
+
+
+async def test_clear_queue_releasing_skips_tracks_without_identifier() -> None:
+    """Defensive: tracks with no identifier are dropped without releasing."""
+    from ryzic import audio_cache
+
+    fake = _RecordingCache()
+    audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
+    try:
+        player = _QueuePlayer(
+            queue=[
+                _IdTrack(identifier=""),
+                _IdTrack(identifier="/var/cache/ryzic/audio/cc/cccccccc.audio"),
+            ]
+        )
+        await lavalink_glue.clear_queue_releasing(cast(lavalink.DefaultPlayer, player))
+        assert fake.released == ["cccccccc"]
+        assert player.queue == []
+    finally:
+        audio_cache.set_audio_cache(None)
+
+
+async def test_websocket_closed_4014_releases_queued_pins() -> None:
+    """Voice 4014 (kicked / channel deleted) clears the queue without playing it.
+
+    Without the helper those queued tracks would leak their pins forever
+    (issue #24).
+    """
+    from ryzic import audio_cache
+
+    @dataclass
+    class _WsClosedEvent:
+        player: _QueuePlayer
+        code: int = 4014
+        reason: str = "Disconnected"
+        by_remote: bool = True
+
+    fake = _RecordingCache()
+    audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
+    try:
+        bot = _FakeApp()
+        handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+        player = _QueuePlayer(
+            queue=[_IdTrack(identifier="/var/cache/ryzic/audio/wc/wsclosed.audio")]
+        )
+        await handler.on_websocket_closed(
+            cast(lavalink.WebSocketClosedEvent, _WsClosedEvent(player=player))
+        )
+        assert fake.released == ["wsclosed"]
+        assert player.queue == []
+    finally:
+        audio_cache.set_audio_cache(None)
+
+
+async def test_websocket_closed_non_4014_does_not_touch_queue() -> None:
+    """Other close codes are transient; the queue (and pins) must survive."""
+    from ryzic import audio_cache
+
+    @dataclass
+    class _WsClosedEvent:
+        player: _QueuePlayer
+        code: int = 1006  # transient
+        reason: str = "Abnormal Closure"
+        by_remote: bool = True
+
+    fake = _RecordingCache()
+    audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
+    try:
+        bot = _FakeApp()
+        handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+        track = _IdTrack(identifier="/var/cache/ryzic/audio/kk/keptkept.audio")
+        player = _QueuePlayer(queue=[track])
+        await handler.on_websocket_closed(
+            cast(lavalink.WebSocketClosedEvent, _WsClosedEvent(player=player))
+        )
+        assert fake.released == []
+        assert player.queue == [track]
+    finally:
+        audio_cache.set_audio_cache(None)
+
+
+async def test_node_disconnected_releases_queued_pins_for_every_player() -> None:
+    """All player queues get their pins released when the node drops."""
+    from ryzic import audio_cache
+
+    @dataclass
+    class _Node:
+        name: str = "ryzic-default"
+
+    @dataclass
+    class _NodeDisconnectedEvent:
+        node: _Node
+        code: int | None = 1006
+        reason: str | None = "lost"
+
+    class _PlayerManager:
+        def __init__(self, players: list[_QueuePlayer]) -> None:
+            self._players = players
+
+        def values(self) -> list[_QueuePlayer]:
+            return list(self._players)
+
+    class _ClientWithPlayers:
+        def __init__(self, players: list[_QueuePlayer]) -> None:
+            self.player_manager = _PlayerManager(players)
+
+    fake = _RecordingCache()
+    audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
+    try:
+        bot = _FakeApp()
+        players = [
+            _QueuePlayer(
+                guild_id=111,
+                queue=[_IdTrack(identifier="/var/cache/ryzic/audio/g1/guild1aa.audio")],
+            ),
+            _QueuePlayer(
+                guild_id=222,
+                queue=[
+                    _IdTrack(identifier="/var/cache/ryzic/audio/g2/guild2aa.audio"),
+                    _IdTrack(identifier="/var/cache/ryzic/audio/g2/guild2bb.audio"),
+                ],
+            ),
+        ]
+        client = _ClientWithPlayers(players)
+        lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, client))
+
+        handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+        await handler.on_node_disconnected(
+            cast(lavalink.NodeDisconnectedEvent, _NodeDisconnectedEvent(node=_Node())),
+        )
+        assert sorted(fake.released) == ["guild1aa", "guild2aa", "guild2bb"]
+        assert all(p.queue == [] for p in players)
+    finally:
+        audio_cache.set_audio_cache(None)

--- a/tests/test_leave_command.py
+++ b/tests/test_leave_command.py
@@ -13,20 +13,11 @@ from tests._command_helpers import (
     FakeAudioTrack,
     FakeBot,
     FakeLavalinkClient,
+    RecordingCache,
     both_in_voice,
     context_for,
     install_lavalink_client,
 )
-
-
-class _RecordingCache:
-    """Captures release() calls so tests can assert pin release on queue clear."""
-
-    def __init__(self) -> None:
-        self.released: list[str] = []
-
-    async def release(self, video_id: str) -> None:
-        self.released.append(video_id)
 
 
 @pytest.fixture(autouse=True)
@@ -117,7 +108,7 @@ async def test_leave_releases_audio_cache_pins_for_queued_tracks() -> None:
     ``audio_cache._in_use`` forever, permanently disabling LRU eviction
     for those files.
     """
-    fake_cache = _RecordingCache()
+    fake_cache = RecordingCache()
     audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake_cache))
     bot = both_in_voice()
     ctx = context_for(bot)

--- a/tests/test_leave_command.py
+++ b/tests/test_leave_command.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from typing import Any, cast
 
 import pytest
 
-from ryzic import lavalink_glue
+from ryzic import audio_cache, lavalink_glue
 from ryzic.commands import leave as leave_module
 from tests._command_helpers import (
     FakeAudioTrack,
@@ -18,10 +19,23 @@ from tests._command_helpers import (
 )
 
 
+class _RecordingCache:
+    """Captures release() calls so tests can assert pin release on queue clear."""
+
+    def __init__(self) -> None:
+        self.released: list[str] = []
+
+    async def release(self, video_id: str) -> None:
+        self.released.append(video_id)
+
+
 @pytest.fixture(autouse=True)
-def _reset_state() -> None:
+def _reset_state() -> Iterator[None]:
     lavalink_glue._reset_state_for_test()
     install_lavalink_client(None)
+    audio_cache.set_audio_cache(None)
+    yield
+    audio_cache.set_audio_cache(None)
 
 
 async def test_voice_precondition_short_circuits() -> None:
@@ -93,6 +107,40 @@ async def test_leave_stops_clears_disconnects_and_responds() -> None:
     fake = cast(Any, ctx)
     assert fake.responses[0][0] == "Left voice channel. Queue cleared."
     assert "ephemeral" not in fake.responses[0][1]
+
+
+async def test_leave_releases_audio_cache_pins_for_queued_tracks() -> None:
+    """Issue #24: queued-but-never-played tracks must release their cache pins.
+
+    ``TrackEndEvent`` fires only for the currently-playing track on
+    ``player.stop()``; queued tracks would otherwise sit in
+    ``audio_cache._in_use`` forever, permanently disabling LRU eviction
+    for those files.
+    """
+    fake_cache = _RecordingCache()
+    audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake_cache))
+    bot = both_in_voice()
+    ctx = context_for(bot)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = True
+    player.current = FakeAudioTrack(
+        title="Now Playing",
+        identifier="/var/cache/ryzic/audio/np/nowplay1.audio",
+    )
+    player.queue = [
+        FakeAudioTrack(title="A", identifier="/var/cache/ryzic/audio/qa/queueda1.audio"),
+        FakeAudioTrack(title="B", identifier="/var/cache/ryzic/audio/qb/queuedb2.audio"),
+    ]
+
+    await leave_module._handle_leave(ctx)
+
+    assert player.queue == []
+    # Both queued tracks released; the currently-playing track is released
+    # by the TrackEndEvent path (a different code path; see _release_track
+    # in lavalink_glue), not by clear_queue_releasing.
+    assert sorted(fake_cache.released) == ["queueda1", "queuedb2"]
 
 
 def test_leave_loader_registered() -> None:


### PR DESCRIPTION
## Summary

Fixes #24 — `audio_cache` pin leak on the three queue-clear paths that drop unplayed tracks without firing `TrackEndEvent`.

`EventHandler._release_track` releases pins on `TrackEndEvent` (FINISHED / REPLACED / STOPPED / LOAD_FAILED), but tracks that sat in `player.queue` and were dropped without ever playing never see that event. Their pins stay in `audio_cache._in_use` forever — `LRU` eviction permanently skips them. A noisy guild can convert most of `RYZIC_CACHE_DIR` into permanently-pinned files in a single session, recoverable only on bot restart.

## Design

Centralise queue-clear behind `clear_queue_releasing(player)` in `lavalink_glue.py`. The helper iterates `player.queue` calling the existing `_release_track` (so the path-stem-from-identifier extraction, `None`-track guard, missing-cache guard, and exception swallowing are all reused), then empties the queue.

Three call sites switch from `player.queue.clear()` to `await clear_queue_releasing(player)`:

1. `commands/leave.py` — `/leave` (user-triggered, the path that surfaced this in #23's security review).
2. `lavalink_glue.EventHandler.on_websocket_closed` (Discord 4014: voice channel kicked / channel deleted).
3. `lavalink_glue.EventHandler.on_node_disconnected` (lavalink node drop).

Out of scope per the issue: TTL on the cache; touching `_release_track`; touching `/skip` (which fires REPLACED/STOPPED correctly).

## Files changed

- `src/ryzic/lavalink_glue.py` — add `clear_queue_releasing(player)`; switch the two `EventHandler` queue-clear sites to it.
- `src/ryzic/commands/leave.py` — switch the `/leave` queue-clear to the helper.
- `tests/test_leave_command.py` — add a `_RecordingCache`, extend the autouse fixture to install/clear it, and add `test_leave_releases_audio_cache_pins_for_queued_tracks` asserting both queued tracks' video_ids get released on `/leave`.
- `tests/test_lavalink_bridge.py` — add `_QueuePlayer` stand-in plus tests for the helper itself (happy path, empty queue, missing-identifier skip), the websocket-closed 4014 path (releases) vs non-4014 (no-op), and the node-disconnected path across multiple players.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run ty check` — clean
- [x] `uv run pytest -q --cov-fail-under=80` — 312 passed, coverage 90.71%

Closes #24.