### PR TITLE
fix(audio-cache): release queued pins on guild-leave teardown path

### DIFF
--- a/src/ryzic/lavalink_glue.py
+++ b/src/ryzic/lavalink_glue.py
@@ -481,6 +481,9 @@ async def _on_guild_leave(event: hikari.GuildLeaveEvent) -> None:
     client = _ll_client
     if client is not None:
         try:
+            player = cast(lavalink.DefaultPlayer | None, client.player_manager.get(guild_id))
+            if player is not None:
+                await clear_queue_releasing(player)
             await client.player_manager.destroy(guild_id)
         except Exception:
             _log.exception("guild=%d failed to destroy player on guild-leave", guild_id)

--- a/tests/test_lavalink_bridge.py
+++ b/tests/test_lavalink_bridge.py
@@ -894,6 +894,47 @@ async def test_websocket_closed_non_4014_does_not_touch_queue() -> None:
         audio_cache.set_audio_cache(None)
 
 
+async def test_guild_leave_releases_queued_pins_then_destroys_player() -> None:
+    """Bot kicked / leaving a guild must release queued pins before destroy.
+
+    Sibling of issue #24 (PR #28): without releasing first, queued tracks
+    that never fire ``TrackEndEvent`` keep their pins forever — a noisy
+    guild that kicks the bot would leak the entire queue.
+    """
+    from ryzic import audio_cache
+
+    destroy_calls: list[int] = []
+    queued_player = _QueuePlayer(
+        queue=[
+            _IdTrack(identifier="/var/cache/ryzic/audio/gl/glleave1.audio"),
+            _IdTrack(identifier="/var/cache/ryzic/audio/gl/glleave2.audio"),
+        ]
+    )
+
+    class _PlayerManager:
+        def get(self, guild_id: int) -> _QueuePlayer | None:
+            return queued_player if guild_id == 111 else None
+
+        async def destroy(self, guild_id: int) -> None:
+            destroy_calls.append(guild_id)
+
+    class _Client:
+        def __init__(self) -> None:
+            self.player_manager = _PlayerManager()
+
+    fake = RecordingCache()
+    audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, _Client()))
+    try:
+        await lavalink_glue._on_guild_leave(_make_guild_leave_event(111))
+        assert sorted(fake.released) == ["glleave1", "glleave2"]
+        assert queued_player.queue == []
+        # Existing teardown must still run so the player_manager entry goes away.
+        assert destroy_calls == [111]
+    finally:
+        audio_cache.set_audio_cache(None)
+
+
 async def test_node_disconnected_releases_queued_pins_for_every_player() -> None:
     """All player queues get their pins released when the node drops."""
     from ryzic import audio_cache


### PR DESCRIPTION
## Summary

Sibling of issue #29 — same audio-cache pin-leak pattern as #24/PR #28, this time on the guild-leave teardown path.

`EventHandler._on_guild_leave` (in `src/ryzic/lavalink_glue.py`) called `player_manager.destroy(guild_id)` directly. Tracks sitting in `player.queue` that never played never see `TrackEndEvent`, so `_release_track` never runs and their `audio_cache._in_use` pins stay held forever — a guild kicking the bot mid-queue would leak every queued file's pin.

## Design

Reuses the existing `clear_queue_releasing(player)` helper PR #28 added: fetch the player via `player_manager.get(guild_id)`, run the release-then-clear walk if a player exists, then proceed with the existing `destroy(guild_id)`. Only `_on_guild_leave` changed; the helper is unchanged. Whole new block stays inside the existing `try` so any failure still hits the `Exception` log line that was already there.

## Files changed

- `src/ryzic/lavalink_glue.py` — `_on_guild_leave` now releases queued pins before `player_manager.destroy()`.
- `tests/test_lavalink_bridge.py` — new `test_guild_leave_releases_queued_pins_then_destroys_player` exercising the full path with a fake `player_manager` whose `get` returns a `_QueuePlayer` with two queued tracks and whose `destroy` records calls; asserts both video_ids land in `RecordingCache.released` AND that `destroy(guild_id)` still ran.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run ty check` — clean
- [x] `uv run pytest -q --cov-fail-under=80` — 314 passed, coverage 90.91%

Closes #29.