### PR TITLE
docs(readme): add CodeQL + latest-release badges for the public repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ryzic
 
 [![CI](https://github.com/VeryLongOrgNameSuchWow/ryzic/actions/workflows/ci.yml/badge.svg)](https://github.com/VeryLongOrgNameSuchWow/ryzic/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/VeryLongOrgNameSuchWow/ryzic/actions/workflows/codeql.yml/badge.svg)](https://github.com/VeryLongOrgNameSuchWow/ryzic/actions/workflows/codeql.yml)
+[![Latest release](https://img.shields.io/github/v/release/VeryLongOrgNameSuchWow/ryzic?include_prereleases&sort=semver)](https://github.com/VeryLongOrgNameSuchWow/ryzic/releases)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13%2B-blue.svg)](https://www.python.org/downloads/)
 


### PR DESCRIPTION
## Summary

Two new badges in the README header now that the repo is public:

- **CodeQL** — visibility-gated workflow added in PR #22 will now actually run; badge surfaces its status.
- **Latest release** — `shields.io` queries the GitHub Releases API; populates the moment the first release lands.

## Test plan

- [x] Markdown renders (badges visible at top of README on the PR diff)
- [ ] CodeQL workflow runs successfully on this PR (validates the visibility gate works post-flip)
- [ ] Latest-release badge resolves to "no releases" until PR #30 merges, then to "v0.1.0"

Part of #25.