### PR TITLE
chore(ci): add OSSF Scorecard + Dependabot non-major auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,43 @@
+name: Dependabot auto-merge
+
+# Auto-approves and enables auto-merge (squash) for non-major Dependabot PRs.
+# Major bumps are left for manual review.
+#
+# The repo ruleset on `main` requires squash-only merges + status checks pass,
+# so `gh pr merge --auto --squash` queues the PR and GitHub completes the
+# merge once CI is green. Repo settings already have allow_auto_merge: true
+# and delete_branch_on_merge: true, so no further cleanup is needed.
+#
+# Uses the default GITHUB_TOKEN (sufficient for self-PR actions); no App
+# token needed since this workflow does not need to fire downstream workflows
+# the way release-please does.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve non-major bumps
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr review --approve "$PR_URL"
+
+      - name: Enable auto-merge for non-major bumps
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,47 @@
+name: Scorecard
+
+# OSSF Scorecard supply-chain analysis. Runs weekly + on push to `main` and
+# uploads SARIF to the Security tab. `publish_results: true` posts the score
+# to securityscorecards.dev so the public badge resolves once added to README
+# (separate follow-up — this PR is workflow-only).
+#
+# No PR trigger on purpose: Scorecard scores `main` state, not per-PR diffs.
+
+on:
+  schedule:
+    # Weekly Monday 04:19 UTC. Off-zero minute to dodge the :00 stampede.
+    - cron: "19 4 * * 1"
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload SARIF to code scanning
+      id-token: write           # publish_results OIDC attestation
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - uses: github/codeql-action/upload-sarif@c3f298df8c1fea2fefe20c785e6aa00f32df8260  # v4.35.3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Two CI additions completing the public-flip workflow checklist tracked in #25.

## `scorecard.yml` — OSSF Scorecard

Runs the canonical `ossf/scorecard-action` weekly (Monday 04:19 UTC, off-zero) and on every push to `main`. Uploads SARIF to GitHub code scanning so findings show up in the Security tab, and sets `publish_results: true` so the score is posted to `securityscorecards.dev` and the public badge will resolve when added to README. No PR trigger — Scorecard scores `main` state, not per-PR diffs. Top-level `read-all` with the job carrying just `security-events: write`, `id-token: write`, `contents: read`, `actions: read` per the action's docs.

## `dependabot-auto-merge.yml` — non-major auto-merge

Reads the bump's `update-type` via `dependabot/fetch-metadata`. For non-major bumps it `gh pr review --approve`s and `gh pr merge --auto --squash`es, leaning on the existing `main` ruleset to gate the actual merge on green CI + squash-only. Major bumps fall through with no action so they wait for manual review (consistent with how yt-dlp gets its own ungrouped slot in `dependabot.yml`). Uses `secrets.GITHUB_TOKEN` — no App token needed because this workflow does not need to fire downstream workflows the way release-please does.

## Out of scope

- README Scorecard badge — separate small PR if you want it (the badge resolves only after the first scheduled run posts results).
- Any `dependabot.yml` changes — schedule + groupings already correct.

## Pinned action SHAs

- `ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a` (v2.4.3)
- `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (v7.0.1)
- `dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98` (v3.1.0)
- `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2) — reused from existing workflows
- `github/codeql-action/upload-sarif@c3f298df8c1fea2fefe20c785e6aa00f32df8260` (v4.35.3) — reused from `codeql.yml`

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` passes for both files
- [x] `uv run ruff check && uv run ruff format --check && uv run ty check && uv run pytest -q --cov-fail-under=80` — all green (no source changes)
- [ ] Watch the first Scorecard run after merge: SARIF uploads to Security tab, score appears at `https://securityscorecards.dev/viewer/?uri=github.com/VeryLongOrgNameSuchWow/ryzic`
- [ ] Confirm dependabot-auto-merge fires on the next dependabot PR (non-major path approves + queues; major path no-ops)

Refs #25