### PR TITLE
fix(ci): exempt yt-dlp from Dependabot auto-merge to match dependabot.yml intent

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,6 +2,7 @@ name: Dependabot auto-merge
 
 # Auto-approves and enables auto-merge (squash) for non-major Dependabot PRs.
 # Major bumps are left for manual review.
+# yt-dlp is also exempt from auto-merge — it parses untrusted user URLs and ships frequent releases (mirrors the ungrouped dependabot.yml carve-out).
 #
 # The repo ruleset on `main` requires squash-only merges + status checks pass,
 # so `gh pr merge --auto --squash` queues the PR and GitHub completes the
@@ -29,14 +30,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Approve non-major bumps
-        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' && !contains(steps.metadata.outputs.dependency-names, 'yt-dlp') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr review --approve "$PR_URL"
 
       - name: Enable auto-merge for non-major bumps
-        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' && !contains(steps.metadata.outputs.dependency-names, 'yt-dlp') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## The bug

PR #33 (\`chore(ci): add OSSF Scorecard + Dependabot non-major auto-merge\`) added \`.github/workflows/dependabot-auto-merge.yml\`, which auto-approves and enables auto-merge for **any** non-major Dependabot PR. That silently undoes the documented carve-out in \`dependabot.yml\`, which ungroups \`yt-dlp\` from the \`python-minor-and-patch\` group so each YouTube fix is reviewed individually:

\`\`\`yaml
groups:
  python-minor-and-patch:
    update-types: [minor, patch]
    exclude-patterns:
      - yt-dlp
\`\`\`

yt-dlp parses untrusted user-supplied URLs into network fetches and subprocess invocations and ships frequent releases tracking YouTube changes — exactly the package we don't want auto-merging on a green CI.

## The fix

Add a \`!contains(steps.metadata.outputs.dependency-names, 'yt-dlp')\` clause to the existing step-level \`if:\` on both the auto-approve and auto-merge steps so yt-dlp PRs fall through to manual review. Major bumps remain manual as before. The \`actor == 'dependabot[bot]'\` job-level filter is unchanged.

The top-of-file comment was extended with one sentence noting the exemption mirrors the \`dependabot.yml\` carve-out.

## Test plan

- [ ] First yt-dlp Dependabot PR after merge stays open requiring manual approval (the auto-approve + auto-merge steps both skip).
- [ ] First non-yt-dlp non-major Dependabot bump (e.g. another pip dep, or a github-actions update) still gets auto-approved + auto-merged as before.
- [ ] Any future major bump for any dependency continues to require manual review.

Surfaced by the foss-audit-v2 supply-chain audit teammate.