### PR TITLE
chore(repo): FOSS audit polish — env gate + CONTRIBUTING fix + README upgrade/roadmap/support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Tying this job to a GitHub Environment gives maintainers a one-click
+    # "pause deployments" brake from Settings → Environments → ghcr without
+    # editing or disabling the workflow file.
+    environment: ghcr
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Squash your branch into a single Conventional Commit at merge time, or keep indi
 2. Branch off `main`. Push to a feature branch (we don't accept pushes directly to `main`).
 3. Make sure CI is green: `uv run ruff check && uv run ruff format --check && uv run ty check && uv run pytest -q`.
 4. Open a PR. Keep the PR focused — one logical change per PR is much easier to review than a kitchen sink.
-5. PRs need at least one approving review before merge. Don't self-merge.
+5. External PRs get a maintainer review before merge. Maintainer self-merges are OK once CI is green and the review gates below come back clean — there is currently a single maintainer, so an outside approval isn't always available, but the gates are non-negotiable.
 
 Before-merge gates (run as separate review passes on substantial PRs):
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 A self-hostable Discord music bot. Plays YouTube audio in voice channels via [Lavalink](https://lavalink.dev/), with a local LRU cache so frequently-played tracks survive yt-dlp breakage. One bot per server you run yourself; no public hosting, no telemetry, no premium tier.
 
+> **Roadmap:** see [open milestones](https://github.com/VeryLongOrgNameSuchWow/ryzic/milestones) and the [`epic` label](https://github.com/VeryLongOrgNameSuchWow/ryzic/issues?q=is%3Aissue+is%3Aopen+label%3Aepic) for what's planned next.
+>
+> **Support:** maintainer is best-effort and typically responds to issues and PRs within ~a week. Bugs and feature requests go in [Issues](https://github.com/VeryLongOrgNameSuchWow/ryzic/issues); see [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR.
+
 ## Features
 
 - Six slash commands: `/play`, `/skip`, `/queue`, `/pause`, `/resume`, `/leave`.
@@ -96,6 +100,15 @@ All configuration is via environment variables (read from `.env` by `docker comp
 | `RYZIC_CACHE_MAX_GB` | no | `5` | LRU eviction kicks in once cached audio exceeds this size (GiB). |
 | `RYZIC_LOG_LEVEL` | no | `INFO` | One of `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. |
 | `RYZIC_GUILD_IDS` | no | unset | Comma-separated guild IDs for instant slash-command registration. Unset = global registration (up to 1h propagation). |
+
+## Upgrading
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+The image is pinned to `:latest` by default; pin to a specific `:vX.Y.Z` in your `compose.yaml` if you want manual control over upgrades. The audio + playlist cache (the `RYZIC_CACHE_DIR` bind mount) and the SQLite database inside it persist across upgrades — `docker compose pull` only replaces the image, not the volume.
 
 ## Self-hoster considerations
 


### PR DESCRIPTION
## Summary

Bundle A of the FOSS audit cleanup. Five small, tightly-related polish items in one PR — no behavior change, only workflow + docs.

**Tier 1**

- **#2 — `environment:` gate on `release.yml`.** Adds `environment: ghcr` to the release job so maintainers can pause deployments from Settings → Environments without editing the workflow file. Empty environment created via `gh api -X PUT repos/.../environments/ghcr` (no protection rules yet — that's a follow-up if/when needed).
- **#5 — CONTRIBUTING self-contradiction.** The file demanded an outside approving review while ryzic has a single maintainer. Reworded to: external PRs get maintainer review; maintainer self-merges are OK once CI is green and the review gates (`/review`, `/security-review`, `/simplify`) come back clean.

**Tier 2**

- **#11 — README `## Upgrading` section.** `docker compose pull && docker compose up -d`, with a note that the cache directory + SQLite DB persist across upgrades.
- **#18 — Roadmap pointer in README.** One-line callout to [open milestones](https://github.com/VeryLongOrgNameSuchWow/ryzic/milestones) and the [`epic` label](https://github.com/VeryLongOrgNameSuchWow/ryzic/issues?q=is%3Aissue+is%3Aopen+label%3Aepic). The `epic` label exists on the repo and #8 (M2) already carries it.
- **#20 — "responds within ~a week" line.** Sets maintainer-response expectations explicitly in the README under the new callout block.

## Verification

All four gates pass on this branch:

- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run ty check`
- [x] `uv run pytest -q --cov-fail-under=80` — 314 passed, coverage 90.91%
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`

## Test plan

- [ ] CI green on this PR (lint + ty + pytest + docker build).
- [ ] Confirm the `environment: ghcr` gate shows up under Settings → Environments and is reachable for the release job (no protection rules required to function).
- [ ] Sanity-check rendered README: roadmap pointer + support line read naturally above the Features section; Upgrading section sits between Configuration and Self-hoster considerations.