### PR TITLE
feat(deploy): pull-only compose.yaml for v0.1.0 GHCR consumers

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -37,6 +37,7 @@
           - "Dockerfile"
           - ".dockerignore"
           - "compose.yaml"
+          - "compose.dev.yaml"
           - "lavalink/**"
           - "tests/integration/**"
 

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -14,6 +14,7 @@ on:
       - Dockerfile
       - .dockerignore
       - compose.yaml
+      - compose.dev.yaml
       - lavalink/application.yml
       - .github/workflows/release.yml
       - .github/workflows/release-dry-run.yml

--- a/README.md
+++ b/README.md
@@ -36,12 +36,17 @@ A self-hostable Discord music bot. Plays YouTube audio in voice channels via [La
    - **Do not pick Administrator.** A music bot has no business with admin rights — it's a security smell and many server owners refuse such invites.
 5. Open the generated URL and invite the bot to your server.
 
-### 2. Clone and configure
+### 2. Fetch the deploy files
+
+You only need three files on disk — the published [`ghcr.io/verylongorgnamesuchwow/ryzic`](https://github.com/VeryLongOrgNameSuchWow/ryzic/pkgs/container/ryzic) image carries the bot itself, so there's no source tree to maintain.
 
 ```bash
-git clone https://github.com/VeryLongOrgNameSuchWow/ryzic.git
-cd ryzic
-cp .env.example .env
+mkdir ryzic && cd ryzic
+curl -fsSLO https://raw.githubusercontent.com/VeryLongOrgNameSuchWow/ryzic/main/compose.yaml
+curl -fsSLO https://raw.githubusercontent.com/VeryLongOrgNameSuchWow/ryzic/main/.env.example
+mkdir lavalink && curl -fsSL -o lavalink/application.yml \
+  https://raw.githubusercontent.com/VeryLongOrgNameSuchWow/ryzic/main/lavalink/application.yml
+mv .env.example .env
 ```
 
 Edit `.env` and paste the token into `DISCORD_BOT_TOKEN=`.
@@ -58,11 +63,13 @@ RYZIC_GUILD_IDS=123456789012345678
 docker compose up -d
 ```
 
-The first boot pulls the Lavalink image and downloads the `youtube-source` plugin (~30s). Tail the logs to confirm both services are healthy:
+The first boot pulls the ryzic + Lavalink images and downloads the `youtube-source` plugin (~30s). Tail the logs to confirm both services are healthy:
 
 ```bash
 docker compose logs -f
 ```
+
+`compose.yaml` pins the bot to the `:0.1` minor tag — `docker compose pull && docker compose up -d` picks up patch releases on the 0.1.x line. Bumping to a future `:0.2` is a manual edit, since pre-1.0 minor bumps may include breaking changes (see [SEMVER.md](SEMVER.md)).
 
 ### 4. Try it
 
@@ -109,10 +116,20 @@ All configuration is via environment variables (read from `.env` by `docker comp
 You don't need Docker to hack on the code — only to run a real Lavalink (which the integration tests spin up themselves via testcontainers).
 
 ```bash
+git clone https://github.com/VeryLongOrgNameSuchWow/ryzic.git
+cd ryzic
 uv sync
 uv run pytest -q
 uv run python -m ryzic    # requires DISCORD_BOT_TOKEN + a reachable Lavalink
 ```
+
+To run the local working tree under compose instead of the published GHCR image, layer the dev overlay on top of `compose.yaml`:
+
+```bash
+docker compose -f compose.yaml -f compose.dev.yaml up --build
+```
+
+The overlay swaps `image: ghcr.io/...` for `build: .` so iteration doesn't require pushing to GHCR.
 
 Run the same lint/type/test suite CI runs before opening a PR — see [CONTRIBUTING.md § Pull requests](CONTRIBUTING.md#pull-requests) for the canonical command. [docs/manual-smoke-tests.md](docs/manual-smoke-tests.md) is the end-to-end checklist run before each release.
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ The first boot pulls the ryzic + Lavalink images and downloads the `youtube-sour
 docker compose logs -f
 ```
 
-`compose.yaml` pins the bot to the `:0.1` minor tag — `docker compose pull && docker compose up -d` picks up patch releases on the 0.1.x line. Bumping to a future `:0.2` is a manual edit, since pre-1.0 minor bumps may include breaking changes (see [SEMVER.md](SEMVER.md)).
-
 ### 4. Try it
 
 Join a voice channel, then in any text channel the bot can see:
@@ -115,7 +113,9 @@ docker compose pull
 docker compose up -d
 ```
 
-The image is pinned to `:latest` by default; pin to a specific `:vX.Y.Z` in your `compose.yaml` if you want manual control over upgrades. The audio + playlist cache (the `RYZIC_CACHE_DIR` bind mount) and the SQLite database inside it persist across upgrades — `docker compose pull` only replaces the image, not the volume.
+`compose.yaml` pins the bot to the `:0.1` minor tag, so `docker compose pull` picks up 0.1.x patch releases automatically. Bumping to a future `:0.2` is a manual edit — pre-1.0 minor bumps may include breaking changes (see [SEMVER.md](SEMVER.md)). Pin to a specific `:vX.Y.Z` if you want full manual control.
+
+The audio + playlist cache (the `RYZIC_CACHE_DIR` bind mount) and the SQLite database inside it persist across upgrades — `docker compose pull` only replaces the image, not the volume.
 
 ## Self-hoster considerations
 

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,0 +1,16 @@
+# Compose overlay for local development against a working tree.
+#
+# Usage:
+#   docker compose -f compose.yaml -f compose.dev.yaml up --build
+#
+# This overlay replaces the published GHCR `image:` from compose.yaml with a
+# `build:` from the local Dockerfile, so contributors can iterate without
+# pushing to GHCR. Operators just running the bot don't need this file.
+
+services:
+  ryzic:
+    build: .
+    # The image: from compose.yaml is still inherited; setting it to an
+    # explicit dev tag prevents the local build from cache-colliding with a
+    # previously-pulled GHCR image of the same name.
+    image: ryzic:dev

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,9 @@
 services:
   ryzic:
-    build: .
+    # Pinned to the `:0.1` minor tag: `docker compose pull` picks up 0.1.x
+    # patch releases automatically. Bumping to a future `:0.2` is a manual
+    # edit — pre-1.0 minor bumps may include breaking changes (see SEMVER.md).
+    image: ghcr.io/verylongorgnamesuchwow/ryzic:0.1
     depends_on:
       lavalink:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Restructures the deploy story so the canonical "self-hostable" UX is fetch-three-files-and-up — operators don't need a source clone to run the published GHCR image. With v0.1.0 about to ship the first GHCR build (release-please PR #30), the README-default flow should match what users actually want: pull a published image, not maintain a working tree.

## What changed

- **`compose.yaml`** swaps `build: .` for `image: ghcr.io/verylongorgnamesuchwow/ryzic:0.1`. Pinned to the **minor tag** (not `:latest`) for predictable updates: `docker compose pull` picks up 0.1.x patches automatically; bumping to a future `:0.2` is an explicit manual edit, since pre-1.0 minor bumps may include breaking changes ([SEMVER.md](SEMVER.md)).
- **`compose.dev.yaml` (new)** is a thin overlay re-adding `build: .` for contributors iterating against a working tree:
  ```
  docker compose -f compose.yaml -f compose.dev.yaml up --build
  ```
  Sets `image: ryzic:dev` to avoid cache collisions with the pulled GHCR image.
- **README** install steps now lead with `mkdir ryzic && curl compose.yaml + .env.example + lavalink/application.yml` (the three files an operator actually needs on disk). The `git clone` flow moves under **Development**, alongside the dev-overlay command.
- **`release-dry-run.yml`** also watches `compose.dev.yaml` so changes to it still gate the release path.
- **`.github/labeler.yml`** tags `compose.dev.yaml` under `area:deploy`.

## Design choice (Option A vs B)

The brief offered two shapes: (A) make `compose.yaml` the pull-only one and add a dev overlay, or (B) keep `compose.yaml` as dev-shaped and add a separate `compose.prod.yaml`. **This PR takes A.**

Rationale:
- The pull-only file is what "just want to run it" operators want to be the default they read on the README.
- The dev overlay only needs to add `build:` (and disambiguate the local image tag) — minimal drift surface, since the lavalink/healthcheck/volume/cache stanzas live exclusively in `compose.yaml` and are inherited.
- Option B would require the prod file to either duplicate those stanzas (drift risk) or use the same overlay mechanism in reverse (operators would need to remember to invoke two files). Option A keeps the operator path single-file.

## Image tag pinning

`release.yml`'s `docker/metadata-action` step already emits `:X.Y` from the resolved tag, so `:0.1` automatically points at the latest 0.1.x patch on every release-please cut — no `release-please-config.json` change needed. When 0.2 ships, `:0.1` will freeze (release-please doesn't repoint old minor tags); operators stay on 0.1.x until they manually edit `compose.yaml` to `:0.2`. That's the intended pre-1.0 upgrade ceremony.

## Coordination notes

- `ryzic-cleanup`'s in-flight upgrade-snippet PR adds a `docker compose pull && up -d` section. The pull-only compose here is the foundation that snippet builds on; either PR can land first. If theirs lands first I'll rebase and drop the (smaller) upgrade hint already in §3 to avoid duplication; if mine lands first their snippet slots in cleanly.
- README is also touched by `ryzic-cleanup`'s items 3/4/5. Likely a textual conflict on the install section; whichever lands second rebases.

## Verification

- `uv run ruff check` — passes
- `uv run ruff format --check` — passes
- `uv run ty check` — passes
- `uv run pytest -q --cov-fail-under=80` — 314 passed, coverage 90.91%
- `python3 -c "import yaml; yaml.safe_load(open('<file>'))"` for compose.yaml, compose.dev.yaml, release.yml, release-dry-run.yml, labeler.yml — all OK
- `podman-compose -f compose.yaml config` — resolves, image is `ghcr.io/verylongorgnamesuchwow/ryzic:0.1`
- `podman-compose -f compose.yaml -f compose.dev.yaml config` — resolves, overlay correctly adds `build:` and overrides `image: ryzic:dev`

## Test plan

- [ ] CI green (lint/type/test/coverage + release-dry-run on the new compose.dev.yaml)
- [ ] After v0.1.0 ships, smoke-test the pull-only README flow end-to-end against the live image

🤖 Generated with [Claude Code](https://claude.com/claude-code)