### PR TITLE
feat(release): SLSA build provenance attestation on GHCR push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,11 @@ on:
 permissions:
   contents: write
   packages: write
+  # Required by actions/attest-build-provenance: id-token mints the OIDC
+  # token sigstore uses to identify the builder; attestations writes the
+  # generated SLSA provenance to the repo's attestations store.
+  id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -58,7 +63,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ github.event.inputs.tag || github.ref_name }}
             type=raw,value=latest,enable=${{ github.event_name == 'push' }}
 
-      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+      - id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
           push: true
@@ -66,6 +72,18 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Generates SLSA build provenance for the pushed image and uploads it
+      # to the repo's attestation store. Users can verify with:
+      #   gh attestation verify oci://ghcr.io/<repo>@<digest> --repo <repo>
+      # This only succeeds in a real release context (tag push / dispatch
+      # against a tag) because OIDC token issuance for the sigstore signer
+      # requires `id-token: write` from a workflow run authorized to mint one.
+      - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
       # Release notes are owned by release-please (see release-please.yml).
       # By the time this tag fires, the GitHub Release already exists with


### PR DESCRIPTION
## Summary

Signs every published GHCR image with SLSA build provenance via [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance), giving consumers cryptographic linkage from `:tag` → digest → source commit → builder identity. Brings ryzic to parity with kbmcp, which gets the equivalent free via `pypa/gh-action-pypi-publish`'s default `attestations: true`.

## What changed

- New `permissions:` on the `release` workflow:
  - `id-token: write` — mints the OIDC token sigstore uses to identify the builder.
  - `attestations: write` — writes the generated SLSA provenance to the repo's attestation store.
- Added `id: build` to the existing `docker/build-push-action` step so its `outputs.digest` is referenceable.
- Added `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` (v4.1.0, SHA-pinned) after the build/push step, with:
  - `subject-name: ghcr.io/${{ github.repository }}`
  - `subject-digest: ${{ steps.build.outputs.digest }}`
  - `push-to-registry: true` — uploads the attestation as an OCI artifact alongside the image, so anyone with `gh attestation verify oci://ghcr.io/<repo>@<digest> --repo <repo>` can verify without API access.

## Verifying a release

After the next release-please tag cuts, consumers can run:

```bash
gh attestation verify oci://ghcr.io/verylongorgnamesuchwow/ryzic@<digest> --repo VeryLongOrgNameSuchWow/ryzic
```

…to confirm the image was built from this repository, by this workflow, on this commit. The existing softprops-driven release-notes section composes nicely: users get the digest from the GitHub Release body, then verify it against the attestation in one command.

## CI behavior

**This step will not produce attestations during PR CI** — `release.yml` only runs on tag push or `workflow_dispatch`. PRs don't fire it, so there's no PR-time check to gate on. The first real validation will be the **next release-please-cut tag push** (probably the v0.1.0 cut from PR #30, if that lands after this PR).

If the attestation step itself fails at release time (e.g. transient sigstore outage), the image push has already succeeded — the release is shipped, but un-attested. That's the desired failure mode: provenance is supplemental, not gating.

## Pre-existing observation (not in scope)

While wiring this up I noticed the existing `Append image digest to release notes` step at the bottom uses `steps.meta.outputs.digest`, but `docker/metadata-action` doesn't emit a `digest` output (only `tags`, `labels`, `version`, `json`, etc.). The shell fallback `${IMAGE_DIGEST:-<digest unavailable>}` likely renders "<digest unavailable>" in release notes today. Per the brief I'm not touching that step in this PR — flagging for a follow-up.

## release-please considerations

No `release-please-config.json` change needed — this is purely a workflow-level addition. Tag-shape is unchanged.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — OK
- `uv run ruff check` — passes
- `uv run ruff format --check` — passes
- `uv run ty check` — passes
- `uv run pytest -q --cov-fail-under=80` — 314 passed, coverage 90.91%
- Pinned action SHA verified via `gh api repos/actions/attest-build-provenance/git/refs/tags/v4.1.0` — `a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32` resolves to the v4.1.0 release commit.
- Action inputs (`subject-name`, `subject-digest`, `push-to-registry`) verified against the action's `action.yml` schema.

## Test plan

- [ ] CI green (lint/type/test/coverage; release-dry-run is unaffected since release.yml itself is touched and dry-run only validates the build step)
- [ ] After v0.1.0 release-please cuts, observe a successful attestation in the workflow run
- [ ] Run `gh attestation verify oci://ghcr.io/verylongorgnamesuchwow/ryzic@<v0.1.0 digest> --repo VeryLongOrgNameSuchWow/ryzic` against the published image; confirm verifier output

🤖 Generated with [Claude Code](https://claude.com/claude-code)