### PR TITLE
docs(deploy): fold remaining /review nits from PR #37

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,6 +34,7 @@ docs
 
 # Compose stack and lavalink config aren't part of the bot image
 compose.yaml
+compose.dev.yaml
 docker-compose.yaml
 docker-compose.yml
 lavalink

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ The first boot pulls the ryzic + Lavalink images and downloads the `youtube-sour
 docker compose logs -f
 ```
 
+See [Upgrading](#upgrading) for how the `:0.1` pin behaves on subsequent `docker compose pull`s.
+
 ### 4. Try it
 
 Join a voice channel, then in any text channel the bot can see:


### PR DESCRIPTION
## Summary

PR #37 landed before its two `/review` nits could be folded into the same force-push. This is the small follow-up.

- **`.dockerignore`**: also exclude `compose.dev.yaml` for symmetry with `compose.yaml`. Neither belongs in the runtime image — only the source tree the bot builds from does.
- **README §3**: add a cross-link to the `## Upgrading` section. The previous PR removed an inline upgrade hint there to keep the canonical upgrade story in one place; this adds the missing signpost so readers in §3 know where to find it.

## Verification

- `uv run ruff check` — passes
- `uv run ruff format --check` — passes
- `uv run ty check` — passes
- `uv run pytest -q --cov-fail-under=80` — 314 passed, coverage 90.91%

## Test plan

- [ ] CI green (lint/type/test/coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)