### PR TITLE
fix(release): read digest from build step, not metadata-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISPATCH_TAG: ${{ github.event.inputs.tag }}
-          IMAGE_DIGEST: ${{ steps.meta.outputs.digest }}
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           tag="${DISPATCH_TAG:-${GITHUB_REF#refs/tags/}}"
           # Only append if the release exists. Skip silently otherwise (manual


### PR DESCRIPTION
## Summary

\`docker/metadata-action\` doesn't emit a \`digest\` output — only \`tags\`, \`labels\`, \`version\`, \`json\`, etc. The shell fallback \`\${IMAGE_DIGEST:-<digest unavailable>}\` has been silently rendering the literal placeholder in every release's notes since the digest-append step landed in #21.

PR #38 added \`id: build\` to \`docker/build-push-action\` so its real \`outputs.digest\` is referenceable. Switch to that source.

Closes #39.

## Test plan

- [x] One-line change; verified by reading the surrounding shell block
- [ ] Validates fully on the next \`v0.1.x\` cut (PR #30 is the natural opportunity once smoke test clears)