### PR TITLE
fix(deploy): authenticate Lavalink healthcheck against /version

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -27,7 +27,7 @@ services:
       - lavalink_plugins:/opt/Lavalink/plugins
       - cache:/var/cache/ryzic:ro
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:2333/version"]
+      test: ["CMD-SHELL", "wget -q --spider --header=\"Authorization: $$LAVALINK_SERVER_PASSWORD\" http://localhost:2333/version"]
       interval: 10s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
## Summary

Closes #44 (BLOCKER for v0.1.0).

\`compose.yaml\`'s Lavalink healthcheck didn't pass the password header → \`/version\` returned 401 → healthcheck never passed → ryzic never started. Every operator following the README's \`docker compose up -d\` flow hung indefinitely.

Switch to \`CMD-SHELL\` form (so env var interpolates) and pass \`Authorization: \$LAVALINK_SERVER_PASSWORD\`. Note the \`\$\$\` escape — single \`\$\` is consumed by Compose; doubled passes through to the shell.

## Why CI didn't catch it

Integration tests use \`testcontainers\` (bypasses the compose healthcheck path); \`docker-build\` only builds the image. The compose stack has never been brought up end-to-end in automation. Worth a follow-up: either add a smoke-test workflow OR document that the manual smoke-test in \`docs/manual-smoke-tests.md\` is the gating gate.

## Test plan

- [x] \`python3 -c "import yaml; yaml.safe_load(open('compose.yaml'))"\` — passes
- [x] \`uv run ruff check\` — clean (no Python touched)
- [x] **Live verified**: re-ran \`docker compose -f compose.yaml -f compose.dev.yaml up -d\` against the patched file → lavalink \`(healthy)\` within 30s → ryzic \`Up\` and connecting to the gateway
- [ ] CI's docker-build job confirms the YAML still validates

## Surfaced by

Manual smoke test of v0.1.0 (PR #30) caught this on first bring-up. v0.1.0 cannot ship without this fix.