### PR TITLE
fix(ci): use commit SHA (not tag-object SHA) for codeql-action pins

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
         language: [python]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: github/codeql-action/init@c3f298df8c1fea2fefe20c785e6aa00f32df8260  # v4.35.3
+      - uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7  # v4.35.3
         with:
           languages: ${{ matrix.language }}
-      - uses: github/codeql-action/analyze@c3f298df8c1fea2fefe20c785e6aa00f32df8260  # v4.35.3
+      - uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7  # v4.35.3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -42,6 +42,6 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@c3f298df8c1fea2fefe20c785e6aa00f32df8260  # v4.35.3
+      - uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7  # v4.35.3
         with:
           sarif_file: results.sarif

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,16 @@ Forward-looking planning lives in GitHub Issues. See [#13](https://github.com/Ve
 - Secrets in commits (tokens, `.env`, signing keys). `.gitignore` lists the obvious patterns; if you find yourself fighting it, stop and ask.
 - New runtime dependencies without a justification in the PR body.
 
+## Action pinning
+
+GitHub Actions pins must use the **commit SHA**, not the annotated tag-object SHA. The Actions runner accepts either, but OSSF Scorecard's webapp verification rejects tag-object SHAs as `imposter commit` and silently tanks the score. To resolve a tag to its target commit:
+
+```bash
+git ls-remote https://github.com/<org>/<repo>.git refs/tags/vX.Y.Z^{}
+```
+
+The `^{}` suffix peels the annotated tag to the underlying commit. Dependabot already uses commit SHAs by default — this only matters when manually adding a new action pin.
+
 ## Manual smoke tests
 
 [docs/manual-smoke-tests.md](docs/manual-smoke-tests.md) is the checklist run before each release. PRs that touch the playback path should at minimum re-run the **Core playback** section locally and call out the result in the PR description.


### PR DESCRIPTION
## Summary

Scorecard CI has been failing 15-for-15 since the workflow landed, every run reporting `imposter commit` against the `github/codeql-action` pin. Root cause: the pin `c3f298df8c1fea2fefe20c785e6aa00f32df8260` (commented `# v4.35.3`) is the **annotated tag-object SHA**, not the **commit SHA** of v4.35.3.

The Actions runner happily resolves either form, which is why CodeQL itself runs fine. Scorecard's webapp verification, however, calls GitHub's `CompareCommits` API, which only accepts commit SHAs — the tag-object SHA returns 404 and Scorecard surfaces it as `imposter commit`.

This PR replaces the bad SHA with the correct commit SHA `e46ed2cbd01164d986452f91f178727624ae40d7` for the same v4.35.3 release, in all three places it appears:

- `.github/workflows/codeql.yml` line 43 (`init` step)
- `.github/workflows/codeql.yml` line 46 (`analyze` step)
- `.github/workflows/scorecard.yml` line 45 (`upload-sarif` step)

## Audit

While in here, every other SHA-pinned action across `.github/workflows/*.yml` was checked with `gh api repos/<org>/<repo>/git/commits/<SHA>`:

| Action pin | Result |
| --- | --- |
| `actions/attest-build-provenance@a2bbfa25...` | commit SHA |
| `actions/checkout@de0fac2e...` | commit SHA |
| `actions/create-github-app-token@fee1f7d6...` | commit SHA |
| `actions/dependency-review-action@2031cfc0...` | commit SHA |
| `actions/labeler@634933ed...` | commit SHA |
| `actions/upload-artifact@043fb46d...` | commit SHA |
| `astral-sh/setup-uv@08807647...` | commit SHA |
| `dependabot/fetch-metadata@25dd0e34...` | commit SHA |
| `docker/build-push-action@bcafcacb...` | commit SHA |
| `docker/login-action@4907a6dd...` | commit SHA |
| `docker/metadata-action@030e8812...` | commit SHA |
| `docker/setup-buildx-action@4d04d5d9...` | commit SHA |
| `googleapis/release-please-action@45996ed1...` | commit SHA |
| `ossf/scorecard-action@4eaacf05...` | commit SHA |

14 / 14 of the other pins are valid commit SHAs. Dependabot uses commit SHAs by default — only the `codeql-action` set was wrong, presumably from a manual initial pin.

## Contributor note

Added an "Action pinning" section to `CONTRIBUTING.md` documenting the gotcha and the `git ls-remote ... refs/tags/vX.Y.Z^{}` recipe for peeling an annotated tag to its target commit, so future manual pins don't hit the same trap.

## Test plan

- [x] `gh api repos/github/codeql-action/git/commits/e46ed2cbd01164d986452f91f178727624ae40d7 --jq .sha` returns the same SHA (it's a real commit).
- [x] `gh api repos/github/codeql-action/git/commits/c3f298df8c1fea2fefe20c785e6aa00f32df8260` returns 404 (confirms the old SHA was a tag-object).
- [x] `grep -r c3f298df8c1fea2fefe20c785e6aa00f32df8260 .github/` is empty after the change.
- [ ] CI green on this PR.
- [ ] After merge: next Scorecard run no longer reports `imposter commit` for `github/codeql-action`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)