### PR TITLE
docs: codify operator-decisions principle (CLAUDE.md + M1.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,12 @@ Tests:
 - **Pre-1.0 SemVer** — minor bumps may break. See `SEMVER.md`.
 - **Never commit secrets**. `.env` is gitignored, broader credential patterns too. `.env.example` only.
 
+## Principles
+
+**Operator decisions stay operator decisions.** Operator-level configuration (env vars, OAuth permissions, deploy choices) belongs to the self-hoster. ryzic does not ship slash commands that let server users override or manage operator decisions. The Discord Integrations panel is the user-facing knob; env vars are the operator-facing knob; nothing in slash-command space lives between them.
+
+In practice: no `/normalize on|off` (volume normalization is a global operator setting), no `/dj add @user` (DJ role assignment is `RYZIC_DJ_ROLE_ID`), no `/vc-status on|off` (voice-channel status is `RYZIC_VC_STATUS`).
+
 ## Env vars
 
 Canonical reference is `.env.example` and the env-var table in `README.md`. Required: `DISCORD_BOT_TOKEN`. Everything else has a default.

--- a/docs/plans/M1.md
+++ b/docs/plans/M1.md
@@ -408,6 +408,8 @@ volumes:
 
 ## 10. Env vars + first-run README
 
+**Operator vs. user surface.** Env vars are the operator-facing knob; the Discord Integrations panel is the user-facing knob. ryzic does not ship slash commands that let server users override or manage operator decisions (no `/normalize`, no `/dj add`, no `/vc-status`). Canonical statement of this principle lives in `CLAUDE.md` under `## Principles` — keep this note short and let CLAUDE.md own the wording.
+
 | Var | Required | Default | Purpose |
 |---|---|---|---|
 | `DISCORD_BOT_TOKEN` | yes | — | Bot token from Discord Developer Portal |


### PR DESCRIPTION
## Summary

Codifies the **operator decisions stay operator decisions** principle that emerged as a de facto rule across the 2026-05-02 overnight UX/QoL audit.

- Adds a new `## Principles` section to `CLAUDE.md` with the canonical wording (operator-level config — env vars, OAuth permissions, deploy choices — belongs to the self-hoster; no slash commands let server users override or manage operator decisions).
- Adds a one-paragraph cross-reference at the top of `docs/plans/M1.md` §10 (Env vars + first-run README), pointing back to CLAUDE.md as the source of truth so the two don't drift.

## Why now

The morning audit's planning agent enforced this as a hard line in three independent proposals:

- **#2 Volume normalization** — no `/normalize on|off`; normalization is a global operator setting.
- **#8 DJ role** — no `/dj add @user`; DJ role assignment is `RYZIC_DJ_ROLE_ID`.
- **#17 Voice-channel status** — no `/vc-status on|off`; controlled by `RYZIC_VC_STATUS`.

The recurrence across three unrelated proposals indicated the rule was load-bearing but undocumented. This is pre-M3 anchoring work — landing the principle now means subsequent reviews can cite a written source instead of re-deriving it each time.

## Scope

- Pure docs. No code, no CHANGELOG, no version bump (release-please owns those).
- `docs:` prefix → patch bump per release-please's pre-1.0 mapping.
- README intentionally untouched (end-user-facing; CLAUDE.md is the contributor/architectural doc home).

## Test plan

- [ ] `git diff main...HEAD` shows only the targeted additions to `CLAUDE.md` and `docs/plans/M1.md`.
- [ ] CI green (only doc-affecting jobs should run substantively).
- [ ] Reviewer skim of voice/style match against existing CLAUDE.md sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)