### PR TITLE
feat(ux): show channel + requester on single-track /play embed

### DIFF
--- a/src/ryzic/commands/play.py
+++ b/src/ryzic/commands/play.py
@@ -248,6 +248,8 @@ async def _play_single(
         track_info,
         position=queue_len_before + 1,
         playing_now=not was_playing,
+        channel_id=channel_id,
+        requester_id=ctx.user.id,
     )
     await ctx.respond(embed=embed)
 

--- a/src/ryzic/ux.py
+++ b/src/ryzic/ux.py
@@ -105,12 +105,23 @@ def format_duration(ms: int) -> str:
     return f"{minutes}:{seconds:02d}"
 
 
-def build_queued_track_embed(track: TrackInfo, position: int, *, playing_now: bool) -> hikari.Embed:
+def build_queued_track_embed(
+    track: TrackInfo,
+    position: int,
+    *,
+    playing_now: bool,
+    channel_id: int,
+    requester_id: int,
+) -> hikari.Embed:
     """Build the embed for a single-track ``/play`` success (M1 §3).
 
     ``position`` is 1-indexed within the queue. ``playing_now`` swaps
     the trailing ``"position N in queue"`` for ``"playing now"`` when
-    the queue was empty and the player was idle.
+    the queue was empty and the player was idle. ``channel_id`` is the
+    voice channel ryzic joined; ``requester_id`` is the invoking user.
+    Both render as Discord mentions in inline fields so users see a
+    clickable channel/user pill — footer text would render them as raw
+    ``<#…>`` / ``<@…>`` strings instead.
     """
     title = safe_truncate(escape_markdown(track.title), EMBED_DESCRIPTION_MAX // 2)
     uploader = safe_truncate(escape_markdown(track.uploader), EMBED_FOOTER_MAX // 4)
@@ -121,6 +132,8 @@ def build_queued_track_embed(track: TrackInfo, position: int, *, playing_now: bo
     else:
         footer = f"by {uploader} · {duration} · position {position} in queue"
     embed = hikari.Embed(title="Queued", description=description)
+    embed.add_field(name="Channel", value=f"<#{channel_id}>", inline=True)
+    embed.add_field(name="Requested by", value=f"<@{requester_id}>", inline=True)
     embed.set_footer(safe_truncate(footer, EMBED_FOOTER_MAX))
     return embed
 

--- a/tests/test_play_command.py
+++ b/tests/test_play_command.py
@@ -444,6 +444,11 @@ async def test_single_track_success_idle_plays_now(cache: Any) -> None:
     assert isinstance(embed, hikari.Embed)
     assert embed.title == "Queued"
     assert "playing now" in (embed.footer.text if embed.footer else "")
+    # Channel + requester surface as inline mention fields so users see
+    # which voice channel ryzic joined and who triggered playback.
+    field_pairs = {f.name: f.value for f in embed.fields}
+    assert field_pairs["Channel"] == "<#999>"
+    assert field_pairs["Requested by"] == "<@222>"
     # /play also seeded the last_play_channel for the EventHandler
     # error reporter to land in the right text channel.
     assert lavalink_glue.last_play_channel.get(111) == 555

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -210,6 +210,10 @@ def test_playlist_embed_live_path() -> None:
     assert "4:00" in embed.description
     assert embed.footer is not None
     assert "alice" in (embed.footer.text or "")
+    # Regression guard: single-track embed (PR #75 / issue #69) added inline
+    # fields for channel + requester. Playlist embed deliberately stays
+    # field-free — keep the asymmetry explicit until/unless we harmonize.
+    assert embed.fields == []
 
 
 def test_playlist_embed_partial_failure_appends_footer_line() -> None:

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -115,7 +115,13 @@ def test_format_duration_clamps_negative() -> None:
 
 
 def test_track_embed_playing_now() -> None:
-    embed = ux.build_queued_track_embed(_track(), position=1, playing_now=True)
+    embed = ux.build_queued_track_embed(
+        _track(),
+        position=1,
+        playing_now=True,
+        channel_id=999,
+        requester_id=222,
+    )
     assert isinstance(embed, hikari.Embed)
     assert embed.title == "Queued"
     assert embed.description is not None
@@ -128,7 +134,13 @@ def test_track_embed_playing_now() -> None:
 
 
 def test_track_embed_position_in_queue() -> None:
-    embed = ux.build_queued_track_embed(_track(), position=4, playing_now=False)
+    embed = ux.build_queued_track_embed(
+        _track(),
+        position=4,
+        playing_now=False,
+        channel_id=999,
+        requester_id=222,
+    )
     assert embed.footer is not None
     text = embed.footer.text or ""
     assert "position 4 in queue" in text
@@ -139,6 +151,8 @@ def test_track_embed_escapes_markdown_in_title_and_uploader() -> None:
         _track(title="evil **bold** [link](url)", uploader="hax_or"),
         position=1,
         playing_now=False,
+        channel_id=999,
+        requester_id=222,
     )
     assert embed.description is not None
     # Both ``**`` and ``[`` get escaped — neither bold nor a markdown link
@@ -148,6 +162,23 @@ def test_track_embed_escapes_markdown_in_title_and_uploader() -> None:
     assert "\\*\\*bold\\*\\*" in embed.description
     assert embed.footer is not None
     assert "hax\\_or" in (embed.footer.text or "")
+
+
+def test_track_embed_includes_channel_and_requester_fields() -> None:
+    # Mention syntax (``<#…>`` / ``<@…>``) lives in inline embed fields
+    # rather than the footer because Discord renders mentions as pills
+    # in field values but as raw text in footers.
+    embed = ux.build_queued_track_embed(
+        _track(),
+        position=1,
+        playing_now=True,
+        channel_id=999,
+        requester_id=222,
+    )
+    assert embed.fields is not None
+    field_pairs = {f.name: (f.value, f.is_inline) for f in embed.fields}
+    assert field_pairs["Channel"] == ("<#999>", True)
+    assert field_pairs["Requested by"] == ("<@222>", True)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #69 (audit item #12 from the morning UX/QoL roadmap).

The single-track ``/play`` confirmation embed previously surfaced only title + duration + queue position, while the playlist embed already credited the requester — a clear asymmetry the audit flagged as parity work, not net-new feature.

This adds two inline fields to ``build_queued_track_embed``:
- **Channel** — the voice channel ryzic joined, as ``<#channel_id>``.
- **Requested by** — the invoking user, as ``<@user_id>``.

Mentions live in field values rather than the footer because Discord renders ``<#…>`` / ``<@…>`` as clickable pills in fields and as raw text in footers. The playlist embed is intentionally untouched — its existing ``requested by {username}`` footer was the spec's reference point, not its target.

Source diff is 17 LOC (excluding tests), well under the audit's XS estimate.

## Test plan

- [x] ``uv run pytest -q --cov-fail-under=80`` passes (336 tests, 91.12% coverage)
- [x] ``uv run ruff check`` passes
- [x] ``uv run ruff format --check`` passes
- [x] ``uv run ty check`` passes
- [x] New ``test_track_embed_includes_channel_and_requester_fields`` asserts both fields, their values, and inline placement
- [x] ``test_single_track_success_when_idle_plays_now`` extended to verify field plumbing from ``_handle_play``
- [x] Confirmed playlist embed builder is untouched