### PR TITLE
chore(ci): scope workflow permissions to jobs (Scorecard hardening)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,11 +20,6 @@ on:
     # onto every other GHA scheduled job firing at :00.
     - cron: "17 7 * * 1"
 
-permissions:
-  actions: read
-  contents: read
-  security-events: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -34,6 +29,10 @@ jobs:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     if: ${{ github.event.repository.visibility == 'public' }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write   # upload SARIF to code scanning
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,14 +15,13 @@ name: Dependabot auto-merge
 
 on: pull_request
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
+    permissions:
+      contents: write         # gh pr merge --auto requires write to enable auto-merge on the branch
+      pull-requests: write    # gh pr review --approve and gh pr merge both write to the PR
     steps:
       - id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v3.1.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,13 +15,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write         # release-please pushes the release-PR branch and creates the tag/release on merge
+      pull-requests: write    # opens/updates the release PR
     steps:
       # Mint an installation token from the vlonsw-release-please GitHub App
       # (App ID + private key in repo secrets) instead of falling through to

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,6 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-  packages: write
-  # Required by actions/attest-build-provenance: id-token mints the OIDC
-  # token sigstore uses to identify the builder; attestations writes the
-  # generated SLSA provenance to the repo's attestations store.
-  id-token: write
-  attestations: write
-
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -34,6 +25,14 @@ jobs:
     # "pause deployments" brake from Settings → Environments → ghcr without
     # editing or disabling the workflow file.
     environment: ghcr
+    permissions:
+      contents: write       # gh release edit appends the image-digest section to the release notes
+      packages: write       # docker push to ghcr.io
+      # Required by actions/attest-build-provenance: id-token mints the OIDC
+      # token sigstore uses to identify the builder; attestations writes the
+      # generated SLSA provenance to the repo's attestations store.
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:


### PR DESCRIPTION
## Summary

Resolves 5 OpenSSF Scorecard HIGH-severity [TokenPermissions](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) alerts on `main` by moving each `permissions:` block from workflow top-level to the specific job that actually needs the writes. The check flags any workflow that grants write tokens at top-level — even one job not using a perm gets the same broad token, violating least privilege.

This is a scoping-only change. Every job previously needed every perm already declared at top-level for it (single-job workflows, or the writes were meaningful for the only writing job). The narrowing is purely on the GITHUB_TOKEN minted per job — no step's behavior changes.

## Alerts addressed

| File | Line | Permission |
|---|---|---|
| `.github/workflows/codeql.yml` | 26 | `security-events: write` |
| `.github/workflows/dependabot-auto-merge.yml` | 19 | `contents: write` |
| `.github/workflows/release-please.yml` | 19 | `contents: write` |
| `.github/workflows/release.yml` | 22 | `contents: write` |
| `.github/workflows/release.yml` | 23 | `packages: write` |

## Per-job scoping

- **`codeql.yml`** — `analyze` job: `actions: read`, `contents: read`, `security-events: write` (CodeQL `analyze` action uploads SARIF to code scanning).
- **`dependabot-auto-merge.yml`** — `auto-merge` job: `contents: write`, `pull-requests: write` (`gh pr merge --auto` requires content write to enable auto-merge on the branch; `gh pr review` writes to the PR).
- **`release-please.yml`** — `release-please` job: `contents: write`, `pull-requests: write` (release-please pushes the release-PR branch and creates the tag/release on merge; opens/updates the release PR).
- **`release.yml`** — `release` job: `contents: write` (`gh release edit` appends the image-digest section to the release notes), `packages: write` (`docker push` to ghcr.io), `id-token: write` + `attestations: write` (sigstore/SLSA build provenance via `actions/attest-build-provenance`).

## Out of scope

- `scorecard.yml` is already correctly structured (top-level `permissions: read-all` as the safe default, per-job writes scoped on `analysis`) and is untouched.
- Other workflows (`ci.yml`, `labeler.yml`, `dependency-review.yml`, `release-dry-run.yml`) only declare read-level perms (or `pull-requests: write` for posting comments) and were not flagged HIGH by Scorecard.
- Step `uses:` SHAs (Scorecard-fixed in #53) are unchanged.

`chore:` prefix → release-please will not bump version.

## Test plan

- [ ] Visual review of the four diffs — top-level `permissions:` blocks removed; per-job blocks contain only the listed perms.
- [ ] CI green on this PR (the touched workflows mostly don't run on PRs that only edit `.github/workflows/*`, but `ci.yml` and `dependency-review.yml` do).
- [ ] Once merged, observe the next OpenSSF Scorecard run on `main` — TokenPermissions HIGHs should drop from 5 to 0.
- [ ] Sanity-check via the next dependabot PR and the next `release-please` run that auto-merge / release-PR flow still works (these only fire async, so verify in the wild).