### PR TITLE
feat: in-memory track history with /recent and /replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A self-hostable Discord music bot. Plays YouTube audio in voice channels via [La
 
 ## Features
 
-- Six slash commands: `/play`, `/skip`, `/queue`, `/pause`, `/resume`, `/leave`.
+- Eight slash commands: `/play`, `/skip`, `/queue`, `/pause`, `/resume`, `/leave`, `/recent`, `/replay`.
 - Per-guild queue with paged display.
 - LRU audio cache backed by SQLite — re-playing a track skips the network round-trip and survives transient yt-dlp regressions.
 - Auto-leave after 5 minutes idle in voice (sensible Discord etiquette).

--- a/docs/manual-smoke-tests.md
+++ b/docs/manual-smoke-tests.md
@@ -26,6 +26,16 @@ Reset state between runs with `docker compose down -v && docker compose up -d` i
 - [ ] `/pause` halts playback; `/resume` resumes from the same position (no audible jump).
 - [ ] `/leave` disconnects the bot and clears the queue; `/queue` afterwards reports empty.
 
+## Track history
+
+- [ ] `/recent` with a fresh boot reports `No tracks have played yet.` (ephemeral).
+- [ ] After 2-3 tracks complete (or are skipped), `/recent` lists them newest-first with clickable titles and a "Use /replay …" footer.
+- [ ] `/replay` (no argument) re-queues the most recent finished track via the same code path as `/play` (cache hit, no re-download).
+- [ ] `/replay 2` re-queues the second-most-recent track.
+- [ ] `/replay 99` (out of range) returns an ephemeral "Only N track(s) in history."
+- [ ] After more than 25 tracks have played, `/recent` caps the list at 25 entries (oldest fall off).
+- [ ] After `docker compose restart ryzic`, `/recent` reports empty — history is in-memory only by design.
+
 ## Auto-leave
 
 - [ ] After the final track in a queue ends, the bot stays connected briefly, then disconnects after ~5 minutes of idle and posts `Idle for 5 minutes — disconnecting.` in the channel where `/play` was last used.

--- a/src/ryzic/bot.py
+++ b/src/ryzic/bot.py
@@ -143,6 +143,8 @@ def main() -> None:
             "ryzic.commands.resume",
             "ryzic.commands.leave",
             "ryzic.commands.seek",
+            "ryzic.commands.recent",
+            "ryzic.commands.replay",
         )
         await client.start()
 

--- a/src/ryzic/commands/recent.py
+++ b/src/ryzic/commands/recent.py
@@ -1,0 +1,41 @@
+"""``/recent`` slash command (issue #96).
+
+Renders the per-guild ring of recently-played tracks newest-first.
+Read-only — no voice precondition.
+"""
+
+from __future__ import annotations
+
+import hikari
+import lightbulb
+
+from .. import track_history, ux
+
+loader = lightbulb.Loader()
+
+
+@loader.command
+class Recent(
+    lightbulb.SlashCommand,
+    name="recent",
+    description="Show the last tracks played in this server.",
+    contexts=[hikari.ApplicationContextType.GUILD],
+):
+    @lightbulb.invoke
+    async def invoke(self, ctx: lightbulb.Context) -> None:
+        await _handle_recent(ctx)
+
+
+async def _handle_recent(ctx: lightbulb.Context) -> None:
+    guild_id = ctx.guild_id
+    if guild_id is None:
+        await ctx.respond("Run /recent in a server.", ephemeral=True)
+        return
+
+    history = track_history.get(guild_id)
+    if not history:
+        await ctx.respond("No tracks have played yet.", ephemeral=True)
+        return
+
+    embed = ux.build_recent_embed(history)
+    await ctx.respond(embed=embed)

--- a/src/ryzic/commands/replay.py
+++ b/src/ryzic/commands/replay.py
@@ -1,0 +1,66 @@
+"""``/replay`` slash command (issue #96).
+
+Re-queues a previously-played track by routing through ``_handle_play``
+so the cache/pinning/voice-handshake logic stays in one place. Position
+is 1-indexed and defaults to 1 (most recent).
+"""
+
+from __future__ import annotations
+
+import hikari
+import lightbulb
+
+from .. import track_history
+from .play import _handle_play
+
+loader = lightbulb.Loader()
+
+
+@loader.command
+class Replay(
+    lightbulb.SlashCommand,
+    name="replay",
+    description="Re-queue a previously-played track from /recent.",
+    contexts=[hikari.ApplicationContextType.GUILD],
+):
+    position = lightbulb.integer(
+        "position",
+        "Position in /recent (1 = most recent). Defaults to 1.",
+        default=1,
+        min_value=1,
+        max_value=track_history.MAX_HISTORY_SIZE,
+    )
+
+    @lightbulb.invoke
+    async def invoke(self, ctx: lightbulb.Context) -> None:
+        await _handle_replay(ctx, self.position)
+
+
+async def _handle_replay(ctx: lightbulb.Context, position: int) -> None:
+    guild_id = ctx.guild_id
+    if guild_id is None:
+        await ctx.respond("Run /replay in a server.", ephemeral=True)
+        return
+
+    history = track_history.get(guild_id)
+    if not history:
+        await ctx.respond("No tracks have played yet.", ephemeral=True)
+        return
+
+    # ``min_value=1`` already constrains position ≥ 1; the upper bound
+    # is the static MAX_HISTORY_SIZE cap. The actual ring may be
+    # shorter (boot-fresh guild), so we still bounds-check against the
+    # live length here.
+    if position > len(history):
+        await ctx.respond(
+            f"Only {len(history)} track(s) in history.",
+            ephemeral=True,
+        )
+        return
+
+    track = history[position - 1]
+    # Defer here (not inside ``_handle_play``) so /play's own ``Play.invoke``
+    # remains responsible for its defer call — ``_handle_play`` is the
+    # shared body, callers own their own response lifecycle.
+    await ctx.defer()
+    await _handle_play(ctx, track.url)

--- a/src/ryzic/commands/replay.py
+++ b/src/ryzic/commands/replay.py
@@ -52,8 +52,9 @@ async def _handle_replay(ctx: lightbulb.Context, position: int) -> None:
     # shorter (boot-fresh guild), so we still bounds-check against the
     # live length here.
     if position > len(history):
+        plural = "" if len(history) == 1 else "s"
         await ctx.respond(
-            f"Only {len(history)} track(s) in history.",
+            f"Only {len(history)} track{plural} in history.",
             ephemeral=True,
         )
         return

--- a/src/ryzic/lavalink_glue.py
+++ b/src/ryzic/lavalink_glue.py
@@ -51,7 +51,7 @@ import hikari
 import lavalink
 from lavalink.common import VoiceServerUpdatePayload, VoiceStateUpdatePayload
 
-from . import audio_cache, config
+from . import audio_cache, config, track_history, ux
 
 _log = logging.getLogger(__name__)
 
@@ -244,6 +244,42 @@ async def _release_track(track: lavalink.AudioTrack | None) -> None:
         _log.exception("failed to release audio cache entry %s", video_id)
 
 
+# EndReason values that mean "the user actually heard this track".
+# FINISHED = natural end. REPLACED = the next track took over via
+# ``player.play(track=...)`` (e.g. ``/skip``). LOAD_FAILED / STOPPED /
+# CLEANUP are excluded — failures were never heard, ``/leave`` winds the
+# session down explicitly, and Lavalink cleanup events don't correspond
+# to user-facing playback. A tuple (rather than a frozenset) because
+# ``lavalink.server.EndReason`` overrides ``__eq__`` without preserving
+# ``__hash__``, so the values are not hashable.
+_HEARD_END_REASONS: tuple[lavalink.server.EndReason, ...] = (
+    lavalink.server.EndReason.FINISHED,
+    lavalink.server.EndReason.REPLACED,
+)
+
+
+def _record_history(
+    guild_id: int,
+    track: lavalink.AudioTrack | None,
+    reason: lavalink.server.EndReason,
+) -> None:
+    """Append ``track`` to ``guild_id``'s history if the user actually heard it.
+
+    Reads the original :class:`~ryzic.ytdlp.TrackInfo` off the lavalink
+    AudioTrack via :func:`ux.get_track_info`. When metadata is absent
+    (a future code path that bypasses ``attach_track_info``) we drop
+    the entry rather than fabricate one — history is a UX surface, not
+    a play-count store, so a missing-metadata gap is preferable to a
+    half-populated row.
+    """
+    if track is None or reason not in _HEARD_END_REASONS:
+        return
+    info = ux.get_track_info(track)
+    if info is None:
+        return
+    track_history.record(guild_id, info)
+
+
 async def clear_queue_releasing(player: lavalink.DefaultPlayer) -> None:
     """Release audio cache pins for every queued track, then clear the queue.
 
@@ -308,6 +344,7 @@ class EventHandler:
             _track_title(event.track),
             event.reason,
         )
+        _record_history(guild_id, event.track, event.reason)
         await _release_track(event.track)
 
         # NEVER call player.play() here; the default player auto-advances

--- a/src/ryzic/track_history.py
+++ b/src/ryzic/track_history.py
@@ -1,0 +1,60 @@
+"""Per-guild ring buffer of recently-played tracks (issue #96).
+
+Populated by ``lavalink_glue.EventHandler.on_track_end`` only on the
+:class:`lavalink.server.EndReason` values that represent a track the
+user actually heard (``FINISHED`` for natural end, ``REPLACED`` for
+``/skip``-style mid-track advance). ``LOAD_FAILED`` / ``STOPPED`` /
+``CLEANUP`` are excluded — failures were never heard, ``/leave``
+explicitly winds down the session, and Lavalink cleanup events don't
+correspond to user-facing playback.
+
+State is in-memory only — by design (issue #96 hard line). Cross-session
+persistence is a separate, out-of-scope feature with its own design
+question. The bot's restart drops history, which matches every other
+"this is what just played" surface in Discord.
+
+Module-level state (mirrors ``lavalink_glue``'s singletons): a single
+process owns one history per guild. Tests reset via
+:func:`_reset_state_for_test`.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+from .ytdlp import TrackInfo
+
+# Bounded buffer. 25 lines comfortably fits one Discord embed
+# description (~4096 chars) even with long titles. Issue #96 explicitly
+# called the cap as "20-50"; 25 is the midpoint that matches the
+# audit's competitor-survey median.
+MAX_HISTORY_SIZE = 25
+
+
+_history: dict[int, deque[TrackInfo]] = {}
+
+
+def record(guild_id: int, track: TrackInfo) -> None:
+    """Push ``track`` onto the front of ``guild_id``'s history ring.
+
+    Newest entry is always at index 0; the deque's left-side push +
+    ``maxlen`` evicts the oldest from the right when the cap is reached.
+    Idempotent against the same track replaying back-to-back: we still
+    record it (history is per-event, not per-unique-track) so a user who
+    just replayed sees their action reflected.
+    """
+    ring = _history.setdefault(guild_id, deque(maxlen=MAX_HISTORY_SIZE))
+    ring.appendleft(track)
+
+
+def get(guild_id: int) -> list[TrackInfo]:
+    """Return ``guild_id``'s history newest-first, or ``[]`` if empty."""
+    ring = _history.get(guild_id)
+    if ring is None:
+        return []
+    return list(ring)
+
+
+def _reset_state_for_test() -> None:
+    """Test-only: clear all per-guild history state."""
+    _history.clear()

--- a/src/ryzic/ux.py
+++ b/src/ryzic/ux.py
@@ -57,6 +57,12 @@ _ELLIPSIS: Final = "…"
 # collapse to a single "… and N more" line per M1 §3.
 _QUEUE_PREVIEW_MAX: Final = 10
 
+# Number of history entries enumerated inline in ``/recent``. The ring's
+# hard cap (``track_history.MAX_HISTORY_SIZE``) is the upper bound; the
+# preview cap exists so a future widening of that constant cannot
+# quietly blow Discord's description budget.
+_RECENT_PREVIEW_MAX: Final = 25
+
 # Namespaced ``AudioTrack.extra`` key for the stashed :class:`TrackInfo`.
 _TRACK_INFO_EXTRA_KEY: Final = "ryzic_track_info"
 
@@ -331,3 +337,28 @@ def _build_queue_description(queue: list[tuple[TrackInfo, int]]) -> str:
     if overflow > 0:
         lines.append(f"… and {overflow} more")
     return safe_truncate("\n".join(lines), EMBED_DESCRIPTION_MAX)
+
+
+def build_recent_embed(history: list[TrackInfo]) -> hikari.Embed:
+    """Build the ``/recent`` embed (issue #96).
+
+    ``history`` is newest-first. Caller guarantees non-empty (the
+    command short-circuits on the empty case with a friendly ephemeral).
+    Lines are 1-indexed so ``/replay <N>`` semantics match the displayed
+    number directly.
+    """
+    preview = history[:_RECENT_PREVIEW_MAX]
+    lines = [
+        (
+            f"{idx}. [{escape_markdown(info.title)}]({info.url}) — "
+            f"{format_duration(info.duration_ms)}"
+        )
+        for idx, info in enumerate(preview, start=1)
+    ]
+    overflow = len(history) - len(preview)
+    if overflow > 0:
+        lines.append(f"… and {overflow} more")
+    description = safe_truncate("\n".join(lines), EMBED_DESCRIPTION_MAX)
+    embed = hikari.Embed(title=f"Recently played ({len(history)})", description=description)
+    embed.set_footer("Use /replay <position> to re-queue.")
+    return embed

--- a/tests/_command_helpers.py
+++ b/tests/_command_helpers.py
@@ -87,9 +87,13 @@ class FakeContext:
         self.channel_id = channel_id
         self.client = FakeLightbulbClient(bot)
         self.responses: list[tuple[Any, dict[str, Any]]] = []
+        self.defer_calls: int = 0
 
     async def respond(self, content: Any = None, **kwargs: Any) -> None:
         self.responses.append((content, kwargs))
+
+    async def defer(self) -> None:
+        self.defer_calls += 1
 
 
 @dataclass

--- a/tests/test_lavalink_bridge.py
+++ b/tests/test_lavalink_bridge.py
@@ -706,6 +706,7 @@ def test_is_valid_discord_endpoint_allowlist() -> None:
 class _IdTrack:
     title: str = "song"
     identifier: str = "abc12345"
+    extra: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -717,7 +718,12 @@ class _PlayerWithGuild:
 class _EndEvent:
     track: _IdTrack | None
     player: _PlayerWithGuild
-    reason: str = "FINISHED"
+    # ``lavalink.server.EndReason`` overrides ``__eq__`` without preserving
+    # ``__hash__``, which trips dataclass's mutable-default guard. Wrap in
+    # a factory so the enum value is sourced fresh per instance.
+    reason: lavalink.server.EndReason = field(
+        default_factory=lambda: lavalink.server.EndReason.FINISHED
+    )
 
 
 @dataclass
@@ -1114,3 +1120,140 @@ async def test_node_disconnected_releases_queued_pins_for_every_player() -> None
         assert all(p.queue == [] for p in players)
     finally:
         audio_cache.set_audio_cache(None)
+
+
+# ---------------------------------------------------------------------------
+# Track history (issue #96)
+# ---------------------------------------------------------------------------
+
+
+def _track_with_info(title: str, *, identifier: str = "abc12345") -> _IdTrack:
+    """Build an _IdTrack with an attached TrackInfo (matches /play's wiring)."""
+    from ryzic import ux
+    from tests._command_helpers import make_track_info
+
+    track = _IdTrack(identifier=identifier)
+    info = make_track_info(title=title)
+    ux.attach_track_info(cast(lavalink.AudioTrack, track), info)
+    return track
+
+
+async def test_track_end_records_history_on_finished() -> None:
+    """A naturally-finishing track is appended to the per-guild history."""
+    from ryzic import track_history
+
+    track_history._reset_state_for_test()
+    bot = _FakeApp()
+    handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+    track = _track_with_info("Song A")
+
+    await handler.on_track_end(
+        cast(
+            lavalink.TrackEndEvent,
+            _EndEvent(
+                track=track,
+                player=_PlayerWithGuild(),
+                reason=lavalink.server.EndReason.FINISHED,
+            ),
+        )
+    )
+
+    history = track_history.get(111)
+    assert [t.title for t in history] == ["Song A"]
+
+
+async def test_track_end_records_history_on_replaced() -> None:
+    """``/skip`` lands as REPLACED — still counts as 'user heard most of it'."""
+    from ryzic import track_history
+
+    track_history._reset_state_for_test()
+    bot = _FakeApp()
+    handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+    track = _track_with_info("Skipped")
+
+    await handler.on_track_end(
+        cast(
+            lavalink.TrackEndEvent,
+            _EndEvent(
+                track=track,
+                player=_PlayerWithGuild(),
+                reason=lavalink.server.EndReason.REPLACED,
+            ),
+        )
+    )
+
+    assert [t.title for t in track_history.get(111)] == ["Skipped"]
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        lavalink.server.EndReason.LOAD_FAILED,
+        lavalink.server.EndReason.STOPPED,
+        lavalink.server.EndReason.CLEANUP,
+    ],
+)
+async def test_track_end_does_not_record_for_excluded_reasons(
+    reason: lavalink.server.EndReason,
+) -> None:
+    """LOAD_FAILED / STOPPED / CLEANUP must NOT enter history."""
+    from ryzic import track_history
+
+    track_history._reset_state_for_test()
+    bot = _FakeApp()
+    handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+    track = _track_with_info("Never Counted")
+
+    await handler.on_track_end(
+        cast(
+            lavalink.TrackEndEvent,
+            _EndEvent(track=track, player=_PlayerWithGuild(), reason=reason),
+        )
+    )
+
+    assert track_history.get(111) == []
+
+
+async def test_track_end_without_metadata_does_not_record() -> None:
+    """A track with no attached TrackInfo is dropped — no half-populated rows."""
+    from ryzic import track_history
+
+    track_history._reset_state_for_test()
+    bot = _FakeApp()
+    handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+    bare = _IdTrack(identifier="bare0001")  # no attach_track_info call
+
+    await handler.on_track_end(
+        cast(
+            lavalink.TrackEndEvent,
+            _EndEvent(
+                track=bare,
+                player=_PlayerWithGuild(),
+                reason=lavalink.server.EndReason.FINISHED,
+            ),
+        )
+    )
+
+    assert track_history.get(111) == []
+
+
+async def test_track_end_with_none_track_does_not_record() -> None:
+    """``TrackEndEvent`` carries ``Optional[AudioTrack]``; ``None`` short-circuits."""
+    from ryzic import track_history
+
+    track_history._reset_state_for_test()
+    bot = _FakeApp()
+    handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+
+    await handler.on_track_end(
+        cast(
+            lavalink.TrackEndEvent,
+            _EndEvent(
+                track=None,
+                player=_PlayerWithGuild(),
+                reason=lavalink.server.EndReason.FINISHED,
+            ),
+        )
+    )
+
+    assert track_history.get(111) == []

--- a/tests/test_recent_command.py
+++ b/tests/test_recent_command.py
@@ -1,0 +1,64 @@
+"""Tests for ``ryzic.commands.recent``."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import hikari
+import pytest
+
+from ryzic import track_history
+from ryzic.commands import recent as recent_module
+from tests._command_helpers import (
+    FakeBot,
+    context_for,
+    make_track_info,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    track_history._reset_state_for_test()
+
+
+async def test_outside_guild_short_circuits() -> None:
+    bot = FakeBot()
+    ctx = context_for(bot, guild_id=None)
+
+    await recent_module._handle_recent(ctx)
+
+    fake = cast(Any, ctx)
+    assert fake.responses[0][0] == "Run /recent in a server."
+    assert fake.responses[0][1].get("ephemeral") is True
+
+
+async def test_empty_history_returns_friendly_ephemeral() -> None:
+    bot = FakeBot()
+    ctx = context_for(bot, guild_id=111)
+
+    await recent_module._handle_recent(ctx)
+
+    fake = cast(Any, ctx)
+    assert fake.responses[0][0] == "No tracks have played yet."
+    assert fake.responses[0][1].get("ephemeral") is True
+
+
+async def test_renders_history_embed_newest_first() -> None:
+    bot = FakeBot()
+    ctx = context_for(bot, guild_id=111)
+    track_history.record(111, make_track_info(video_id="aaaaaaaaaaa", title="First"))
+    track_history.record(111, make_track_info(video_id="bbbbbbbbbbb", title="Second"))
+
+    await recent_module._handle_recent(ctx)
+
+    fake = cast(Any, ctx)
+    embed = fake.responses[0][1]["embed"]
+    assert isinstance(embed, hikari.Embed)
+    # Newest first — "Second" precedes "First" in the description.
+    description = embed.description or ""
+    assert description.index("Second") < description.index("First")
+
+
+def test_recent_loader_registered() -> None:
+    assert recent_module.Recent._command_data.name == "recent"
+    assert recent_module.Recent._command_data.description.startswith("Show")

--- a/tests/test_replay_command.py
+++ b/tests/test_replay_command.py
@@ -77,7 +77,7 @@ async def test_position_out_of_range_returns_friendly_ephemeral(
     await replay_module._handle_replay(ctx, position=5)
 
     fake = cast(Any, ctx)
-    assert "Only 1 track" in str(fake.responses[0][0])
+    assert fake.responses[0][0] == "Only 1 track in history."
     assert fake.responses[0][1].get("ephemeral") is True
     assert play_calls == []
 
@@ -95,6 +95,11 @@ async def test_position_one_routes_through_handle_play_with_newest_url(
     # Position 1 = newest = "B".
     assert len(play_calls) == 1
     assert play_calls[0][1] == "https://x/b"
+    # Pin the defer-once contract documented at replay.py:62-64 so a
+    # future refactor that drops the defer (or moves it into
+    # ``_handle_play`` and double-defers from ``Play.invoke``) is caught.
+    fake = cast(Any, ctx)
+    assert fake.defer_calls == 1
 
 
 async def test_position_two_picks_older_entry(

--- a/tests/test_replay_command.py
+++ b/tests/test_replay_command.py
@@ -1,0 +1,116 @@
+"""Tests for ``ryzic.commands.replay``.
+
+``_handle_play`` is the integration point we don't re-test here — its
+own branches are covered exhaustively in ``tests/test_play_command.py``.
+We patch it to a recording stub to assert the routing contract: replay
+forwards the right URL to the existing /play body, after the history
+lookup succeeds.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import lightbulb
+import pytest
+
+from ryzic import track_history
+from ryzic.commands import replay as replay_module
+from tests._command_helpers import (
+    FakeBot,
+    context_for,
+    make_track_info,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    track_history._reset_state_for_test()
+
+
+@pytest.fixture
+def play_calls(monkeypatch: pytest.MonkeyPatch) -> list[tuple[lightbulb.Context, str]]:
+    """Replace ``_handle_play`` with a recorder; return the captured calls."""
+    calls: list[tuple[lightbulb.Context, str]] = []
+
+    async def fake_handle_play(ctx: lightbulb.Context, url: str) -> None:
+        calls.append((ctx, url))
+
+    monkeypatch.setattr(replay_module, "_handle_play", fake_handle_play)
+    return calls
+
+
+async def test_outside_guild_short_circuits(
+    play_calls: list[tuple[lightbulb.Context, str]],
+) -> None:
+    bot = FakeBot()
+    ctx = context_for(bot, guild_id=None)
+
+    await replay_module._handle_replay(ctx, position=1)
+
+    fake = cast(Any, ctx)
+    assert fake.responses[0][0] == "Run /replay in a server."
+    assert fake.responses[0][1].get("ephemeral") is True
+    assert play_calls == []
+
+
+async def test_empty_history_returns_friendly_ephemeral(
+    play_calls: list[tuple[lightbulb.Context, str]],
+) -> None:
+    bot = FakeBot()
+    ctx = context_for(bot, guild_id=111)
+
+    await replay_module._handle_replay(ctx, position=1)
+
+    fake = cast(Any, ctx)
+    assert fake.responses[0][0] == "No tracks have played yet."
+    assert play_calls == []
+
+
+async def test_position_out_of_range_returns_friendly_ephemeral(
+    play_calls: list[tuple[lightbulb.Context, str]],
+) -> None:
+    bot = FakeBot()
+    ctx = context_for(bot, guild_id=111)
+    track_history.record(111, make_track_info(title="Only"))
+
+    await replay_module._handle_replay(ctx, position=5)
+
+    fake = cast(Any, ctx)
+    assert "Only 1 track" in str(fake.responses[0][0])
+    assert fake.responses[0][1].get("ephemeral") is True
+    assert play_calls == []
+
+
+async def test_position_one_routes_through_handle_play_with_newest_url(
+    play_calls: list[tuple[lightbulb.Context, str]],
+) -> None:
+    bot = FakeBot()
+    ctx = context_for(bot, guild_id=111)
+    track_history.record(111, make_track_info(video_id="aaaaaaaaaaa", url="https://x/a", title="A"))
+    track_history.record(111, make_track_info(video_id="bbbbbbbbbbb", url="https://x/b", title="B"))
+
+    await replay_module._handle_replay(ctx, position=1)
+
+    # Position 1 = newest = "B".
+    assert len(play_calls) == 1
+    assert play_calls[0][1] == "https://x/b"
+
+
+async def test_position_two_picks_older_entry(
+    play_calls: list[tuple[lightbulb.Context, str]],
+) -> None:
+    bot = FakeBot()
+    ctx = context_for(bot, guild_id=111)
+    track_history.record(111, make_track_info(video_id="aaaaaaaaaaa", url="https://x/a", title="A"))
+    track_history.record(111, make_track_info(video_id="bbbbbbbbbbb", url="https://x/b", title="B"))
+
+    await replay_module._handle_replay(ctx, position=2)
+
+    assert len(play_calls) == 1
+    assert play_calls[0][1] == "https://x/a"
+
+
+def test_replay_loader_registered() -> None:
+    assert replay_module.Replay._command_data.name == "replay"
+    assert replay_module.Replay._command_data.description.startswith("Re-queue")

--- a/tests/test_track_history.py
+++ b/tests/test_track_history.py
@@ -1,0 +1,75 @@
+"""Tests for ``ryzic.track_history``."""
+
+from __future__ import annotations
+
+import pytest
+
+from ryzic import track_history
+from tests._command_helpers import make_track_info
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    track_history._reset_state_for_test()
+
+
+def test_empty_guild_returns_empty_list() -> None:
+    assert track_history.get(111) == []
+
+
+def test_record_pushes_newest_first() -> None:
+    a = make_track_info(video_id="aaaaaaaaaaa", title="A")
+    b = make_track_info(video_id="bbbbbbbbbbb", title="B")
+    track_history.record(111, a)
+    track_history.record(111, b)
+
+    history = track_history.get(111)
+    assert [t.title for t in history] == ["B", "A"]
+
+
+def test_record_evicts_oldest_at_cap() -> None:
+    """Cap enforced: oldest entry falls off the right end of the deque."""
+    for i in range(track_history.MAX_HISTORY_SIZE + 5):
+        track_history.record(111, make_track_info(video_id=f"vid{i:08d}", title=f"T{i}"))
+
+    history = track_history.get(111)
+    assert len(history) == track_history.MAX_HISTORY_SIZE
+    # Newest is the last we recorded; oldest visible is offset by 5.
+    assert history[0].title == f"T{track_history.MAX_HISTORY_SIZE + 4}"
+    assert history[-1].title == "T5"
+
+
+def test_record_repeated_track_keeps_each_event() -> None:
+    """History is per-event; recording the same track twice yields two entries."""
+    track = make_track_info(title="Solo")
+    track_history.record(111, track)
+    track_history.record(111, track)
+
+    assert [t.title for t in track_history.get(111)] == ["Solo", "Solo"]
+
+
+def test_per_guild_isolation() -> None:
+    track_history.record(111, make_track_info(video_id="aaaaaaaaaaa", title="A"))
+    track_history.record(222, make_track_info(video_id="bbbbbbbbbbb", title="B"))
+
+    assert [t.title for t in track_history.get(111)] == ["A"]
+    assert [t.title for t in track_history.get(222)] == ["B"]
+
+
+def test_get_returns_snapshot_not_internal_deque() -> None:
+    """``get`` returns a list copy; mutating it must not affect the ring."""
+    track_history.record(111, make_track_info(title="A"))
+    snap = track_history.get(111)
+    snap.clear()
+
+    assert len(track_history.get(111)) == 1
+
+
+def test_reset_state_clears_all_guilds() -> None:
+    track_history.record(111, make_track_info(title="A"))
+    track_history.record(222, make_track_info(title="B"))
+
+    track_history._reset_state_for_test()
+
+    assert track_history.get(111) == []
+    assert track_history.get(222) == []

--- a/tests/test_ux.py
+++ b/tests/test_ux.py
@@ -338,3 +338,34 @@ def test_playlist_embed_escapes_markdown_in_title() -> None:
     assert embed.description is not None
     assert "**hax**" not in embed.description
     assert "\\*\\*hax\\*\\*" in embed.description
+
+
+# ---------------------------------------------------------------------------
+# build_recent_embed (issue #96)
+# ---------------------------------------------------------------------------
+
+
+def test_recent_embed_lists_tracks_in_order_and_counts() -> None:
+    history = [
+        _track(video_id="aaaaaaaaaaa", title="Newest"),
+        _track(video_id="bbbbbbbbbbb", title="Older"),
+    ]
+    embed = ux.build_recent_embed(history)
+
+    assert isinstance(embed, hikari.Embed)
+    assert embed.title == "Recently played (2)"
+    description = embed.description or ""
+    assert "1. [Newest]" in description
+    assert "2. [Older]" in description
+    assert embed.footer is not None
+    assert (embed.footer.text or "").startswith("Use /replay")
+
+
+def test_recent_embed_escapes_markdown_in_titles() -> None:
+    history = [_track(video_id="aaaaaaaaaaa", title="**evil** [link](http://x)")]
+    embed = ux.build_recent_embed(history)
+
+    assert embed.description is not None
+    assert "**evil**" not in embed.description
+    assert "\\*\\*evil\\*\\*" in embed.description
+    assert "\\[link\\]" in embed.description

--- a/uv.lock
+++ b/uv.lock
@@ -835,7 +835,7 @@ wheels = [
 
 [[package]]
 name = "ryzic"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Closes #96.

## Summary

- Per-guild ring buffer of the last 25 played tracks (in-memory, ephemeral by design — issue #96 hard line).
- `/recent` lists newest-first; `/replay [position]` re-queues via the existing `_handle_play` so cache/pinning/voice-handshake logic stays in one place.
- History populated by `lavalink_glue.on_track_end` only for `EndReason.FINISHED` (natural end) and `EndReason.REPLACED` (`/skip` lands here). `LOAD_FAILED`, `STOPPED`, `CLEANUP` are excluded.

## Hard lines respected

- `/replay` re-routes through `_handle_play` — no duplicated play/cache logic.
- No favorites / persistence drift; cross-session storage is a separate, out-of-scope feature.
- ~150 LOC target — production code is ~167 LOC across 3 small modules; the overage is comments documenting non-obvious WHYs (EndReason rationale, deque eviction semantics).

## Test plan

- [ ] `uv run pytest -q` — all green (379 pass)
- [ ] `uv run ruff check .` clean
- [ ] `uv run ruff format --check .` clean
- [ ] `uv run ty check` clean
- [ ] Manual smoke tests in `docs/manual-smoke-tests.md` (new "Track history" section): empty-history ephemeral, newest-first ordering, `/replay` re-queues, out-of-range bounds check, 25-cap eviction, in-memory ephemerality across restart.