### PR TITLE
fix(lavalink_glue): skip voice_lost broadcast on intentional disconnects

### DIFF
--- a/docs/plans/fix-170-voice-lost-broadcast.md
+++ b/docs/plans/fix-170-voice-lost-broadcast.md
@@ -1,0 +1,91 @@
+# Fix #170: Intentional leaves misfire voice-lost broadcast
+
+## Problem
+
+The `voice_lost` channel broadcast fires on paths where the disconnect is **intentional**, not a network failure. Pressing the controller's Leave button, running `/leave`, or hitting the idle auto-leave timer currently emit the "voice was lost" sentence alongside the intentional-leave broadcast.
+
+## Root Cause
+
+All disconnects (intentional and unintentional) result in Discord closing the voice WebSocket with code 4014. The `on_websocket_closed` handler catches ALL 4014 events and broadcasts `voice_lost`, with no mechanism to distinguish intentional from unintentional disconnects.
+
+### Call paths
+
+1. **Leave button** → `_handle_leave` → `bot.update_voice_state(guild_id, None)` → 4014 → `voice_lost`
+2. **`/leave` command** → `_handle_leave` → `bot.update_voice_state(guild_id, None)` → 4014 → `voice_lost`
+3. **Auto-leave** → `_auto_leave` → `bot.update_voice_state(guild_id, None)` → 4014 → `voice_lost`
+
+## Solution
+
+Add a `_pending_intentional_disconnects: set[int]` to track guilds where disconnect was intentional. Check this set in `on_websocket_closed` and skip the `voice_lost` broadcast if present, then clear the entry.
+
+## Implementation
+
+### lavalink_glue.py
+
+1. Add module-level state:
+   ```python
+   _pending_intentional_disconnects: set[int] = set()
+   ```
+
+2. Add helper functions:
+   ```python
+   def _mark_intentional_disconnect(guild_id: int) -> None:
+       """Mark a guild's disconnect as intentional so on_websocket_closed skips voice_lost."""
+       _pending_intentional_disconnects.add(guild_id)
+
+   def _clear_intentional_disconnect(guild_id: int) -> None:
+       """Clear an intentional disconnect marker (called after WebSocket close processed)."""
+       _pending_intentional_disconnects.discard(guild_id)
+   ```
+
+3. Modify `on_websocket_closed` (line 455-464):
+   ```python
+   if event.code != 4014:
+       return
+   if guild_id in _pending_intentional_disconnects:
+       _pending_intentional_disconnects.discard(guild_id)
+       # Skip voice_lost broadcast — disconnect was intentional
+       # Still need to clear queue and reset state
+       await clear_queue_releasing(cast(lavalink.DefaultPlayer, event.player))
+       _cancel_auto_leave(guild_id)
+       _reset_voice_ready(guild_id)
+       # NOTE: no voice_lost broadcast, no teardown (leave handlers already did this)
+       return
+   # Unintentional disconnect — broadcast voice_lost
+   await clear_queue_releasing(...)
+   ...
+   ```
+
+4. Modify `_auto_leave` (line 177-178):
+   - Call `_mark_intentional_disconnect(guild_id)` before `update_voice_state`
+   - Note: `_auto_leave` broadcasts its own message before the disconnect, so we don't need to broadcast again
+
+5. Export `_mark_intentional_disconnect` for use by `/leave` command.
+
+### commands/leave.py
+
+Modify `_handle_leave` (line 59):
+- Import `_mark_intentional_disconnect` from `lavalink_glue`
+- Call `_mark_intentional_disconnect(guild_id)` before `bot.update_voice_state(guild_id, None)`
+
+### now_playing_buttons.py
+
+No changes needed — it calls `_handle_leave` from `leave.py`, which will now mark the disconnect as intentional.
+
+## Testing
+
+1. Unit tests in `tests/test_lavalink_bridge.py`:
+   - Add test for intentional disconnect skipping `voice_lost`
+   - Add test for unintentional disconnect still broadcasting `voice_lost`
+   - Add test for `_mark_intentional_disconnect` / `_clear_intentional_disconnect` lifecycle
+
+2. Manual testing:
+   - Click Leave button → should see only "Left voice channel", no "Voice connection lost"
+   - Run `/leave` → same
+   - Wait for auto-leave → should see only idle message, no "Voice connection lost"
+
+## Files Changed
+
+- `src/ryzic/lavalink_glue.py` — state tracking + `on_websocket_closed` logic
+- `src/ryzic/commands/leave.py` — mark intentional disconnect
+- `tests/test_lavalink_bridge.py` — new tests

--- a/src/ryzic/commands/leave.py
+++ b/src/ryzic/commands/leave.py
@@ -56,6 +56,8 @@ async def _handle_leave(ctx: lightbulb.Context) -> None:
     await lavalink_glue.clear_queue_releasing(player)
 
     bot = cast(hikari.GatewayBot, ctx.client.app)
+    # Mark as intentional so on_websocket_closed skips voice_lost broadcast.
+    lavalink_glue._mark_intentional_disconnect(guild_id)
     await bot.update_voice_state(guild_id, None)
 
     await now_playing.teardown(bot, guild_id)

--- a/src/ryzic/lavalink_glue.py
+++ b/src/ryzic/lavalink_glue.py
@@ -82,6 +82,12 @@ last_play_channel: dict[int, int] = {}
 auto_leave_tasks: dict[int, asyncio.Task[None]] = {}
 _voice_ready_events: dict[int, asyncio.Event] = {}
 
+# Guilds with pending intentional disconnects. When the bot initiates a
+# disconnect (Leave button, /leave, auto-leave), we mark the guild here so
+# the subsequent WebSocket 4014 close event knows not to broadcast
+# "voice_lost" — the disconnect was intentional, not a network failure.
+_pending_intentional_disconnects: set[int] = set()
+
 
 # Singleton lavalink client. Constructed on the first ``ShardReadyEvent``
 # (needs the bot's user id).
@@ -137,6 +143,16 @@ def _reset_voice_ready(guild_id: int) -> None:
     _voice_ready_events.pop(guild_id, None)
 
 
+def _mark_intentional_disconnect(guild_id: int) -> None:
+    """Mark a guild's disconnect as intentional so on_websocket_closed skips voice_lost."""
+    _pending_intentional_disconnects.add(guild_id)
+
+
+def _clear_intentional_disconnect(guild_id: int) -> None:
+    """Clear an intentional disconnect marker (called after WebSocket close processed)."""
+    _pending_intentional_disconnects.discard(guild_id)
+
+
 def _cancel_auto_leave(guild_id: int) -> None:
     task = auto_leave_tasks.pop(guild_id, None)
     if task is not None and not task.done():
@@ -174,6 +190,8 @@ async def _auto_leave(bot: hikari.GatewayBot, guild_id: int, seconds: int) -> No
     if player is None or not player.is_connected:
         return
 
+    # Mark as intentional so on_websocket_closed skips voice_lost broadcast.
+    _mark_intentional_disconnect(guild_id)
     try:
         await bot.update_voice_state(guild_id, None)
     except Exception:
@@ -454,6 +472,22 @@ class EventHandler:
         )
         if event.code != 4014:
             return
+
+        # Intentional disconnect (Leave button, /leave, auto-leave) — skip
+        # the voice_lost broadcast. The leave handlers already cleaned up
+        # and sent their own message.
+        if guild_id in _pending_intentional_disconnects:
+            _pending_intentional_disconnects.discard(guild_id)
+            await clear_queue_releasing(cast(lavalink.DefaultPlayer, event.player))
+            _cancel_auto_leave(guild_id)
+            _reset_voice_ready(guild_id)
+            from . import now_playing
+
+            await now_playing.teardown(self._bot, guild_id)
+            return
+
+        # Unintentional disconnect (kicked, channel deleted, region migrated).
+        # Broadcast voice_lost and teardown.
         await clear_queue_releasing(cast(lavalink.DefaultPlayer, event.player))
         _cancel_auto_leave(guild_id)
         _reset_voice_ready(guild_id)
@@ -680,3 +714,4 @@ def _reset_state_for_test() -> None:
     auto_leave_tasks.clear()
     _auto_leave_seconds = DEFAULT_AUTO_LEAVE_SECONDS
     _voice_ready_events.clear()
+    _pending_intentional_disconnects.clear()

--- a/tests/test_lavalink_bridge.py
+++ b/tests/test_lavalink_bridge.py
@@ -1365,6 +1365,86 @@ async def test_websocket_closed_4014_broadcasts_voice_lost_from_catalog() -> Non
     assert bot.created_messages[0][1] == "Voice connection lost. Queue cleared."
 
 
+async def test_websocket_closed_4014_skips_broadcast_on_intentional_disconnect() -> None:
+    """When disconnect is intentional (Leave button, /leave, auto-leave), skip voice_lost.
+
+    Regression for #170: the Leave button and /leave were triggering "Voice
+    connection lost" broadcasts alongside their intentional-leave messages.
+    """
+    from ryzic import audio_cache
+
+    @dataclass
+    class _WsClosedEvent:
+        player: _QueuePlayer
+        code: int = 4014
+        reason: str = "Disconnected"
+        by_remote: bool = True
+
+    fake = RecordingCache()
+    audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
+    try:
+        bot = _FakeApp()
+        lavalink_glue.last_play_channel[111] = 999
+        handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+        player = _QueuePlayer(
+            queue=[_IdTrack(identifier="/var/cache/ryzic/audio/int/intentional.audio")]
+        )
+
+        # Mark disconnect as intentional before the WebSocket close fires
+        lavalink_glue._mark_intentional_disconnect(111)
+
+        await handler.on_websocket_closed(
+            cast(lavalink.WebSocketClosedEvent, _WsClosedEvent(player=player)),
+        )
+
+        # No voice_lost broadcast — the disconnect was intentional
+        assert bot.created_messages == []
+        # Queue still cleared (for auto-leave case; /leave already cleared it)
+        assert fake.released == ["intentional"]
+        assert player.queue == []
+        # Marker cleared after processing
+        assert 111 not in lavalink_glue._pending_intentional_disconnects
+    finally:
+        audio_cache.set_audio_cache(None)
+
+
+async def test_intentional_disconnect_marker_lifecycle() -> None:
+    """The marker can be set, checked, and cleared."""
+    lavalink_glue._mark_intentional_disconnect(111)
+    assert 111 in lavalink_glue._pending_intentional_disconnects
+
+    lavalink_glue._clear_intentional_disconnect(111)
+    assert 111 not in lavalink_glue._pending_intentional_disconnects
+
+    # Clearing a non-existent marker is safe (idempotent)
+    lavalink_glue._clear_intentional_disconnect(222)
+    assert 222 not in lavalink_glue._pending_intentional_disconnects
+
+
+async def test_websocket_closed_4014_clears_intentional_disconnect_marker() -> None:
+    """The marker is cleared even if no broadcast happens."""
+
+    @dataclass
+    class _WsClosedEvent:
+        player: _QueuePlayer
+        code: int = 4014
+        reason: str = "Disconnected"
+        by_remote: bool = True
+
+    bot = _FakeApp()
+    handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+
+    lavalink_glue._mark_intentional_disconnect(111)
+    assert 111 in lavalink_glue._pending_intentional_disconnects
+
+    await handler.on_websocket_closed(
+        cast(lavalink.WebSocketClosedEvent, _WsClosedEvent(player=_QueuePlayer())),
+    )
+
+    # Marker cleared after processing
+    assert 111 not in lavalink_glue._pending_intentional_disconnects
+
+
 async def test_node_disconnected_broadcasts_node_reconnecting_from_catalog() -> None:
     """NodeDisconnected path posts the catalog rendering, once per guild."""
 


### PR DESCRIPTION
## Problem

The `voice_lost` broadcast was firing on all WebSocket 4014 close events, including intentional disconnects from:
- Leave button click
- `/leave` command
- Idle auto-leave timer

This caused misleading "Voice connection lost. Queue cleared." messages alongside the correct "Left voice channel" or "Idle for X minutes — disconnecting." messages.

## Solution

Add `_pending_intentional_disconnects: set[int]` to track guilds with pending intentional disconnects:

1. Mark disconnect as intentional before calling `update_voice_state(guild_id, None)` in:
   - `_auto_leave` (idle timer)
   - `_handle_leave` (Leave button and `/leave` command)

2. In `on_websocket_closed`, check for intentional disconnect:
   - If intentional: skip `voice_lost` broadcast, still clear queue/teardown controller
   - If unintentional: broadcast `voice_lost` as before

## Testing

- Added tests for intentional disconnect marker lifecycle
- Added test for intentional disconnect skipping `voice_lost` broadcast  
- Added test for marker being cleared after processing
- All 564 tests pass

Fixes #170