### PR TITLE
fix(lavalink_glue): clean up intentional-disconnect marker on error paths

### DIFF
--- a/src/ryzic/commands/leave.py
+++ b/src/ryzic/commands/leave.py
@@ -58,7 +58,11 @@ async def _handle_leave(ctx: lightbulb.Context) -> None:
     bot = cast(hikari.GatewayBot, ctx.client.app)
     # Mark as intentional so on_websocket_closed skips voice_lost broadcast.
     lavalink_glue._mark_intentional_disconnect(guild_id)
-    await bot.update_voice_state(guild_id, None)
+    try:
+        await bot.update_voice_state(guild_id, None)
+    except Exception:
+        lavalink_glue._clear_intentional_disconnect(guild_id)
+        raise
 
     await now_playing.teardown(bot, guild_id)
     await ctx.respond(t("leave.success.left", locale=locale_for_public(ctx)))

--- a/src/ryzic/lavalink_glue.py
+++ b/src/ryzic/lavalink_glue.py
@@ -195,6 +195,7 @@ async def _auto_leave(bot: hikari.GatewayBot, guild_id: int, seconds: int) -> No
     try:
         await bot.update_voice_state(guild_id, None)
     except Exception:
+        _clear_intentional_disconnect(guild_id)
         _log.exception("auto-leave: failed to disconnect from guild %d", guild_id)
 
     _reset_voice_ready(guild_id)
@@ -477,7 +478,7 @@ class EventHandler:
         # the voice_lost broadcast. The leave handlers already cleaned up
         # and sent their own message.
         if guild_id in _pending_intentional_disconnects:
-            _pending_intentional_disconnects.discard(guild_id)
+            _clear_intentional_disconnect(guild_id)
             await clear_queue_releasing(cast(lavalink.DefaultPlayer, event.player))
             _cancel_auto_leave(guild_id)
             _reset_voice_ready(guild_id)
@@ -622,6 +623,7 @@ async def _on_guild_leave(event: hikari.GuildLeaveEvent) -> None:
     _cancel_auto_leave(guild_id)
     last_play_channel.pop(guild_id, None)
     _voice_ready_events.pop(guild_id, None)
+    _clear_intentional_disconnect(guild_id)
     from . import now_playing
 
     # No REST teardown — the bot has just lost its messages-write


### PR DESCRIPTION
## Summary

Post-merge review of #197 found 4 bugs in the intentional-disconnect marker implementation:

1. **`_auto_leave`: Marker leaks on exception** — If `update_voice_state` throws after marking the disconnect as intentional, the exception is logged but the marker remains set. A subsequent unintentional disconnect (bot kicked from channel) would be misclassified as intentional, skipping the `voice_lost` broadcast.

2. **`_handle_leave`: Marker leaks on exception** — Same issue as `_auto_leave`, but without any exception handling. If `update_voice_state` throws, the marker leaks, `teardown()` and `ctx.respond()` never execute, and subsequent unintentional disconnects are misclassified.

3. **`_on_guild_leave`: Marker not cleaned up** — When the bot is kicked from a guild, `_on_guild_leave` cleans up `last_play_channel`, `_voice_ready_events`, and `auto_leave_tasks` but NOT `_pending_intentional_disconnects`. This creates orphaned entries.

4. **Dead code: `_clear_intentional_disconnect` never called in production** — The helper function was defined but only used in tests. `on_websocket_closed` used inline `.discard()` instead.

## Changes

- Add `_clear_intentional_disconnect(guild_id)` call in `_auto_leave` exception handler
- Add try/except in `_handle_leave` to clear marker on failure (with re-raise)
- Add `_clear_intentional_disconnect(guild_id)` call in `_on_guild_leave`
- Use `_clear_intentional_disconnect` helper consistently in `on_websocket_closed`

## Testing

All 564 tests pass. Type checking and linting pass.

Fixes post-merge review issues from #197.