### PR TITLE
fix(now_playing): bump controller to channel bottom after broadcasts

### DIFF
--- a/src/ryzic/lavalink_glue.py
+++ b/src/ryzic/lavalink_glue.py
@@ -237,12 +237,19 @@ async def _send_to_last_play_channel(bot: hikari.GatewayBot, guild_id: int, cont
             channel_id,
             guild_id,
         )
+        return
     except hikari.HikariError:
         _log.warning(
             "could not post to last_play_channel %d for guild %d",
             channel_id,
             guild_id,
         )
+        return
+
+    # Bump controller to channel bottom after broadcast (rate-limited)
+    from . import now_playing
+
+    await now_playing.bump_if_needed(bot, guild_id)
 
 
 def _track_title(track: lavalink.AudioTrack | None) -> str:

--- a/src/ryzic/now_playing.py
+++ b/src/ryzic/now_playing.py
@@ -29,6 +29,7 @@ ephemeral graceful-failure path (see :func:`is_known_message`).
 from __future__ import annotations
 
 import logging
+import time
 
 import hikari
 
@@ -68,6 +69,12 @@ _LABEL_LEAVE = t("controller.button.leave", locale="en_US")
 # and an extra registry layer would be ceremony. Tests reset via
 # :func:`_reset_state_for_test`.
 _controllers: dict[int, tuple[int, int]] = {}
+
+# Per-guild last bump time (unix timestamp). Rate-limits controller reposts
+# so broadcasts don't spam the channel. 60s minimum between bumps (balances
+# keeping the controller visible vs. avoiding notification noise).
+_last_bump_time: dict[int, float] = {}
+MIN_BUMP_INTERVAL = 60.0
 
 
 def is_known_message(guild_id: int, message_id: int) -> bool:
@@ -312,6 +319,79 @@ async def teardown(bot: hikari.GatewayBot, guild_id: int) -> None:
         )
 
 
+async def bump_if_needed(bot: hikari.GatewayBot, guild_id: int) -> None:
+    """Repost the controller at channel bottom if rate limit allows.
+
+    Called from ``lavalink_glue._send_to_last_play_channel`` after a broadcast
+    message posts. When enough time has passed since the last bump (60s minimum),
+    this deletes the old controller message and posts a fresh one at the channel
+    bottom, keeping the controller visible below the broadcast.
+
+    Best-effort: if deletion or posting fails, we log and return. The old
+    controller remains functional (buttons still work until it scrolls too far).
+    No-op when the guild has no active controller.
+    """
+    record = _controllers.get(guild_id)
+    if record is None:
+        return
+
+    # Rate limit: at most one bump per minute per guild
+    now = time.time()
+    last = _last_bump_time.get(guild_id, 0.0)
+    if now - last < MIN_BUMP_INTERVAL:
+        return
+
+    channel_id, old_message_id = record
+
+    # Render current player state
+    player = lavalink_glue.get_player(guild_id)
+    if player is None or player.current is None:
+        embed = ux.build_now_playing_idle_embed(locale="en_US")
+        components = _build_idle_components()
+    else:
+        info = ux.get_track_info(player.current)
+        if info is None:
+            embed = ux.build_now_playing_idle_embed(locale="en_US")
+            components = _build_idle_components()
+        else:
+            embed = ux.build_now_playing_embed(
+                info,
+                position_ms=player.position,
+                paused=player.paused,
+                queue_length=len(player.queue),
+                locale="en_US",
+            )
+            components = _build_components_paused() if player.paused else _build_components()
+
+    # Delete old controller (best-effort)
+    try:
+        await bot.rest.delete_message(channel_id, old_message_id)
+    except hikari.NotFoundError:
+        pass  # Already deleted, that's fine
+    except hikari.HikariError:
+        _log.warning(
+            "guild=%d failed to delete old controller %d/%d for bump; continuing",
+            guild_id,
+            channel_id,
+            old_message_id,
+        )
+
+    # Post fresh controller at bottom
+    try:
+        message = await bot.rest.create_message(channel_id, embed=embed, components=components)
+    except hikari.HikariError:
+        _log.exception(
+            "guild=%d failed to post bumped controller in channel %d",
+            guild_id,
+            channel_id,
+        )
+        return
+
+    _controllers[guild_id] = (channel_id, int(message.id))
+    _last_bump_time[guild_id] = now
+
+
 def _reset_state_for_test() -> None:
     """Test-only: clear all per-guild controller state."""
     _controllers.clear()
+    _last_bump_time.clear()

--- a/tests/test_now_playing.py
+++ b/tests/test_now_playing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any, cast
 from unittest.mock import MagicMock
 
@@ -330,6 +331,143 @@ async def test_lavalink_default_player_typing_uses_player_manager_get() -> None:
     assert cast_player is None  # nothing created yet
     cast_lavalink = cast(lavalink.Client, ll)
     assert cast_lavalink.player_manager.get(111) is None
+
+
+# ---------------------------------------------------------------------------
+# bump_if_needed (rate-limited controller repost)
+# ---------------------------------------------------------------------------
+
+
+class _FakeRestWithDelete(_FakeRest):
+    """Extends _FakeRest with delete_message tracking."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.delete_calls: list[dict[str, Any]] = []
+
+    async def delete_message(self, channel_id: int, message_id: int) -> None:
+        self.delete_calls.append({"channel_id": channel_id, "message_id": message_id})
+        if self._edit_error is not None:
+            # Reuse edit_error for delete errors
+            raise self._edit_error
+
+
+async def test_bump_if_needed_no_op_when_no_controller() -> None:
+    """No controller record → nothing to bump."""
+    rest = _FakeRestWithDelete()
+    bot = _bot_with_rest(rest)
+
+    await now_playing.bump_if_needed(bot, 111)
+
+    assert rest.create_calls == []
+    assert rest.delete_calls == []
+
+
+async def test_bump_if_needed_rate_limits() -> None:
+    """Within 60s of last bump → skip."""
+    rest = _FakeRestWithDelete(create_returns=9001)
+    bot = _bot_with_rest(rest)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = True
+    player.current = make_track_with_info(title="Track")
+    lavalink_glue.last_play_channel[111] = 555
+
+    await now_playing.upsert_for_track_start(bot, 111)
+    # Set last bump time to "now - 30s" (within rate limit)
+    now_playing._last_bump_time[111] = time.time() - 30.0
+
+    await now_playing.bump_if_needed(bot, 111)
+
+    assert len(rest.delete_calls) == 0
+    assert len(rest.create_calls) == 1  # Only the upsert
+
+
+async def test_bump_if_needed_deletes_old_and_posts_new() -> None:
+    """After interval → delete old controller, post fresh one."""
+    rest = _FakeRestWithDelete(create_returns=9100)
+    bot = _bot_with_rest(rest)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = True
+    player.current = make_track_with_info(title="Track")
+    lavalink_glue.last_play_channel[111] = 555
+
+    await now_playing.upsert_for_track_start(bot, 111)
+    rest.create_calls.clear()
+    rest.delete_calls.clear()
+
+    # Simulate enough time passed
+    now_playing._last_bump_time[111] = 0.0
+
+    await now_playing.bump_if_needed(bot, 111)
+
+    # Delete old controller, create new one
+    assert len(rest.delete_calls) == 1
+    assert rest.delete_calls[0]["message_id"] == 9100
+    assert len(rest.create_calls) == 1
+    assert now_playing.is_known_message(111, 9101)
+
+
+async def test_bump_if_needed_handles_missing_player() -> None:
+    """No player → idle embed in bumped controller."""
+    rest = _FakeRestWithDelete(create_returns=9200)
+    bot = _bot_with_rest(rest)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)  # No player created
+    now_playing._controllers[111] = (555, 9199)
+    now_playing._last_bump_time[111] = 0.0
+    lavalink_glue.last_play_channel[111] = 555
+
+    await now_playing.bump_if_needed(bot, 111)
+
+    embed: hikari.Embed = rest.create_calls[0]["embed"]
+    assert embed.title == t("ux.np.title.idle", locale="en_US")
+
+
+async def test_bump_if_needed_handles_deleted_message() -> None:
+    """Old controller already deleted → still posts new one."""
+    rest = _FakeRestWithDelete(
+        create_returns=9300,
+        edit_error=hikari.NotFoundError(url="x", headers={}, raw_body=b""),  # type: ignore[arg-type]
+    )
+    bot = _bot_with_rest(rest)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = True
+    player.current = make_track_with_info(title="Track")
+    now_playing._controllers[111] = (555, 9299)
+    now_playing._last_bump_time[111] = 0.0
+    lavalink_glue.last_play_channel[111] = 555
+
+    await now_playing.bump_if_needed(bot, 111)
+
+    # Delete attempt (fails with 404), then create new
+    assert len(rest.delete_calls) == 1
+    assert len(rest.create_calls) == 1
+    assert now_playing.is_known_message(111, 9300)
+
+
+async def test_bump_updates_timestamp() -> None:
+    """Bump updates _last_bump_time."""
+    rest = _FakeRestWithDelete(create_returns=9400)
+    bot = _bot_with_rest(rest)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = True
+    player.current = make_track_with_info()
+    now_playing._controllers[111] = (555, 9399)
+    now_playing._last_bump_time[111] = 0.0
+    lavalink_glue.last_play_channel[111] = 555
+
+    await now_playing.bump_if_needed(bot, 111)
+
+    assert 111 in now_playing._last_bump_time
+    assert now_playing._last_bump_time[111] > 0.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The persistent now-playing controller (#90) is edited in place at its original message location. When broadcasts (voice_lost, auto_leave, track_exception, track_stuck, node_reconnecting) post new messages, the controller scrolls up and becomes hard to find.

## Solution

Rate-limited bump mechanism:
- Track last bump time per guild (60s minimum interval)
- After sending broadcast, check if enough time has passed
- Delete old controller, post fresh one at channel bottom
- Best-effort: tolerate delete failures, log create errors

## Testing

- Unit tests for rate limiting, bump behavior, edge cases
- All existing tests pass

Fixes #171