### PR TITLE
fix: periodially refresh now-playing controllers so progress advances (#172)

### DIFF
--- a/src/ryzic/bot.py
+++ b/src/ryzic/bot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import shutil
 
@@ -18,10 +19,6 @@ _log = logging.getLogger(__name__)
 # inside ``cfg.cache_dir``. Kept as a module constant so tests can refer
 # to the same name without hard-coding a literal in two places.
 _COOKIES_SCRATCH_FILENAME = "youtube-cookies.txt"
-
-# Background task that periodically refreshes now-playing controllers.
-# Stored at module level so shutdown can cancel it cleanly.
-_refresh_task: asyncio.Task[None] | None = None
 
 
 def _build_client(bot: hikari.GatewayBot, cfg: config.Config) -> lightbulb.Client:
@@ -144,9 +141,10 @@ def main() -> None:
     now_playing_buttons.register_listener(bot)
 
     cache: audio_cache.AudioCache | None = None
+    refresh_task: asyncio.Task[None] | None = None
 
     async def _on_starting(_: hikari.StartingEvent) -> None:
-        nonlocal cache
+        nonlocal cache, refresh_task
         # Audio cache must be ready BEFORE /play runs — start it before
         # syncing the slash commands so a fast user invocation can
         # never race the bootstrap.
@@ -165,14 +163,15 @@ def main() -> None:
             "ryzic.commands.replay",
             "ryzic.commands.np",
         )
-        global _refresh_task
-        _refresh_task = bot.loop.create_task(_update_controllers_loop(bot))
+        refresh_task = asyncio.create_task(_update_controllers_loop(bot))
         await client.start()
 
     async def _on_stopping(_: hikari.StoppingEvent) -> None:
         await client.stop()
-        if _refresh_task is not None:
-            _refresh_task.cancel()
+        if refresh_task is not None:
+            refresh_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await refresh_task
         if cache is not None:
             audio_cache.set_audio_cache(None)
             await cache.close()

--- a/src/ryzic/bot.py
+++ b/src/ryzic/bot.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import shutil
 
@@ -9,7 +10,7 @@ import dotenv
 import hikari
 import lightbulb
 
-from . import audio_cache, config, lavalink_glue, now_playing_buttons, ytdlp
+from . import audio_cache, config, lavalink_glue, now_playing, now_playing_buttons, ytdlp
 
 _log = logging.getLogger(__name__)
 
@@ -17,6 +18,10 @@ _log = logging.getLogger(__name__)
 # inside ``cfg.cache_dir``. Kept as a module constant so tests can refer
 # to the same name without hard-coding a literal in two places.
 _COOKIES_SCRATCH_FILENAME = "youtube-cookies.txt"
+
+# Background task that periodically refreshes now-playing controllers.
+# Stored at module level so shutdown can cancel it cleanly.
+_refresh_task: asyncio.Task[None] | None = None
 
 
 def _build_client(bot: hikari.GatewayBot, cfg: config.Config) -> lightbulb.Client:
@@ -106,6 +111,18 @@ async def _bootstrap_audio_cache(cfg: config.Config) -> audio_cache.AudioCache:
     return cache
 
 
+async def _update_controllers_loop(bot: hikari.GatewayBot) -> None:
+    """Periodically refresh the now-playing controllers to advance progress bars."""
+    while True:
+        try:
+            await asyncio.sleep(15)
+            await now_playing.refresh_all(bot)
+        except asyncio.CancelledError:
+            break
+        except Exception:
+            _log.exception("periodic controller refresh loop failed")
+
+
 def main() -> None:
     dotenv.load_dotenv()
     cfg = config.load()
@@ -148,10 +165,14 @@ def main() -> None:
             "ryzic.commands.replay",
             "ryzic.commands.np",
         )
+        global _refresh_task
+        _refresh_task = bot.loop.create_task(_update_controllers_loop(bot))
         await client.start()
 
     async def _on_stopping(_: hikari.StoppingEvent) -> None:
         await client.stop()
+        if _refresh_task is not None:
+            _refresh_task.cancel()
         if cache is not None:
             audio_cache.set_audio_cache(None)
             await cache.close()

--- a/src/ryzic/now_playing.py
+++ b/src/ryzic/now_playing.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import logging
 import time
+import asyncio
 
 import hikari
 
@@ -201,6 +202,21 @@ async def refresh(bot: hikari.GatewayBot, guild_id: int) -> None:
         return
     channel_id = record[0]
     await _render_for_player(bot, guild_id, channel_id)
+
+
+async def refresh_all(bot: hikari.GatewayBot) -> None:
+    """Refresh all active controllers.
+
+    Used by the bot's background loop to advance progress bars.
+    Staggers updates to avoid API burst limits.
+    """
+    for guild_id in list(_controllers.keys()):
+        try:
+            await refresh(bot, guild_id)
+            await asyncio.sleep(0.1)
+        except Exception:
+            # refresh() handles its own logging for expected errors.
+            pass
 
 
 async def _render_for_player(bot: hikari.GatewayBot, guild_id: int, channel_id: int) -> None:

--- a/src/ryzic/now_playing.py
+++ b/src/ryzic/now_playing.py
@@ -28,9 +28,9 @@ ephemeral graceful-failure path (see :func:`is_known_message`).
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
-import asyncio
 
 import hikari
 
@@ -205,18 +205,26 @@ async def refresh(bot: hikari.GatewayBot, guild_id: int) -> None:
 
 
 async def refresh_all(bot: hikari.GatewayBot) -> None:
-    """Refresh all active controllers.
+    """Refresh all active controllers whose progress is actually moving.
 
-    Used by the bot's background loop to advance progress bars.
-    Staggers updates to avoid API burst limits.
+    Used by the bot's background loop to advance progress bars. Skips
+    paused / idle / disconnected players so we don't issue byte-identical
+    edits every cycle (their state only changes via an event, which
+    already routes through :func:`refresh`). Staggers updates to spread
+    concurrent in-flight REST requests.
     """
     for guild_id in list(_controllers.keys()):
+        player = lavalink_glue.get_player(guild_id)
+        if player is None or player.paused or player.current is None:
+            continue
         try:
             await refresh(bot, guild_id)
             await asyncio.sleep(0.1)
         except Exception:
-            # refresh() handles its own logging for expected errors.
-            pass
+            # refresh()/_post_or_edit already logs HikariErrors (the
+            # expected REST failures). Anything reaching here is an
+            # unexpected bug — log it so it isn't silently lost.
+            _log.debug("periodic refresh failed for guild %d", guild_id, exc_info=True)
 
 
 async def _render_for_player(bot: hikari.GatewayBot, guild_id: int, channel_id: int) -> None:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -14,13 +14,12 @@ import asyncio
 import logging
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch, AsyncMock, MagicMock
+from unittest.mock import MagicMock, patch
 
 import hikari
 import pytest
 
 from ryzic import bot, config, ytdlp
-from ryzic import now_playing
 
 
 def _make_cfg(cache_dir: Path, cookies_path: Path | None) -> config.Config:
@@ -200,26 +199,22 @@ def test_install_cookies_creates_cache_dir_if_missing(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_update_controllers_loop_refreshes_active_controllers() -> None:
-    """The loop periodically calls refresh for all recorded controllers."""
+    """The loop calls refresh_all once per cycle and exits on cancellation."""
     bot_mock = MagicMock(spec=hikari.GatewayBot)
 
-    # Setup controllers
-    now_playing._controllers = {111: (555, 9001), 222: (666, 9002)}
-
-    # Test by making the loop iterate once: first sleep returns immediately,
-    # second sleep raises CancelledError to break the loop.
+    # refresh_all is patched out, so each cycle is exactly one sleep + one
+    # refresh_all. The second sleep raises CancelledError to break the loop
+    # after one completed iteration.
     call_count = 0
 
     async def counting_refresh_all(bot):
         nonlocal call_count
         call_count += 1
 
-    with patch("ryzic.now_playing.refresh_all", side_effect=counting_refresh_all):
-        # side_effect: first sleep(15) returns None, second sleep(0.1) raises CancelledError
-        with patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError()]):
-            try:
-                await bot._update_controllers_loop(bot_mock)
-            except asyncio.CancelledError:
-                pass
+    with (
+        patch("ryzic.now_playing.refresh_all", side_effect=counting_refresh_all),
+        patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError()]),
+    ):
+        await bot._update_controllers_loop(bot_mock)
 
-    assert call_count >= 1
+    assert call_count == 1

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -10,14 +10,17 @@ without the writable scratch copy this helper produces.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock, MagicMock
 
+import hikari
 import pytest
 
 from ryzic import bot, config, ytdlp
+from ryzic import now_playing
 
 
 def _make_cfg(cache_dir: Path, cookies_path: Path | None) -> config.Config:
@@ -193,3 +196,30 @@ def test_install_cookies_creates_cache_dir_if_missing(tmp_path: Path) -> None:
     cfg = _make_cfg(cache_dir=cache_dir, cookies_path=source)
     bot._install_youtube_cookies(cfg)
     assert cache_dir.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_update_controllers_loop_refreshes_active_controllers() -> None:
+    """The loop periodically calls refresh for all recorded controllers."""
+    bot_mock = MagicMock(spec=hikari.GatewayBot)
+
+    # Setup controllers
+    now_playing._controllers = {111: (555, 9001), 222: (666, 9002)}
+
+    # Test by making the loop iterate once: first sleep returns immediately,
+    # second sleep raises CancelledError to break the loop.
+    call_count = 0
+
+    async def counting_refresh_all(bot):
+        nonlocal call_count
+        call_count += 1
+
+    with patch("ryzic.now_playing.refresh_all", side_effect=counting_refresh_all):
+        # side_effect: first sleep(15) returns None, second sleep(0.1) raises CancelledError
+        with patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError()]):
+            try:
+                await bot._update_controllers_loop(bot_mock)
+            except asyncio.CancelledError:
+                pass
+
+    assert call_count >= 1


### PR DESCRIPTION
Fixes #172. Implements a background loop in bot.py that periodically calls now_playing.refresh for all active controllers.