### PR TITLE
fix(lavalink_glue): bound and clear intentional-disconnect marker (#203)

### DIFF
--- a/src/ryzic/commands/leave.py
+++ b/src/ryzic/commands/leave.py
@@ -57,11 +57,11 @@ async def _handle_leave(ctx: lightbulb.Context) -> None:
 
     bot = cast(hikari.GatewayBot, ctx.client.app)
     # Mark as intentional so on_websocket_closed skips voice_lost broadcast.
-    lavalink_glue._mark_intentional_disconnect(guild_id)
+    lavalink_glue.mark_intentional_disconnect(guild_id)
     try:
         await bot.update_voice_state(guild_id, None)
     except Exception:
-        lavalink_glue._clear_intentional_disconnect(guild_id)
+        lavalink_glue.clear_intentional_disconnect(guild_id)
         raise
 
     await now_playing.teardown(bot, guild_id)

--- a/src/ryzic/lavalink_glue.py
+++ b/src/ryzic/lavalink_glue.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import time
 from pathlib import Path
 from typing import cast
 
@@ -59,6 +60,17 @@ _log = logging.getLogger(__name__)
 
 DEFAULT_AUTO_LEAVE_SECONDS = 300
 VOICE_READY_TIMEOUT_SECONDS = 5.0
+
+# Bounds the leak window for the intentional-disconnect marker. The marker is
+# set just before ``bot.update_voice_state(guild_id, None)``; the resulting
+# WebSocket 4014 close arrives sub-second later, so 30s is generous. Two leak
+# modes the structural clears don't reach: (a) a non-4014 voice close (4006 /
+# 4009 / 4011 / 4012 / 4015) lands before the 4014, (b) the 4014 never arrives
+# at all (``update_voice_state`` no-op, lost close). Without a TTL the marker
+# sits forever and the next genuine disconnect misclassifies as intentional,
+# silently suppressing ``voice_lost``. A >30s-delayed 4014 may produce a
+# spurious ``voice_lost`` — strictly better than today's silent skip.
+INTENTIONAL_DISCONNECT_TTL_SECONDS: float = 30.0
 
 # Mutated once at startup by ``register_listeners`` from ``cfg.auto_leave_seconds``.
 # Module-level by design (mirrors the ``_ll_client`` singleton): the auto-leave
@@ -82,11 +94,14 @@ last_play_channel: dict[int, int] = {}
 auto_leave_tasks: dict[int, asyncio.Task[None]] = {}
 _voice_ready_events: dict[int, asyncio.Event] = {}
 
-# Guilds with pending intentional disconnects. When the bot initiates a
-# disconnect (Leave button, /leave, auto-leave), we mark the guild here so
-# the subsequent WebSocket 4014 close event knows not to broadcast
-# "voice_lost" — the disconnect was intentional, not a network failure.
-_pending_intentional_disconnects: set[int] = set()
+# Guilds with pending intentional disconnects, keyed by guild_id to the
+# ``time.monotonic()`` stamp recorded when the disconnect was initiated.
+# When the bot initiates a disconnect (Leave button, /leave, auto-leave), we
+# mark the guild here so the subsequent WebSocket 4014 close event knows not
+# to broadcast "voice_lost" — the disconnect was intentional, not a network
+# failure. Entries are bounded by ``INTENTIONAL_DISCONNECT_TTL_SECONDS`` and
+# garbage-collected lazily by ``_gc_intentional_disconnects``.
+_pending_intentional_disconnects: dict[int, float] = {}
 
 
 # Singleton lavalink client. Constructed on the first ``ShardReadyEvent``
@@ -143,14 +158,43 @@ def _reset_voice_ready(guild_id: int) -> None:
     _voice_ready_events.pop(guild_id, None)
 
 
-def _mark_intentional_disconnect(guild_id: int) -> None:
-    """Mark a guild's disconnect as intentional so on_websocket_closed skips voice_lost."""
-    _pending_intentional_disconnects.add(guild_id)
+def _gc_intentional_disconnects(now: float | None = None) -> None:
+    """Discard intentional-disconnect markers older than the TTL.
+
+    Called lazily at the top of ``on_websocket_closed`` and inside
+    ``_intentional_disconnect_is_pending`` so the leak window is bounded
+    without relying on a structural event arriving.
+    """
+    if now is None:
+        now = time.monotonic()
+    cutoff = now - INTENTIONAL_DISCONNECT_TTL_SECONDS
+    for gid, stamp in list(_pending_intentional_disconnects.items()):
+        if stamp < cutoff:
+            del _pending_intentional_disconnects[gid]
 
 
-def _clear_intentional_disconnect(guild_id: int) -> None:
-    """Clear an intentional disconnect marker (called after WebSocket close processed)."""
-    _pending_intentional_disconnects.discard(guild_id)
+def mark_intentional_disconnect(guild_id: int) -> None:
+    """Mark a guild's disconnect as intentional so on_websocket_closed skips voice_lost.
+
+    Cross-module API: called by ``commands.leave`` and the auto-leave timer
+    in this module just before ``bot.update_voice_state(guild_id, None)``.
+    """
+    _pending_intentional_disconnects[guild_id] = time.monotonic()
+
+
+def clear_intentional_disconnect(guild_id: int) -> None:
+    """Clear an intentional disconnect marker (idempotent; safe to call when none set)."""
+    _pending_intentional_disconnects.pop(guild_id, None)
+
+
+def _intentional_disconnect_is_pending(guild_id: int) -> bool:
+    """True if an intentional-disconnect marker for ``guild_id`` is still within TTL.
+
+    Runs lazy GC first so an expired marker cannot suppress a genuine
+    disconnect's ``voice_lost`` broadcast.
+    """
+    _gc_intentional_disconnects()
+    return guild_id in _pending_intentional_disconnects
 
 
 def _cancel_auto_leave(guild_id: int) -> None:
@@ -191,11 +235,11 @@ async def _auto_leave(bot: hikari.GatewayBot, guild_id: int, seconds: int) -> No
         return
 
     # Mark as intentional so on_websocket_closed skips voice_lost broadcast.
-    _mark_intentional_disconnect(guild_id)
+    mark_intentional_disconnect(guild_id)
     try:
         await bot.update_voice_state(guild_id, None)
     except Exception:
-        _clear_intentional_disconnect(guild_id)
+        clear_intentional_disconnect(guild_id)
         _log.exception("auto-leave: failed to disconnect from guild %d", guild_id)
 
     _reset_voice_ready(guild_id)
@@ -337,6 +381,24 @@ async def clear_queue_releasing(player: lavalink.DefaultPlayer) -> None:
         await _release_track(track)
 
 
+async def _teardown_player_session(
+    bot: hikari.GatewayBot, guild_id: int, player: lavalink.DefaultPlayer
+) -> None:
+    """Run the full per-guild cleanup sequence shared by every teardown path.
+
+    Releases queued pins, cancels the auto-leave timer, drops the voice-ready
+    handshake event, and tears down the now-playing controller. Owns NO
+    broadcast — callers decide whether to post ``voice_lost`` /
+    ``node_reconnecting`` (the node path is per-guild deduped outside).
+    """
+    await clear_queue_releasing(player)
+    _cancel_auto_leave(guild_id)
+    _reset_voice_ready(guild_id)
+    from . import now_playing
+
+    await now_playing.teardown(bot, guild_id)
+
+
 def _safe_error_text(text: str | None) -> str:
     """Sanitise server-supplied error text before posting to a public channel.
 
@@ -471,35 +533,45 @@ class EventHandler:
             event.reason,
             event.by_remote,
         )
+        # Lazy GC bounds the lost-close / silent-no-op leak window before any
+        # membership check below reads stale state.
+        _gc_intentional_disconnects()
+
         if event.code != 4014:
+            # Non-4014 voice closes (4006/4009/4011/4012/4015) are transient
+            # or terminal-without-disconnect; they must not leave a marker
+            # behind, or the next genuine 4014 misclassifies as intentional
+            # and silently skips voice_lost. Do NOT clear above the 4014 path
+            # unconditionally — that would break #197 (the 4014 membership
+            # check would always be False → voice_lost always broadcasts).
+            clear_intentional_disconnect(guild_id)
             return
 
         # Intentional disconnect (Leave button, /leave, auto-leave) — skip
         # the voice_lost broadcast. The leave handlers already cleaned up
         # and sent their own message.
-        if guild_id in _pending_intentional_disconnects:
-            _clear_intentional_disconnect(guild_id)
-            await clear_queue_releasing(cast(lavalink.DefaultPlayer, event.player))
-            _cancel_auto_leave(guild_id)
-            _reset_voice_ready(guild_id)
-            from . import now_playing
-
-            await now_playing.teardown(self._bot, guild_id)
+        if _intentional_disconnect_is_pending(guild_id):
+            clear_intentional_disconnect(guild_id)
+            await _teardown_player_session(
+                self._bot, guild_id, cast(lavalink.DefaultPlayer, event.player)
+            )
             return
 
         # Unintentional disconnect (kicked, channel deleted, region migrated).
-        # Broadcast voice_lost and teardown.
-        await clear_queue_releasing(cast(lavalink.DefaultPlayer, event.player))
-        _cancel_auto_leave(guild_id)
-        _reset_voice_ready(guild_id)
+        # Broadcast voice_lost and teardown. The broadcast runs AFTER
+        # ``_teardown_player_session`` returns (i.e. after now_playing.teardown);
+        # this reorder vs. the pre-extraction order is safe because
+        # ``_send_to_last_play_channel`` and ``now_playing.teardown`` touch
+        # disjoint state.
+        await _teardown_player_session(
+            self._bot, guild_id, cast(lavalink.DefaultPlayer, event.player)
+        )
+        clear_intentional_disconnect(guild_id)
         await _send_to_last_play_channel(
             self._bot,
             guild_id,
             _broadcast_t("lavalink.broadcast.voice_lost"),
         )
-        from . import now_playing
-
-        await now_playing.teardown(self._bot, guild_id)
 
     @lavalink.listener(lavalink.NodeDisconnectedEvent)
     async def on_node_disconnected(self, event: lavalink.NodeDisconnectedEvent) -> None:
@@ -512,16 +584,15 @@ class EventHandler:
         client = _ll_client
         if client is None:
             return
-        from . import now_playing
 
         reconnect_message = _broadcast_t("lavalink.broadcast.node_reconnecting")
         notified: set[int] = set()
         for player in list(client.player_manager.values()):
             guild_id = player.guild_id
-            await clear_queue_releasing(cast(lavalink.DefaultPlayer, player))
-            _cancel_auto_leave(guild_id)
-            _reset_voice_ready(guild_id)
-            await now_playing.teardown(self._bot, guild_id)
+            await _teardown_player_session(
+                self._bot, guild_id, cast(lavalink.DefaultPlayer, player)
+            )
+            clear_intentional_disconnect(guild_id)
             if guild_id in notified:
                 continue
             notified.add(guild_id)
@@ -623,7 +694,7 @@ async def _on_guild_leave(event: hikari.GuildLeaveEvent) -> None:
     _cancel_auto_leave(guild_id)
     last_play_channel.pop(guild_id, None)
     _voice_ready_events.pop(guild_id, None)
-    _clear_intentional_disconnect(guild_id)
+    clear_intentional_disconnect(guild_id)
     from . import now_playing
 
     # No REST teardown — the bot has just lost its messages-write

--- a/tests/test_lavalink_bridge.py
+++ b/tests/test_lavalink_bridge.py
@@ -58,6 +58,10 @@ class _FakeApp:
             raise self._create_message_error
         self.created_messages.append((channel_id, content))
 
+    async def edit_message(self, *_: Any, **__: Any) -> None:
+        """Stand-in for ``hikari.RESTService.edit_message`` used by now_playing.teardown."""
+        return None
+
     async def update_voice_state(self, guild_id: int, channel_id: int | None) -> None:
         self.voice_state_calls.append((guild_id, channel_id))
 
@@ -1391,7 +1395,7 @@ async def test_websocket_closed_4014_skips_broadcast_on_intentional_disconnect()
         )
 
         # Mark disconnect as intentional before the WebSocket close fires
-        lavalink_glue._mark_intentional_disconnect(111)
+        lavalink_glue.mark_intentional_disconnect(111)
 
         await handler.on_websocket_closed(
             cast(lavalink.WebSocketClosedEvent, _WsClosedEvent(player=player)),
@@ -1410,14 +1414,14 @@ async def test_websocket_closed_4014_skips_broadcast_on_intentional_disconnect()
 
 async def test_intentional_disconnect_marker_lifecycle() -> None:
     """The marker can be set, checked, and cleared."""
-    lavalink_glue._mark_intentional_disconnect(111)
+    lavalink_glue.mark_intentional_disconnect(111)
     assert 111 in lavalink_glue._pending_intentional_disconnects
 
-    lavalink_glue._clear_intentional_disconnect(111)
+    lavalink_glue.clear_intentional_disconnect(111)
     assert 111 not in lavalink_glue._pending_intentional_disconnects
 
     # Clearing a non-existent marker is safe (idempotent)
-    lavalink_glue._clear_intentional_disconnect(222)
+    lavalink_glue.clear_intentional_disconnect(222)
     assert 222 not in lavalink_glue._pending_intentional_disconnects
 
 
@@ -1434,7 +1438,7 @@ async def test_websocket_closed_4014_clears_intentional_disconnect_marker() -> N
     bot = _FakeApp()
     handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
 
-    lavalink_glue._mark_intentional_disconnect(111)
+    lavalink_glue.mark_intentional_disconnect(111)
     assert 111 in lavalink_glue._pending_intentional_disconnects
 
     await handler.on_websocket_closed(
@@ -1527,3 +1531,232 @@ async def test_track_exception_broadcast_uses_catalog_template() -> None:
     )
     assert bot.created_messages == [(999, expected)]
     assert bot.created_messages[0][1] == "Track **Plain Title** failed: 403 Forbidden. Skipping."
+
+
+# ---------------------------------------------------------------------------
+# Intentional-disconnect marker leak fix (#203)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _WsClosedEvent203:
+    player: _QueuePlayer
+    code: int = 4014
+    reason: str = "Disconnected"
+    by_remote: bool = True
+
+
+@dataclass
+class _Node203:
+    name: str = "ryzic-default"
+
+
+@dataclass
+class _NodeDisconnectedEvent203:
+    node: _Node203
+    code: int | None = 1006
+    reason: str | None = "lost"
+
+
+class _PlayerManager203:
+    def __init__(self, players: list[_QueuePlayer]) -> None:
+        self._players = players
+
+    def values(self) -> list[_QueuePlayer]:
+        return list(self._players)
+
+
+class _ClientWithPlayers203:
+    def __init__(self, players: list[_QueuePlayer]) -> None:
+        self.player_manager = _PlayerManager203(players)
+
+
+async def test_websocket_closed_non_4014_clears_intentional_disconnect_marker() -> None:
+    """A non-4014 voice close must clear the marker so the next 4014 is genuine.
+
+    Regression for #203 leak mode (a): the pre-fix path returned before the
+    membership check, leaving the marker set forever.
+    """
+    bot = _FakeApp()
+    lavalink_glue.last_play_channel[111] = 999
+    handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+    player = _QueuePlayer(queue=[_IdTrack(identifier="/var/cache/ryzic/audio/nn/nnkept.audio")])
+
+    lavalink_glue.mark_intentional_disconnect(111)
+    await handler.on_websocket_closed(
+        cast(lavalink.WebSocketClosedEvent, _WsClosedEvent203(player=player, code=4011)),
+    )
+
+    # Marker cleared, no broadcast, queue untouched (non-4014 doesn't tear down)
+    assert 111 not in lavalink_glue._pending_intentional_disconnects
+    assert bot.created_messages == []
+    assert player.queue == [_IdTrack(identifier="/var/cache/ryzic/audio/nn/nnkept.audio")]
+
+
+async def test_websocket_closed_non_4014_without_marker_is_noop() -> None:
+    """No marker + non-4014 close → no broadcast, no exception."""
+    bot = _FakeApp()
+    lavalink_glue.last_play_channel[111] = 999
+    handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+
+    await handler.on_websocket_closed(
+        cast(lavalink.WebSocketClosedEvent, _WsClosedEvent203(player=_QueuePlayer(), code=4011)),
+    )
+
+    assert bot.created_messages == []
+    assert lavalink_glue._pending_intentional_disconnects == {}
+
+
+async def test_node_disconnected_clears_intentional_disconnect_markers() -> None:
+    """Node drop tears down every player AND clears each marker (#203 mode b)."""
+    bot = _FakeApp()
+    lavalink_glue.last_play_channel[111] = 999
+    lavalink_glue.last_play_channel[222] = 888
+    players = [_QueuePlayer(guild_id=111, queue=[]), _QueuePlayer(guild_id=222, queue=[])]
+    client = _ClientWithPlayers203(players)
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, client))
+
+    lavalink_glue.mark_intentional_disconnect(111)
+    lavalink_glue.mark_intentional_disconnect(222)
+
+    handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+    await handler.on_node_disconnected(
+        cast(lavalink.NodeDisconnectedEvent, _NodeDisconnectedEvent203(node=_Node203())),
+    )
+
+    assert 111 not in lavalink_glue._pending_intentional_disconnects
+    assert 222 not in lavalink_glue._pending_intentional_disconnects
+    # node_reconnecting broadcast per guild, no voice_lost
+    expected = _broadcast_t("lavalink.broadcast.node_reconnecting")
+    assert bot.created_messages == [(999, expected), (888, expected)]
+
+
+async def test_node_disconnected_with_marker_does_not_suppress_node_reconnecting() -> None:
+    """The marker only suppresses voice_lost; node_reconnecting still broadcasts."""
+    bot = _FakeApp()
+    lavalink_glue.last_play_channel[111] = 999
+    client = _ClientWithPlayers203([_QueuePlayer(guild_id=111, queue=[])])
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, client))
+
+    lavalink_glue.mark_intentional_disconnect(111)
+
+    handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+    await handler.on_node_disconnected(
+        cast(lavalink.NodeDisconnectedEvent, _NodeDisconnectedEvent203(node=_Node203())),
+    )
+
+    expected = _broadcast_t("lavalink.broadcast.node_reconnecting")
+    assert bot.created_messages == [(999, expected)]
+
+
+async def test_intentional_disconnect_marker_expires_after_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An expired marker must NOT suppress voice_lost (lost-close bounded by TTL).
+
+    Regression for #203 leak mode (c): the 4014 never arrives, so only the
+    TTL + lazy GC clears the marker. After TTL the next 4014 is genuine.
+    """
+    clock = _FakeClock(0.0)
+    monkeypatch.setattr(lavalink_glue.time, "monotonic", clock.monotonic)
+
+    bot = _FakeApp()
+    lavalink_glue.last_play_channel[111] = 999
+    handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+
+    lavalink_glue.mark_intentional_disconnect(111)  # stamped at t=0
+    clock.t = lavalink_glue.INTENTIONAL_DISCONNECT_TTL_SECONDS + 1.0
+
+    await handler.on_websocket_closed(
+        cast(lavalink.WebSocketClosedEvent, _WsClosedEvent203(player=_QueuePlayer())),
+    )
+
+    # Marker expired → voice_lost IS broadcast; marker cleared
+    assert bot.created_messages == [(999, _broadcast_t("lavalink.broadcast.voice_lost"))]
+    assert 111 not in lavalink_glue._pending_intentional_disconnects
+
+
+async def test_intentional_disconnect_marker_within_ttl_still_suppresses_voice_lost() -> None:
+    """Within TTL the marker still suppresses voice_lost (#197 preserved with TTL)."""
+    bot = _FakeApp()
+    lavalink_glue.last_play_channel[111] = 999
+    handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+    player = _QueuePlayer(queue=[_IdTrack(identifier="/var/cache/ryzic/audio/tt/ttlkeep.audio")])
+
+    lavalink_glue.mark_intentional_disconnect(111)
+
+    await handler.on_websocket_closed(
+        cast(lavalink.WebSocketClosedEvent, _WsClosedEvent203(player=player)),
+    )
+
+    assert bot.created_messages == []
+    assert player.queue == []
+    assert 111 not in lavalink_glue._pending_intentional_disconnects
+
+
+async def test_non_4014_then_4014_classifies_as_unintentional() -> None:
+    """Two-event sequence: non-4014 clears marker, next 4014 is genuine.
+
+    Proves the marker stays cleared across events (the leak the fix closes).
+    """
+    bot = _FakeApp()
+    lavalink_glue.last_play_channel[111] = 999
+    handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+    player = _QueuePlayer(queue=[])
+
+    lavalink_glue.mark_intentional_disconnect(111)
+
+    # First: non-4014 close clears the marker, no broadcast.
+    await handler.on_websocket_closed(
+        cast(lavalink.WebSocketClosedEvent, _WsClosedEvent203(player=player, code=4011)),
+    )
+    assert bot.created_messages == []
+    assert 111 not in lavalink_glue._pending_intentional_disconnects
+
+    # Second: 4014 close → marker absent → genuine disconnect → voice_lost.
+    await handler.on_websocket_closed(
+        cast(lavalink.WebSocketClosedEvent, _WsClosedEvent203(player=player, code=4014)),
+    )
+    assert bot.created_messages == [(999, _broadcast_t("lavalink.broadcast.voice_lost"))]
+    assert 111 not in lavalink_glue._pending_intentional_disconnects
+
+
+async def test_teardown_player_session_runs_full_cleanup_sequence() -> None:
+    """The extracted helper runs the full cleanup sequence.
+
+    Covers: queued tracks released, queue empty, auto-leave cancelled,
+    ``_voice_ready_events`` entry gone, now-playing controller torn down.
+    """
+    from ryzic import audio_cache, now_playing
+
+    fake = RecordingCache()
+    audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
+    try:
+        bot = _FakeApp()
+        guild_id = 111
+        player = _QueuePlayer(queue=[_IdTrack(identifier="/var/cache/ryzic/audio/td/tdown1.audio")])
+        lavalink_glue._start_auto_leave(cast(hikari.GatewayBot, bot), guild_id)
+        lavalink_glue._voice_ready_events[guild_id] = asyncio.Event()
+        now_playing._controllers[guild_id] = (999, 1)
+
+        await lavalink_glue._teardown_player_session(
+            cast(hikari.GatewayBot, bot), guild_id, cast(lavalink.DefaultPlayer, player)
+        )
+
+        assert fake.released == ["tdown1"]
+        assert player.queue == []
+        assert guild_id not in lavalink_glue.auto_leave_tasks
+        assert guild_id not in lavalink_glue._voice_ready_events
+        assert guild_id not in now_playing._controllers
+    finally:
+        audio_cache.set_audio_cache(None)
+
+
+class _FakeClock:
+    """Minimal controllable clock for TTL tests."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self.t = start
+
+    def monotonic(self) -> float:
+        return self.t


### PR DESCRIPTION
## Problem

`_pending_intentional_disconnects` (a `set[int]` in `lavalink_glue.py`) leaked three ways, silently suppressing the next genuine disconnect's `voice_lost` broadcast:

1. **Non-4014 voice closes** (4006/4009/4011/4012/4015): `on_websocket_closed` did `if event.code != 4014: return` *before* the marker membership check, so the marker stayed set.
2. **Node drops**: `on_node_disconnected` tore down each player without clearing the marker.
3. **Lost closes / `update_voice_state` no-ops**: no structural event ever arrives to clear the marker.

The result: the next genuine disconnect misclassified as intentional → `voice_lost` silently skipped. The intentional/unintentional 4014 branches also duplicated the cleanup sequence verbatim (DRY violation), and `commands/leave.py` reached into `lavalink_glue._mark_intentional_disconnect` / `._clear_intentional_disconnect` (private).

## Fix

**Storage + TTL:** `_pending_intentional_disconnects` changed from `set[int]` to `dict[int, float]` (guild_id → `time.monotonic()` stamp). New `INTENTIONAL_DISCONNECT_TTL_SECONDS = 30.0` bounds the lost-close / silent-no-op leak window. The intentional 4014 arrives sub-second after `update_voice_state(None)`, so 30s is generous; a >30s-delayed 4014 may produce a spurious `voice_lost` — strictly better than today's silent skip.

**Lazy GC:** `_gc_intentional_disconnects` discards expired entries; called at the top of `on_websocket_closed` and inside the membership predicate.

**Three structural clears:**
1. Non-4014 close: a new branch at the top of `on_websocket_closed` (below the GC, above the 4014 path so #197's membership check stays intact) clears the marker then returns.
2. Node drop: `clear_intentional_disconnect(guild_id)` alongside each player's teardown in the per-guild loop.
3. Lost close: bounded by the TTL + lazy GC (no structural event).

**Public helpers (drop underscore):** `mark_intentional_disconnect`, `clear_intentional_disconnect` are now the cross-module API (docstring says so). `_intentional_disconnect_is_pending` (private) wraps GC + membership. `commands/leave.py` updated to the public names.

**DRY extraction:** the duplicated cleanup sequence (`clear_queue_releasing` → `_cancel_auto_leave` → `_reset_voice_ready` → `now_playing.teardown`) is now `async def _teardown_player_session(bot, guild_id, player)`, used by both 4014 branches and the node loop. The helper owns NO broadcast; the node path keeps its per-guild `notified` dedup outside the helper. The unintentional 4014 branch now broadcasts `voice_lost` AFTER `_teardown_player_session` returns (i.e. after `now_playing.teardown`); this reorder is safe — `_send_to_last_play_channel` and `now_playing.teardown` touch disjoint state, and a one-line comment notes the reorder is intentional.

`_reset_state_for_test` calls `_pending_intentional_disconnects.clear()` — works on the dict unchanged.

## Tests

Eight new tests in `tests/test_lavalink_bridge.py` (using existing `_FakeApp` / `_QueuePlayer` / `_ClientWithPlayers` + autouse `_reset_state`):

1. `test_websocket_closed_non_4014_clears_intentional_disconnect_marker` — marker cleared on 4011, no broadcast, queue untouched.
2. `test_websocket_closed_non_4014_without_marker_is_noop` — no marker, no broadcast, no exception.
3. `test_node_disconnected_clears_intentional_disconnect_markers` — two guilds cleared, `node_reconnecting` per guild, no `voice_lost`.
4. `test_node_disconnected_with_marker_does_not_suppress_node_reconnecting` — marker only suppresses `voice_lost`, not `node_reconnecting`.
5. `test_intentional_disconnect_marker_expires_after_ttl` — `monkeypatch`ed clock; marker at t=0, 4014 at t=TTL+1 → `voice_lost` IS broadcast (lost-close bounded).
6. `test_intentional_disconnect_marker_within_ttl_still_suppresses_voice_lost` — within TTL, no `voice_lost`, queue cleared, marker cleared (#197 preserved with TTL).
7. `test_non_4014_then_4014_classifies_as_unintentional` — two-event sequence proving the marker stays cleared across events.
8. `test_teardown_player_session_runs_full_cleanup_sequence` — unit test the extracted helper: pins released, queue empty, auto-leave cancelled, `_voice_ready_events` gone, controller torn down.

Existing marker-lifecycle tests updated to the public names; all 573 tests pass.

## Closes #203