### PR TITLE
test(commands): correct #196 narrative — replace non-functional regression test (#202)

### DIFF
--- a/tests/_command_helpers.py
+++ b/tests/_command_helpers.py
@@ -159,6 +159,10 @@ class FakePlayer:
 
     @property
     def is_playing(self) -> bool:
+        # Intentionally mirrors real ``lavalink.DefaultPlayer.is_playing``
+        # (``is_connected and current is not None`` — no ``paused`` term).
+        # Do NOT "fix" this to return False when paused; that would diverge
+        # from lavalink semantics and mask guard-policy regressions.
         return self.is_connected and self.current is not None
 
     async def set_pause(self, pause: bool) -> None:

--- a/tests/test_seek_command.py
+++ b/tests/test_seek_command.py
@@ -177,21 +177,30 @@ async def test_bare_seconds_treated_as_absolute() -> None:
     assert player.seek_calls == [45_000]
 
 
-async def test_seek_while_paused_works() -> None:
-    """Regression test for #143: /seek should work on paused tracks."""
+async def test_seek_proceeds_when_lavalink_disconnected_but_current_set() -> None:
+    """#196's actual behavioral change: commands proceed when Lavalink reports
+    disconnected but still holds a stale ``current`` track.
+
+    Pre-#196 guard was ``player is None or not player.is_playing or
+    player.current is None``; with ``is_connected=False`` and a non-None
+    ``current``, ``is_playing`` is False so the old guard fired
+    "Nothing is playing". Post-#196 guard ``player is None or
+    player.current is None`` lets the command proceed. This test
+    distinguishes the two and would fail on pre-#196 code.
+    """
     bot = both_in_voice()
     ctx = context_for(bot)
     ll = FakeLavalinkClient()
     install_lavalink_client(ll)
     player = ll.player_manager.create(guild_id=111)
-    player.is_connected = True
-    player.current = FakeAudioTrack(duration=213_000)
-    player.position = 60_000  # Currently at 1 minute
-    player.paused = True  # Paused!
+    player.is_connected = False  # Lavalink reports disconnected…
+    player.current = FakeAudioTrack(duration=213_000)  # …but holds a stale track
+    player.paused = False
+    player.position = 60_000
 
     await seek_module._handle_seek(ctx, "2:00")
 
-    # Should seek to 2 minutes, NOT return "Nothing is playing"
+    # Post-#196: seek proceeds; NOT "Nothing is playing".
     assert player.seek_calls == [120_000]
     fake = cast(Any, ctx)
     assert fake.responses[0][0] == t("seek.success.jumped", locale="en_US", position="2:00")


### PR DESCRIPTION
## Problem

PR #196 "fixed" #143 by changing the pause/resume/seek/skip guards from `if player is None or not player.is_playing or player.current is None` to `if player is None or player.current is None`. The diagnosis was **false** against installed lavalink 5.11.0:

- `lavalink.DefaultPlayer.is_playing` is `return self.is_connected and self.current is not None` — **no `paused` term**. The old guard was already False for a paused+connected+current player, so #143's stated symptom doesn't reproduce.
- #196's regression test `test_seek_while_paused_works` was **non-functional**: it passes on pre-#196 code (doesn't distinguish pre/post fix).
- #196's commit message falsely claimed `FakePlayer.is_playing` was "fixed to return False when paused" — `tests/_command_helpers.py` was never touched by #196 (`FakePlayer.is_playing` already matched real lavalink: `is_connected and current is not None`).

## What this changes

- **`tests/test_seek_command.py`**: removes the non-functional `test_seek_while_paused_works` and adds `test_seek_proceeds_when_lavalink_disconnected_but_current_set`, which exercises the *actual* behavioral change #196 introduced — letting commands proceed when `is_connected=False` but `current` is set (Lavalink-disconnected-but-stale-current). The new test **fails on pre-#196 code** (old guard fires "Nothing is playing") and **passes post-#196** — verified empirically against `3a0e62e~1`. The paused+connected+current case was already covered by sibling tests (`test_already_paused_returns_friendly_error` in `test_pause_command.py`, `test_resume_success_is_public` in `test_resume_command.py`).
- **`tests/_command_helpers.py`**: adds a Why-comment on `FakePlayer.is_playing` documenting that it intentionally mirrors real `lavalink.DefaultPlayer.is_playing` (`is_connected and current is not None`, no `paused` term), so future contributors don't "fix" it to return False-when-paused — the exact false claim that motivated #196's misdiagnosis.
- **No `src/` guard change.** The guard-policy decision is out of scope (see below).

## Open question for review

The **only** behavioral change #196 introduced is letting pause/resume/seek/skip proceed when `is_connected=False` but `current` is set (Lavalink reports disconnected but holds a stale current). Whether that proceeding-behavior is correct is a **guard-policy judgment** — not for this PR to decide. This PR documents current behavior.

If the policy should be "reject when Lavalink reports disconnected," the guards should revert to `not player.is_playing or player.current is None` and the new test should assert `np.error.nothing_playing` instead. **Flagging for maintainer decision.**

## #143

#143 was auto-closed by #196's "Fixes #143" trailer, but #196 did **not** fix it — the stated symptom doesn't reproduce on current main (likely a misdiagnosed UX-review finding). Recommend reopening #143 pending a real reproducer, or closing as not-reproducible. **This PR does not reopen #143** — that's a maintainer call.

---

`Refs #202` (not `Closes` — #202 stays open pending the guard-policy decision + #143 resolution).