### PR TITLE
test: close v0.6.0 behavior-change coverage gaps (#205)

### DIFF
--- a/src/ryzic/i18n/__init__.py
+++ b/src/ryzic/i18n/__init__.py
@@ -36,7 +36,11 @@ def _on_missing_placeholder(key: str, locale: str, _template: str, name: str) ->
 
 def _configure() -> None:
     try:
-        i18n.load_path.append(str(_LOCALES_DIR))
+        # i18nice is a process-global singleton; ``load_path`` persists
+        # across ``_configure()`` re-invocations (tests re-run it). Guard
+        # the append so repeated calls don't accumulate duplicate entries.
+        if str(_LOCALES_DIR) not in i18n.load_path:
+            i18n.load_path.append(str(_LOCALES_DIR))
         i18n.set("filename_format", "{locale}.{format}")
         i18n.set("file_format", "json")
         i18n.set("fallback", _DEFAULT_LOCALE)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -199,21 +199,50 @@ def test_install_cookies_creates_cache_dir_if_missing(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_update_controllers_loop_refreshes_active_controllers() -> None:
-    """The loop calls refresh_all once per cycle and exits on cancellation."""
+    """The loop calls refresh_all once per cycle and exits on cancellation.
+
+    The loop's first action is ``await asyncio.sleep(15)``, so the sleep
+    must be short-circuited to keep the test fast. We replace
+    ``asyncio.sleep`` with a no-wait stand-in that yields once (so a
+    pending task cancellation is delivered at that await rather than
+    spinning the loop synchronously). Cancellation is driven by the
+    ``refresh_all`` stub itself via ``asyncio.current_task().cancel()``
+    after the first call, rather than a ``side_effect`` list of exact
+    length — this decouples the test from the loop's internal sleep call
+    count (a future jitter or second sleep would not break it).
+
+    The loop calls ``asyncio.sleep`` via the ``asyncio`` module namespace
+    (``import asyncio`` + ``asyncio.sleep``), so patching
+    ``ryzic.bot.asyncio.sleep`` would be identical to patching
+    ``asyncio.sleep`` — there's no narrower module-local reference to
+    target without a src/ change, which is out of scope for #205. The
+    ``with``-scoped ``patch`` keeps the override local to this test;
+    pytest-asyncio runs tests sequentially so no sibling coroutine sees
+    the fake.
+    """
     bot_mock = MagicMock(spec=hikari.GatewayBot)
-
-    # refresh_all is patched out, so each cycle is exactly one sleep + one
-    # refresh_all. The second sleep raises CancelledError to break the loop
-    # after one completed iteration.
     call_count = 0
+    real_sleep = asyncio.sleep
 
-    async def counting_refresh_all(bot):
+    async def _no_wait_sleep(_delay: float, *_a: object, **_kw: object) -> None:
+        # Yield once so a pending cancellation lands here instead of the
+        # loop spinning synchronously through the (un-suspending) fake.
+        await real_sleep(0)
+
+    async def counting_refresh_all(_bot: object) -> None:
         nonlocal call_count
         call_count += 1
+        # Cancel the running loop task after the first refresh so the next
+        # await raises CancelledError and the loop breaks. Done here rather
+        # than via a side_effect list so the test doesn't depend on the
+        # exact number of sleep calls per cycle.
+        task = asyncio.current_task()
+        assert task is not None  # we are running inside the loop task
+        task.cancel()
 
     with (
         patch("ryzic.now_playing.refresh_all", side_effect=counting_refresh_all),
-        patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError()]),
+        patch("asyncio.sleep", new=_no_wait_sleep),
     ):
         await bot._update_controllers_loop(bot_mock)
 

--- a/tests/test_i18n_helper.py
+++ b/tests/test_i18n_helper.py
@@ -6,8 +6,8 @@ Covers the four hook surfaces the helper is responsible for:
 - Missing-key fires ``_on_missing_translation`` (logs at ERROR, returns key).
 - Missing-var fires ``_on_missing_placeholder`` (logs at ERROR, returns
   literal ``%{name}``).
-- Malformed-catalog fallback: simulate by re-running ``_configure()`` with
-  a monkeypatched raise; ``t()`` still returns something usable (the key).
+- Configuration-failure guard: ``_configure()`` swallows a raising
+  ``i18n.set`` so the bot still boots; ``t()`` returns the raw key.
 """
 
 from __future__ import annotations
@@ -27,6 +27,22 @@ def test_smoke_returns_sentinel_value() -> None:
 
 def test_smoke_honors_explicit_locale_kwarg() -> None:
     assert ryzic_i18n.t("i18n.smoke", locale="en_US") == "ok"
+
+
+def test_positive_placeholder_interpolation_renders_value() -> None:
+    """A real catalog key with ``%{var}`` interpolates the supplied value.
+
+    ``i18n.smoke`` has no placeholder, so the success path of ``%{name}``
+    substitution is otherwise only exercised transitively (via
+    ``broadcast_t`` callers). Asserting directly at the helper level catches
+    a regression that breaks interpolation while leaving the sentinel smoke
+    key passing. Uses ``ytdlp.error.generic_with_detail`` (a real en_US key
+    with a single ``%{detail}`` placeholder) so no test-only catalog
+    mutation is needed.
+    """
+    assert ryzic_i18n.t("ytdlp.error.generic_with_detail", detail="boom") == (
+        "Could not load that URL. yt-dlp said: `boom`"
+    )
 
 
 def test_missing_key_returns_key_and_logs(caplog: pytest.LogCaptureFixture) -> None:
@@ -60,18 +76,26 @@ def test_missing_placeholder_leaves_literal_and_logs(
         i18n.add_translation("i18n._test.greet", "", locale="en_US")
 
 
-def test_malformed_catalog_falls_back_to_returning_keys(
+def test_configure_does_not_crash_when_i18n_set_raises(
     caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """If ``_configure()`` raises, ``t()`` must still return something.
+    """If ``i18n.set`` raises mid-``_configure()``, the bot still boots.
 
-    We simulate the failure by monkeypatching ``i18n.set`` to raise, then
-    re-running ``_configure()`` and asserting the exception was swallowed
-    and logged. The sentinel key remains resolvable because the process-
-    level i18nice state from import time is still loaded — what this test
-    really proves is the try/except guard around ``_configure()`` itself
-    doesn't crash the bot.
+    Simulates a catalog/configuration failure by monkeypatching ``i18n.set``
+    to raise, then re-running ``_configure()``. The try/except guard must
+    swallow the exception and log it. ``t()`` still returns the raw key for
+    any input via the process-level i18nice state from import time.
+
+    Renamed from ``test_malformed_catalog_falls_back_to_returning_keys``:
+    the previous name claimed a "malformed catalog" exercise, but the test
+    never pointed ``load_path`` at a bad file — it only proved the
+    ``_configure()`` try/except guard doesn't crash. Renaming (rather than
+    rewriting to load a real malformed JSON file) is the honest, minimal
+    fix; a true malformed-catalog test would require re-pointing the
+    process-global ``i18n.load_path`` and re-running ``_configure()``,
+    which risks polluting other tests under pytest-randomly for marginal
+    extra coverage (the try/except is the actual safety net).
     """
     import i18n
 

--- a/tests/test_now_playing.py
+++ b/tests/test_now_playing.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import hikari
 import lavalink
@@ -222,6 +222,113 @@ async def test_refresh_recovers_from_deleted_message_by_reposting() -> None:
 
     assert len(rest.create_calls) == 1
     assert now_playing.is_known_message(111, 9301)
+
+
+# ---------------------------------------------------------------------------
+# refresh_all — per-guild skip filter + exception isolation (#200)
+# ---------------------------------------------------------------------------
+
+
+async def test_refresh_all_skips_paused_and_idle_players() -> None:
+    """``refresh_all`` only edits controllers whose progress is moving.
+
+    A PLAYING player triggers an edit; a PAUSED player and an IDLE player
+    (``current is None``) are skipped so the loop doesn't issue
+    byte-identical edits every cycle (edit spam / REST quota burns). A
+    regression dropping the paused-skip guard must fail here.
+    """
+    rest = _FakeRest(create_returns=10_000)
+    bot = _bot_with_rest(rest)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+
+    # Three guilds, each with an existing controller (so refresh() has a
+    # record to edit). Seed distinct player states.
+    for guild_id, paused, has_current in [
+        (111, False, True),  # PLAYING -> should be edited
+        (222, True, True),  # PAUSED -> skipped
+        (333, False, False),  # IDLE (current is None) -> skipped
+    ]:
+        player = ll.player_manager.create(guild_id=guild_id)
+        player.is_connected = True
+        player.paused = paused
+        player.current = make_track_with_info() if has_current else None
+        lavalink_glue.last_play_channel[guild_id] = guild_id * 10
+        await now_playing.upsert_for_track_start(bot, guild_id)
+    rest.edit_calls.clear()
+
+    await now_playing.refresh_all(bot)
+
+    edited_guilds = {call["channel_id"] for call in rest.edit_calls}
+    assert edited_guilds == {111 * 10}
+
+
+async def test_refresh_all_skips_guilds_with_no_player() -> None:
+    """A guild whose player disappeared (None) is skipped, not edited."""
+    rest = _FakeRest(create_returns=11_000)
+    bot = _bot_with_rest(rest)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+
+    # Guild 111: PLAYING -> edited. Guild 222: controller record exists
+    # but lavalink_glue.get_player returns None -> skipped.
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = True
+    player.current = make_track_with_info()
+    lavalink_glue.last_play_channel[111] = 1110
+    await now_playing.upsert_for_track_start(bot, 111)
+
+    # Plant a controller record for 222 without creating a player.
+    now_playing._controllers[222] = (2220, 9999)
+    rest.edit_calls.clear()
+
+    await now_playing.refresh_all(bot)
+
+    edited_channels = {call["channel_id"] for call in rest.edit_calls}
+    assert edited_channels == {1110}
+
+
+async def test_refresh_all_isolates_per_guild_exceptions() -> None:
+    """One guild's raising refresh does NOT abort the loop for other guilds.
+
+    The loop catches per-guild exceptions so a single REST failure (or an
+    unexpected bug for one guild) doesn't starve the rest of the
+    controllers' progress-bar advances.
+    """
+    # Two PLAYING guilds. Guild 111's edit raises a HikariError (logged +
+    # swallowed inside _post_or_edit); guild 222's edit must still run.
+    # Use NotFoundError on 111 to force the create fallback path, then
+    # make the create also fail so the refresh for 111 raises within
+    # _post_or_edit's HikariError handling — actually _post_or_edit logs
+    # and returns on HikariError, so the per-guild try/except in
+    # refresh_all is exercised by patching refresh to raise for 111 only.
+    rest = _FakeRest(create_returns=12_000)
+    bot = _bot_with_rest(rest)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+
+    for guild_id in (111, 222):
+        player = ll.player_manager.create(guild_id=guild_id)
+        player.is_connected = True
+        player.current = make_track_with_info()
+        lavalink_glue.last_play_channel[guild_id] = guild_id * 10
+        await now_playing.upsert_for_track_start(bot, guild_id)
+    rest.edit_calls.clear()
+
+    real_refresh = now_playing.refresh
+
+    async def flaky_refresh(b, gid):
+        if gid == 111:
+            raise RuntimeError("simulated per-guild failure")
+        await real_refresh(b, gid)
+
+    with patch.object(now_playing, "refresh", side_effect=flaky_refresh):
+        await now_playing.refresh_all(bot)
+
+    # Guild 222 still got its edit despite guild 111 raising.
+    edited_channels = {call["channel_id"] for call in rest.edit_calls}
+    assert 222 * 10 in edited_channels
+    assert 111 * 10 not in edited_channels
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_queue_command.py
+++ b/tests/test_queue_command.py
@@ -144,6 +144,22 @@ async def test_default_response_is_ephemeral() -> None:
     assert fake.responses[0][1].get("ephemeral") is True
 
 
+def test_queue_option_private_defaults_to_true() -> None:
+    """The lightbulb ``private`` option itself defaults to ``True`` (#159).
+
+    ``_handle_queue``'s ``private: bool = True`` signature default is a
+    separate layer from the slash-command option's ``default=True`` — at
+    runtime lightbulb passes the OPTION default into ``invoke``, not the
+    function signature default. A regression flipping the option's
+    ``default=`` back to ``False`` would pass ``test_default_response_is_
+    ephemeral`` (which calls ``_handle_queue`` directly) while reverting
+    production. Mirror the replay loader test's ``_command_data.options``
+    pattern to assert the option-level default directly.
+    """
+    private_option = queue_module.Queue._command_data.options["private"]
+    assert private_option.default is True
+
+
 async def test_private_false_makes_response_public() -> None:
     """``private=False`` opts back to a public response (issue #100)."""
     bot = FakeBot()


### PR DESCRIPTION
## Gaps covered

Closes the remaining v0.6.0 behavior-change test-coverage gaps from #205 (the disconnect-marker error-path gaps were folded into #209's marker tests and are intentionally not duplicated here).

1. **#200 `refresh_all` per-guild skip-filter + isolation — NOT unit-tested.** `test_update_controllers_loop_refreshes_active_controllers` only asserted the loop calls `refresh_all` once via a counting stub; the filter (`skip when player is None / paused / current is None`), stagger, and per-guild exception isolation were unexercised. Added three direct tests against `refresh_all` in `tests/test_now_playing.py`:
   - `test_refresh_all_skips_paused_and_idle_players` — seeds PLAYING / PAUSED / IDLE players across three guilds and asserts only the PLAYING guild's controller is edited.
   - `test_refresh_all_skips_guilds_with_no_player` — a controller record with no backing player is skipped.
   - `test_refresh_all_isolates_per_guild_exceptions` — one guild's raising `refresh()` does not abort the loop for the other guild.

2. **#159 `/queue` option-default — test asserted the wrong layer.** `test_default_response_is_ephemeral` only exercised the `_handle_queue` function-signature default (`private: bool = True`); the lightbulb option's `default=True` (the value actually passed at runtime) was unchecked. Added `test_queue_option_private_defaults_to_true` asserting `Queue._command_data.options["private"].default is True` (mirrors the replay loader's `_command_data.options` pattern). The existing function-level test is retained — both layers matter.

3. **#153 i18nice positive `%{var}` interpolation — not directly tested at helper level.** `i18n.smoke` has no placeholder, so the success path of `%{var}` substitution was only exercised transitively. Added `test_positive_placeholder_interpolation_renders_value` in `tests/test_i18n_helper.py` asserting `t("ytdlp.error.generic_with_detail", detail="boom")` renders the interpolated value (uses a real `en_US.json` key with `%{detail}` — no test-only catalog mutation).

4. **#153 `_configure()` non-idempotent + misnamed test.**
   - (a) `src/ryzic/i18n/__init__.py`: guarded the `load_path.append` with a membership check so repeated `_configure()` calls don't accumulate duplicate `_LOCALES_DIR` entries. Behavior-preserving one-line src/ change — the only src/ change in this PR.
   - (b) `tests/test_i18n_helper.py`: renamed `test_malformed_catalog_falls_back_to_returning_keys` → `test_configure_does_not_crash_when_i18n_set_raises` with an honest docstring explaining the rename (the old name claimed a malformed-catalog exercise the test never performed; a true malformed-catalog test would require re-pointing the process-global `load_path` and risks cross-test pollution for marginal extra coverage — the try/except is the actual safety net).

5. **#200 `asyncio.sleep` global-patch brittleness.** Replaced the `side_effect=[None, asyncio.CancelledError()]` list (which coupled the test to the loop's exact internal sleep call count and patched a stdlib primitive process-wide) with a no-wait sleep stand-in plus task-self-cancellation from inside the `refresh_all` stub. The test no longer depends on the number of sleep calls per cycle (a future jitter or second sleep won't break it). The loop calls `asyncio.sleep` via the `asyncio` module namespace, so patching `ryzic.bot.asyncio.sleep` would be identical to patching `asyncio.sleep` — without a src/ change (out of scope) there is no narrower module-local reference to target; the `with`-scoped patch keeps the override local to this test. Rationale documented in the test docstring.

## src/ change

One-line idempotency guard in `src/ryzic/i18n/__init__.py::_configure()`:

```python
if str(_LOCALES_DIR) not in i18n.load_path:
    i18n.load_path.append(str(_LOCALES_DIR))
```

i18nice is a process-global singleton; `load_path` persisted across `_configure()` re-invocations (tests re-run it), accumulating duplicate entries. Behavior-preserving — the first call appends exactly as before; subsequent calls are no-ops. No other src/ changes.

## Closes #205