### PR TITLE
fix(commands): align /nowplaying ephemeral default with /queue (#207)

### DIFF
--- a/src/ryzic/commands/np.py
+++ b/src/ryzic/commands/np.py
@@ -1,10 +1,14 @@
 """``/nowplaying`` slash command: show the currently-playing track.
 
-Mirrors ``/queue``'s ``private`` flag (issue #100): ``private=True`` routes
-the success embed to an ephemeral response so the invoker can check the
-current track without spamming a busy channel. Empty/error paths stay
-ephemeral regardless — failure messages don't pollute the channel
-either way.
+``/nowplaying`` (and its ``/np`` alias) are ephemeral-by-default: the
+``private`` option defaults to ``True``, routing the success embed to an
+ephemeral response so the invoker can check the current track without
+spamming a busy channel. Empty/error paths stay ephemeral regardless —
+failure messages don't pollute the channel either way.
+
+Issue #148/#159 aligned ``/queue`` this way (status-introspection
+commands answer the invoker, not the channel); issue #207 extended the
+alignment to ``/nowplaying``. The original mirror-intent was #100.
 
 Issue #150: primary command is ``/nowplaying``; ``/np`` is preserved as a
 shorthand. Lightbulb v3 has no first-class alias parameter on
@@ -33,7 +37,7 @@ class NowPlaying(
     private = lightbulb.boolean(
         "private",
         t("common.param.private.description", locale="en_US"),
-        default=False,
+        default=True,
     )
 
     @lightbulb.invoke
@@ -51,7 +55,7 @@ class Np(
     private = lightbulb.boolean(
         "private",
         t("common.param.private.description", locale="en_US"),
-        default=False,
+        default=True,
     )
 
     @lightbulb.invoke
@@ -59,7 +63,7 @@ class Np(
         await _handle_np(ctx, private=self.private)
 
 
-async def _handle_np(ctx: lightbulb.Context, *, private: bool = False) -> None:
+async def _handle_np(ctx: lightbulb.Context, *, private: bool = True) -> None:
     guild_id = ctx.guild_id
     if guild_id is None:
         await ctx.respond(

--- a/tests/test_np_command.py
+++ b/tests/test_np_command.py
@@ -144,8 +144,11 @@ async def test_paused_state_renders_in_embed() -> None:
     assert "(paused)" in body
 
 
-async def test_default_response_is_public() -> None:
-    """``/np`` without ``private:True`` posts the embed to the channel."""
+async def test_default_response_is_ephemeral() -> None:
+    """``/np`` defaults to ``private=True`` (issue #207, aligned with ``/queue`` #148).
+
+    Status-introspection commands answer the invoker, not the channel.
+    """
     bot = FakeBot()
     ctx = context_for(bot)
     ll = FakeLavalinkClient()
@@ -156,11 +159,28 @@ async def test_default_response_is_public() -> None:
     await np_module._handle_np(ctx)
 
     fake = cast(Any, ctx)
+    assert fake.responses[0][1].get("ephemeral") is True
+
+
+async def test_private_false_makes_response_public() -> None:
+    """``private=False`` opts back to a public response (issue #100)."""
+    bot = FakeBot()
+    ctx = context_for(bot)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.current = cast(Any, make_track_with_info(title="Hello"))
+
+    await np_module._handle_np(ctx, private=False)
+
+    fake = cast(Any, ctx)
     assert fake.responses[0][1].get("ephemeral") is False
+    embed = fake.responses[0][1]["embed"]
+    assert isinstance(embed, hikari.Embed)
 
 
 async def test_private_true_makes_response_ephemeral() -> None:
-    """``private=True`` routes the embed to an ephemeral response (issue #100)."""
+    """``private=True`` (also the default since #207) routes to ephemeral."""
     bot = FakeBot()
     ctx = context_for(bot)
     ll = FakeLavalinkClient()
@@ -189,3 +209,16 @@ def test_loader_registered_np_alias() -> None:
     """``/np`` remains as a shorthand alias to ``/nowplaying`` (issue #150)."""
     assert np_module.Np._command_data.name == "np"
     assert np_module.Np._command_data.description == t("np.command.description", locale="en_US")
+
+
+def test_nowplaying_option_private_defaults_to_true() -> None:
+    """``/nowplaying``'s ``private`` option defaults to ``True`` (issue #207).
+
+    Mirrors the option-default assertion #212 established for ``/queue``.
+    """
+    assert np_module.NowPlaying._command_data.options["private"].default is True
+
+
+def test_np_alias_option_private_defaults_to_true() -> None:
+    """``/np`` alias's ``private`` option defaults to ``True`` (issue #207)."""
+    assert np_module.Np._command_data.options["private"].default is True


### PR DESCRIPTION
## Behavior change (user-facing)

`/nowplaying` and `/np` are now ephemeral-by-default (`private=True`), previously public-by-default (`private=False`). Aligned with `/queue` (#148/#159). Rationale: status-introspection commands should answer the invoker, not the channel. ryzic is pre-1.0 per SEMVER.md; default flips may break — documented here.

## Fix

- Flipped both `@loader.command` classes' (`NowPlaying` primary + `Np` alias) `private` option default `False` → `True`.
- Flipped the `_handle_np` function-level default `False` → `True` so the function default matches the option default (consistency #212 established for `/queue`).
- Corrected `np.py`'s module docstring: the "Mirrors /queue's private flag (issue #100)" claim was stale (it no longer mirrored). Now accurately states `/nowplaying` and `/np` are ephemeral-by-default, references #148/#159 alignment rationale and #207, with #100 noted as the original mirror-intent.
- Added `test_nowplaying_option_private_defaults_to_true` and `test_np_alias_option_private_defaults_to_true` asserting each class's `_command_data.options["private"].default is True`, mirroring the option-default test pattern #212 established for `/queue`.
- Updated existing `test_default_response_is_public` → `test_default_response_is_ephemeral` (asserts the new ephemeral default); added `test_private_false_makes_response_public` preserving the original public-default intent via an explicit `private=False` opt-in; refreshed the `test_private_true_makes_response_ephemeral` docstring.

## Out of scope

Smoke-tests/README doc updates tracked in #206 (will stack on this PR).

Closes #207.