### PR TITLE
fix(commands): reconnecting copy when Lavalink player disconnected (#215)

### DIFF
--- a/src/ryzic/commands/pause.py
+++ b/src/ryzic/commands/pause.py
@@ -9,7 +9,7 @@ import lightbulb
 
 from .. import lavalink_glue, now_playing
 from ..i18n import locale_for_ephemeral, locale_for_public, t
-from ..voice_check import ensure_same_voice
+from ..voice_check import check_player_or_respond, ensure_same_voice
 
 loader = lightbulb.Loader()
 
@@ -33,11 +33,8 @@ async def _handle_pause(ctx: lightbulb.Context) -> None:
     guild_id = cast(int, ctx.guild_id)
 
     player = lavalink_glue.get_player(guild_id)
-    if player is None or player.current is None:
-        await ctx.respond(
-            t("np.error.nothing_playing", locale=locale_for_ephemeral(ctx)),
-            ephemeral=True,
-        )
+    player = await check_player_or_respond(ctx, player)
+    if player is None:
         return
 
     if player.paused:

--- a/src/ryzic/commands/resume.py
+++ b/src/ryzic/commands/resume.py
@@ -9,7 +9,7 @@ import lightbulb
 
 from .. import lavalink_glue, now_playing
 from ..i18n import locale_for_ephemeral, locale_for_public, t
-from ..voice_check import ensure_same_voice
+from ..voice_check import check_player_or_respond, ensure_same_voice
 
 loader = lightbulb.Loader()
 
@@ -33,11 +33,8 @@ async def _handle_resume(ctx: lightbulb.Context) -> None:
     guild_id = cast(int, ctx.guild_id)
 
     player = lavalink_glue.get_player(guild_id)
-    if player is None or player.current is None:
-        await ctx.respond(
-            t("np.error.nothing_playing", locale=locale_for_ephemeral(ctx)),
-            ephemeral=True,
-        )
+    player = await check_player_or_respond(ctx, player)
+    if player is None:
         return
 
     if not player.paused:

--- a/src/ryzic/commands/seek.py
+++ b/src/ryzic/commands/seek.py
@@ -10,7 +10,7 @@ import lightbulb
 from .. import lavalink_glue
 from ..i18n import locale_for_ephemeral, locale_for_public, t
 from ..ux import format_duration, parse_seek_position
-from ..voice_check import ensure_same_voice
+from ..voice_check import check_player_or_respond, ensure_same_voice
 
 loader = lightbulb.Loader()
 
@@ -41,12 +41,12 @@ async def _handle_seek(ctx: lightbulb.Context, raw_position: str) -> None:
     guild_id = cast(int, ctx.guild_id)
 
     player = lavalink_glue.get_player(guild_id)
-    if player is None or player.current is None:
-        await ctx.respond(
-            t("np.error.nothing_playing", locale=locale_for_ephemeral(ctx)),
-            ephemeral=True,
-        )
+    player = await check_player_or_respond(ctx, player)
+    if player is None:
         return
+    # check_player_or_respond returns non-None only when current is set;
+    # restate the invariant for ty since the narrowing lives in the helper.
+    assert player.current is not None
 
     duration_ms = int(player.current.duration or 0)
     if duration_ms <= 0:

--- a/src/ryzic/commands/skip.py
+++ b/src/ryzic/commands/skip.py
@@ -20,8 +20,8 @@ import hikari
 import lightbulb
 
 from .. import lavalink_glue, ux
-from ..i18n import locale_for_ephemeral, locale_for_public, t
-from ..voice_check import ensure_same_voice
+from ..i18n import locale_for_public, t
+from ..voice_check import check_player_or_respond, ensure_same_voice
 
 loader = lightbulb.Loader()
 
@@ -48,12 +48,14 @@ async def _handle_skip(ctx: lightbulb.Context) -> None:
     guild_id = cast(int, ctx.guild_id)
 
     player = lavalink_glue.get_player(guild_id)
-    if player is None or player.current is None:
-        await ctx.respond(
-            t("np.error.nothing_playing", locale=locale_for_ephemeral(ctx)),
-            ephemeral=True,
-        )
+    player = await check_player_or_respond(ctx, player)
+    if player is None:
         return
+    # check_player_or_respond returns non-None only when current is set;
+    # restate the invariant for ty since the narrowing lives in the helper.
+    # (The later ``player.current is None`` after ``skip()`` is a real check
+    # — skip may have cleared it — and stays as-is.)
+    assert player.current is not None
 
     skipped_info = ux.get_track_info(player.current)
     skipped_title = skipped_info.title if skipped_info is not None else player.current.title

--- a/src/ryzic/i18n/locales/en_US.json
+++ b/src/ryzic/i18n/locales/en_US.json
@@ -55,6 +55,7 @@
     "voice.error.bot_starting": "Bot is still starting up. Try again in a moment.",
     "voice.error.bot_not_in_voice": "I'm not in a voice channel.",
     "voice.error.join_my_channel": "Join <#%{channel_id}> to use this.",
+    "voice.error.reconnecting": "Reconnecting to voice — try again in a moment.",
 
     "np.error.nothing_playing": "Nothing is playing.",
 

--- a/src/ryzic/voice_check.py
+++ b/src/ryzic/voice_check.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from typing import cast
 
 import hikari
+import lavalink
 import lightbulb
 
 from .i18n import locale_for_ephemeral, t
@@ -76,3 +77,30 @@ async def ensure_same_voice(ctx: lightbulb.Context) -> int | None:
         return None
 
     return int(bot_state.channel_id)
+
+
+async def check_player_or_respond(
+    ctx: lightbulb.Context,
+    player: lavalink.DefaultPlayer | None,
+) -> lavalink.DefaultPlayer | None:
+    """Three-way guard for ``/pause``, ``/resume``, ``/seek``, ``/skip``.
+
+    Returns the player (caller proceeds) only when it is connected AND
+    holds a current track. Responds ephemerally and returns ``None``
+    (caller aborts) when there is no current track ("Nothing is
+    playing.") or when a track is held but the player reports
+    disconnected ("Reconnecting to voice …") — the transient resync
+    window (region migration, voice-WS blip) where commanding the player
+    would PATCH a server that considers it gone. Mirrors
+    :func:`ensure_same_voice`'s respond-and-return convention. Replaces
+    the duplicated ``if player is None or player.current is None`` block
+    across the four command files.
+    """
+    locale = locale_for_ephemeral(ctx)
+    if player is None or player.current is None:
+        await ctx.respond(t("np.error.nothing_playing", locale=locale), ephemeral=True)
+        return None
+    if not player.is_connected:
+        await ctx.respond(t("voice.error.reconnecting", locale=locale), ephemeral=True)
+        return None
+    return player

--- a/tests/test_lavalink_disconnected_player.py
+++ b/tests/test_lavalink_disconnected_player.py
@@ -1,0 +1,135 @@
+"""Characterization tests pinning lavalink 5.11.0's disconnected-player behaviour.
+
+These tests exercise the REAL :class:`lavalink.DefaultPlayer` against a stub
+node whose ``update_player`` is an :class:`~unittest.mock.AsyncMock`. They pin
+the external-library behaviour that issue #215's reject-up-front stance relies
+on: ``set_pause`` / ``seek`` / ``stop`` / ``skip`` do NOT consult
+``is_connected`` — they always send an HTTP PATCH via ``node.update_player``
+regardless of whether Lavalink considers the player connected.
+
+A future lavalink bump that adds an ``is_connected`` short-circuit (or stops
+PATCHing on a disconnected player) should fail here, which is the signal to
+re-evaluate ryzic's #215 guard policy (reject-with-reconnecting vs. proceed).
+
+Version-fragile by design — see ``docs/plans`` / #215 for the rationale.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import lavalink
+from lavalink.server import AudioTrack
+
+
+def _make_player() -> tuple[lavalink.DefaultPlayer, Any]:
+    """Build a real ``DefaultPlayer`` with a stub node + client.
+
+    Returns ``(player, update_player_mock)`` so tests can assert on the
+    mock without ty balking at the real ``Node.update_player`` overload
+    signature (which has no ``assert_awaited_once``).
+
+    ``is_connected`` is a read-only property (``self.channel_id is not None``)
+    on lavalink 5.11.0, so we leave ``channel_id`` at its constructor default
+    of ``None`` to obtain ``is_connected=False`` — do NOT try to set the
+    property directly.
+    """
+    update_player = AsyncMock(return_value={})
+    node = MagicMock()
+    node.update_player = update_player
+    node.manager = MagicMock()
+    node.manager.client = MagicMock()
+    node.manager.client._dispatch_event = MagicMock()
+
+    player = lavalink.DefaultPlayer(guild_id=111, node=node)
+    # ``channel_id`` stays ``None`` ⇒ ``is_connected`` is False.
+    return player, update_player
+
+
+def _make_track() -> AudioTrack:
+    """Build a real :class:`AudioTrack` with a base64 ``encoded`` string.
+
+    ``play_track`` reads ``track.track`` (the base64 payload, derived from
+    ``data['encoded']``); without it the play path raises. We only need it
+    for the ``skip`` → ``play`` path when the queue is non-empty; the
+    empty-queue path goes via ``stop`` and does not consult ``track``.
+    """
+    raw: Any = {
+        "encoded": "QAAAAAAAAA",
+        "info": {
+            "title": "x",
+            "author": "y",
+            "length": 213_000,
+            "identifier": "id",
+            "uri": "https://example/x",
+            "isStream": False,
+            "isSeekable": True,
+        },
+    }
+    return AudioTrack(raw, requester=0)
+
+
+async def test_set_pause_sends_patch_regardless_of_is_connected() -> None:
+    player, update_player = _make_player()
+    player.current = _make_track()
+    assert player.is_connected is False  # sanity: channel_id is None
+
+    await player.set_pause(True)
+
+    update_player.assert_awaited_once()
+    _, kwargs = update_player.call_args
+    assert kwargs["guild_id"] == "111"
+    assert kwargs["paused"] is True
+
+
+async def test_seek_sends_patch_regardless_of_is_connected() -> None:
+    player, update_player = _make_player()
+    player.current = _make_track()
+
+    await player.seek(120_000)
+
+    update_player.assert_awaited_once()
+    _, kwargs = update_player.call_args
+    assert kwargs["position"] == 120_000
+
+
+async def test_stop_sends_patch_regardless_of_is_connected() -> None:
+    player, update_player = _make_player()
+    player.current = _make_track()
+
+    await player.stop()
+
+    update_player.assert_awaited_once()
+    _, kwargs = update_player.call_args
+    assert kwargs["encoded_track"] is None
+    assert player.current is None
+
+
+async def test_skip_delegates_to_play_and_patches() -> None:
+    """``skip`` delegates to ``play``; with an empty queue ``play`` calls ``stop``,
+    which PATCHes ``encoded_track=None``. Either way ``update_player`` fires
+    even though ``is_connected`` is False — the client does not short-circuit.
+    """
+    player, update_player = _make_player()
+    player.current = _make_track()
+    assert player.queue == []
+
+    await player.skip()
+
+    update_player.assert_awaited()
+    _, kwargs = update_player.call_args
+    assert kwargs["encoded_track"] is None
+
+
+async def test_is_connected_is_read_only_property_derived_from_channel_id() -> None:
+    """Pin the property definition: setting ``channel_id`` flips ``is_connected``.
+
+    If a future lavalink version makes ``is_connected`` a settable attribute or
+    derives it differently, this test fails and the #215 helper's
+    ``not player.is_connected`` branch needs re-evaluation.
+    """
+    player, _ = _make_player()
+    assert player.is_connected is False
+    player.channel_id = 999
+    assert player.is_connected is True

--- a/tests/test_pause_command.py
+++ b/tests/test_pause_command.py
@@ -114,6 +114,28 @@ async def test_pause_success_is_public() -> None:
     assert "ephemeral" not in fake.responses[0][1]
 
 
+async def test_pause_disconnected_but_current_responds_reconnecting() -> None:
+    """#215: reject with reconnecting copy when Lavalink reports disconnected
+    but still holds a stale ``current`` — do NOT proceed to ``set_pause``.
+    """
+    bot = both_in_voice()
+    ctx = context_for(bot)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = False
+    player.current = FakeAudioTrack()
+    player.paused = False
+
+    await pause_module._handle_pause(ctx)
+
+    assert player.set_pause_calls == []
+    fake = cast(Any, ctx)
+    assert fake.responses[0][0] == t("voice.error.reconnecting", locale="en_US")
+    assert fake.responses[0][0] == "Reconnecting to voice — try again in a moment."
+    assert fake.responses[0][1].get("ephemeral") is True
+
+
 def test_pause_loader_registered() -> None:
     assert pause_module.Pause._command_data.name == "pause"
     assert pause_module.Pause._command_data.description == t(

--- a/tests/test_resume_command.py
+++ b/tests/test_resume_command.py
@@ -115,6 +115,28 @@ async def test_resume_success_is_public() -> None:
     assert "ephemeral" not in fake.responses[0][1]
 
 
+async def test_resume_disconnected_but_current_responds_reconnecting() -> None:
+    """#215: reject with reconnecting copy when Lavalink reports disconnected
+    but still holds a stale ``current`` — do NOT proceed to ``set_pause``.
+    """
+    bot = both_in_voice()
+    ctx = context_for(bot)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = False
+    player.current = FakeAudioTrack()
+    player.paused = True
+
+    await resume_module._handle_resume(ctx)
+
+    assert player.set_pause_calls == []
+    fake = cast(Any, ctx)
+    assert fake.responses[0][0] == t("voice.error.reconnecting", locale="en_US")
+    assert fake.responses[0][0] == "Reconnecting to voice — try again in a moment."
+    assert fake.responses[0][1].get("ephemeral") is True
+
+
 def test_resume_loader_registered() -> None:
     assert resume_module.Resume._command_data.name == "resume"
     assert resume_module.Resume._command_data.description == t(

--- a/tests/test_seek_command.py
+++ b/tests/test_seek_command.py
@@ -177,16 +177,24 @@ async def test_bare_seconds_treated_as_absolute() -> None:
     assert player.seek_calls == [45_000]
 
 
-async def test_seek_proceeds_when_lavalink_disconnected_but_current_set() -> None:
-    """#196's actual behavioral change: commands proceed when Lavalink reports
+async def test_seek_disconnected_but_current_responds_reconnecting() -> None:
+    """#215 behavior change: reject with reconnecting copy when Lavalink reports
     disconnected but still holds a stale ``current`` track.
 
-    Pre-#196 guard was ``player is None or not player.is_playing or
-    player.current is None``; with ``is_connected=False`` and a non-None
-    ``current``, ``is_playing`` is False so the old guard fired
-    "Nothing is playing". Post-#196 guard ``player is None or
-    player.current is None`` lets the command proceed. This test
-    distinguishes the two and would fail on pre-#196 code.
+    History: #196 widened the guard from ``player is None or not
+    player.is_playing or player.current is None`` to ``player is None or
+    player.current is None`` so the disconnected-but-current case
+    PROCEEDED (with a success response) rather than saying "Nothing is
+    playing." #210 then pinned that proceed-behavior with this test.
+
+    #215 reverses it: lavalink 5.11.0's ``set_pause``/``seek``/``stop``/
+    ``skip`` do NOT consult ``is_connected`` (they always PATCH via
+    ``node.update_player`` — see ``tests/test_lavalink_disconnected_player.py``),
+    so proceeding's success is server-determined and unverified, and the
+    command paths have no try/except. Reject-up-front with accurate
+    "Reconnecting to voice" copy is safer + more honest than a misleading
+    "Jumped to 2:00." or a false "Nothing is playing." This test now
+    asserts REJECT instead of PROCEED.
     """
     bot = both_in_voice()
     ctx = context_for(bot)
@@ -200,11 +208,12 @@ async def test_seek_proceeds_when_lavalink_disconnected_but_current_set() -> Non
 
     await seek_module._handle_seek(ctx, "2:00")
 
-    # Post-#196: seek proceeds; NOT "Nothing is playing".
-    assert player.seek_calls == [120_000]
+    # #215: seek does NOT proceed; reconnecting ephemeral is sent.
+    assert player.seek_calls == []
     fake = cast(Any, ctx)
-    assert fake.responses[0][0] == t("seek.success.jumped", locale="en_US", position="2:00")
-    assert "ephemeral" not in fake.responses[0][1]
+    assert fake.responses[0][0] == t("voice.error.reconnecting", locale="en_US")
+    assert fake.responses[0][0] == "Reconnecting to voice — try again in a moment."
+    assert fake.responses[0][1].get("ephemeral") is True
 
 
 def test_seek_loader_registered() -> None:

--- a/tests/test_skip_command.py
+++ b/tests/test_skip_command.py
@@ -218,6 +218,32 @@ async def test_skip_while_paused_with_empty_queue_does_not_re_pause() -> None:
     assert player.set_pause_calls == []
 
 
+async def test_skip_disconnected_but_current_responds_reconnecting() -> None:
+    """#215: reject with reconnecting copy when Lavalink reports disconnected
+    but still holds a stale ``current`` — do NOT proceed to ``skip`` (or the
+    defensive ``set_pause``). The helper rejects up-front, so both of skip's
+    unprotected lavalink calls are protected.
+    """
+    bot = both_in_voice()
+    ctx = context_for(bot)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = False
+    player.current = make_track_with_info(title="Stale")
+    player.queue = [make_track_with_info(title="Next", video_id="aaaaaaaaaaa")]
+    player.paused = True
+
+    await skip_module._handle_skip(ctx)
+
+    assert player.skip_calls == 0
+    assert player.set_pause_calls == []
+    fake = cast(Any, ctx)
+    assert fake.responses[0][0] == t("voice.error.reconnecting", locale="en_US")
+    assert fake.responses[0][0] == "Reconnecting to voice — try again in a moment."
+    assert fake.responses[0][1].get("ephemeral") is True
+
+
 def test_skip_loader_registered() -> None:
     assert skip_module.Skip._command_data.name == "skip"
     assert skip_module.Skip._command_data.description == t(

--- a/tests/test_voice_check.py
+++ b/tests/test_voice_check.py
@@ -1,4 +1,4 @@
-"""Tests for ``ryzic.voice_check.ensure_same_voice``.
+"""Tests for ``ryzic.voice_check.ensure_same_voice`` + ``check_player_or_respond``.
 
 We mock the slim subset of ``hikari.GatewayBot`` + ``lightbulb.Context``
 needed by the helper. The real classes carry too many slots to
@@ -153,3 +153,77 @@ async def test_bot_state_with_none_channel_treated_as_disconnected() -> None:
     ctx = _FakeContext(guild_id=111, user_id=1, bot_user_id=10, states=states)
     assert await voice_check.ensure_same_voice(cast(lightbulb.Context, ctx)) is None
     assert ctx.responses[0][0] == t("voice.error.bot_not_in_voice", locale="en_US")
+
+
+# ---------------------------------------------------------------------------
+# check_player_or_respond — three-way guard for pause/resume/seek/skip (#215).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeAudioTrack:
+    """Minimal track stub: only ``current is not None`` matters to the helper."""
+
+
+class _FakePlayer:
+    """Player stub with the ``is_connected`` / ``current`` surface the helper reads.
+
+    Mirrors real ``lavalink.DefaultPlayer``: ``is_connected`` is derived from
+    ``channel_id is not None``.
+    """
+
+    def __init__(self, *, channel_id: int | None, current: _FakeAudioTrack | None) -> None:
+        self.channel_id = channel_id
+        self.current = current
+
+    @property
+    def is_connected(self) -> bool:
+        return self.channel_id is not None
+
+
+async def test_check_player_or_respond_nothing_playing_responds_and_returns_none() -> None:
+    ctx = _FakeContext(guild_id=111, user_id=1, bot_user_id=10, states={})
+    result = await voice_check.check_player_or_respond(cast(lightbulb.Context, ctx), player=None)
+    assert result is None
+    assert ctx.responses[0][0] == t("np.error.nothing_playing", locale="en_US")
+    assert ctx.responses[0][0] == "Nothing is playing."
+    assert ctx.responses[0][1].get("ephemeral") is True
+
+
+async def test_check_player_or_respond_no_current_responds_and_returns_none() -> None:
+    ctx = _FakeContext(guild_id=111, user_id=1, bot_user_id=10, states={})
+    player = _FakePlayer(channel_id=999, current=None)
+    assert (
+        await voice_check.check_player_or_respond(
+            cast(lightbulb.Context, ctx), player=cast(Any, player)
+        )
+        is None
+    )
+    assert ctx.responses[0][0] == t("np.error.nothing_playing", locale="en_US")
+
+
+async def test_check_player_or_respond_reconnecting_responds_and_returns_none() -> None:
+    """#215: a held ``current`` with ``is_connected=False`` is the resync window.
+
+    Reject with ``voice.error.reconnecting`` ephemeral — NOT the misleading
+    "Nothing is playing." (a track IS held) and NOT a silent proceed.
+    """
+    ctx = _FakeContext(guild_id=111, user_id=1, bot_user_id=10, states={})
+    player = _FakePlayer(channel_id=None, current=_FakeAudioTrack())
+    result = await voice_check.check_player_or_respond(
+        cast(lightbulb.Context, ctx), player=cast(Any, player)
+    )
+    assert result is None
+    assert ctx.responses[0][0] == t("voice.error.reconnecting", locale="en_US")
+    assert ctx.responses[0][0] == "Reconnecting to voice — try again in a moment."
+    assert ctx.responses[0][1].get("ephemeral") is True
+
+
+async def test_check_player_or_respond_ready_returns_player() -> None:
+    ctx = _FakeContext(guild_id=111, user_id=1, bot_user_id=10, states={})
+    player = _FakePlayer(channel_id=999, current=_FakeAudioTrack())
+    result = await voice_check.check_player_or_respond(
+        cast(lightbulb.Context, ctx), player=cast(Any, player)
+    )
+    assert result is player
+    assert ctx.responses == []


### PR DESCRIPTION
## Fix

Introduces a single three-way guard helper, `check_player_or_respond`, in
`src/ryzic/voice_check.py` and routes `/pause`, `/resume`, `/seek`, and
`/skip` through it, replacing the duplicated
`if player is None or player.current is None` block across all four command
files.

- **`voice_check.check_player_or_respond(ctx, player)`** — returns the player
  (caller proceeds) only when it is connected AND holds a current track.
  Responds ephemerally and returns `None` (caller aborts) when there is no
  current track (`np.error.nothing_playing`) OR when a track is held but the
  player reports `is_connected=False` (`voice.error.reconnecting`). Mirrors
  `ensure_same_voice`'s respond-and-return convention. No enum, no classify
  function — a single inlined 3-way branch (KISS).
- **`voice.error.reconnecting`** i18n key added to
  `src/ryzic/i18n/locales/en_US.json` in the `voice.error.*` namespace
  alongside `run_in_server` / `bot_starting` / `bot_not_in_voice` /
  `join_my_channel`. Static message, no placeholders, no plural — satisfies
  both main's drift gate and #211's tightened gate (single real render site
  in `voice_check.py`).
- **4 command files** collapse the duplicated guard to one line +
  `if player is None: return`. The success-path code (`set_pause` / `seek` /
  `skip` + the public response) is unchanged. This protects both of skip's
  previously-unprotected lavalink calls (`skip` + the defensive `set_pause`)
  since the helper rejects up-front. No `try/except` added — reject-up-front
  makes it unnecessary.
- **Tests:**
  - `tests/test_lavalink_disconnected_player.py` (NEW) — characterization
    tests pinning lavalink 5.11.0's behaviour: `set_pause` / `seek` / `stop` /
    `skip` all send an HTTP PATCH via `node.update_player` regardless of
    `is_connected`, and `is_connected` is a read-only property derived from
    `channel_id is not None`. Version-fragile by design — a future lavalink
    bump that adds an `is_connected` short-circuit should fail here so the
    team re-evaluates the #215 reject-up-front stance.
  - `tests/test_voice_check.py` — 4 unit tests for `check_player_or_respond`
    (nothing-playing, no-current, reconnecting, ready).
  - 1 disconnected-but-current test per command
    (`test_pause_disconnected_but_current_responds_reconnecting` and
    equivalents for resume / seek / skip) asserting the reconnecting
    ephemeral is sent and the lavalink call does NOT fire.
  - The #210 test `test_seek_proceeds_when_lavalink_disconnected_but_current_set`
    is rewritten to
    `test_seek_disconnected_but_current_responds_reconnecting` with REJECT
    assertions (see below).

## Behavior change vs #210 (user-facing)

#196/#210 let `/pause`, `/resume`, `/seek`, and `/skip` **PROCEED** (with a
success response) when the Lavalink player reported `is_connected=False` but
still held a stale `current` track — the transient resync window (region
migration, voice-WS blip). This PR changes that to **REJECT** with an
ephemeral "Reconnecting to voice — try again in a moment." copy.

**Rationale.** lavalink 5.11.0's `DefaultPlayer.set_pause` / `seek` / `stop` /
`skip` do NOT consult `is_connected` — they always send an HTTP PATCH via
`node.update_player` (pinned by the new characterization test
`tests/test_lavalink_disconnected_player.py`). So whether commanding a
disconnected player raises / no-ops / silently succeeds is
server-determined and unverified, and the four command paths have no
`try/except` around the lavalink calls — an unhandled raise would propagate
to lightbulb's dispatcher. Reject-up-front with accurate copy is safer and
more honest than a misleading "Paused." / "Jumped to 2:00." success, and
more accurate than a false "Nothing is playing." (a track IS held, just not
playable right now).

Pre-1.0 SemVer: behaviour change shipping in 0.6.0.

## Closes #215