### PR TITLE
fix(teardown): unify /leave and auto-leave through _teardown_player_session

### DIFF
--- a/src/ryzic/commands/leave.py
+++ b/src/ryzic/commands/leave.py
@@ -1,11 +1,12 @@
 """``/leave`` slash command (M1 §3).
 
-Stops playback, clears the queue, and disconnects from voice. The
-existing ``QueueEndEvent`` auto-leave timer is rendered moot by the
-explicit disconnect; ``_on_voice_state_update`` in ``lavalink_glue``
-clears ``_voice_ready_events[guild_id]`` once the gateway confirms our
-own state went to ``channel_id is None``, so a follow-up ``/play``
-correctly waits on a fresh handshake.
+Stops playback, clears the queue, and disconnects from voice. Cleanup
+goes through ``_teardown_player_session``, the same helper used by the
+auto-leave timer and the 4014 close paths; the guild-leave path
+releases the same set inline (a REST teardown would 403 once the bot
+has lost the guild). The shared set: queued audio-cache pins, the
+now-playing controller, the auto-leave task, the voice-ready handshake
+event.
 """
 
 from __future__ import annotations
@@ -15,7 +16,7 @@ from typing import cast
 import hikari
 import lightbulb
 
-from .. import lavalink_glue, now_playing
+from .. import lavalink_glue
 from ..i18n import locale_for_ephemeral, locale_for_public, t
 from ..voice_check import ensure_same_voice
 
@@ -35,34 +36,39 @@ class Leave(
 
 
 async def _handle_leave(ctx: lightbulb.Context) -> None:
-    if await ensure_same_voice(ctx) is None:
-        return
-
     guild_id = cast(int, ctx.guild_id)
 
-    player = lavalink_glue.get_player(guild_id)
-    if player is None or not player.is_connected:
-        await ctx.respond(
-            t("voice.error.bot_not_in_voice", locale=locale_for_ephemeral(ctx)),
-            ephemeral=True,
-        )
-        return
-
-    # Stop first so Lavalink halts the stream cleanly; clearing the queue
-    # before update_voice_state guarantees a follow-up auto-advance can
-    # not race a disconnect. Use the releasing helper so audio_cache pins
-    # for queued-but-never-played tracks don't leak (issue #24).
-    await player.stop()
-    await lavalink_glue.clear_queue_releasing(player)
-
-    bot = cast(hikari.GatewayBot, ctx.client.app)
-    # Mark as intentional so on_websocket_closed skips voice_lost broadcast.
-    lavalink_glue.mark_intentional_disconnect(guild_id)
+    # Take ownership of teardown before the first await. _cancel_auto_leave
+    # stops a still-sleeping timer; begin_explicit_leave is the backstop for
+    # a timer whose sleep already completed this tick and self-popped before
+    # we ran — _auto_leave sees the marker and bows out instead of
+    # broadcasting after the explicit leave (#218).
+    lavalink_glue._cancel_auto_leave(guild_id)
+    lavalink_glue.begin_explicit_leave(guild_id)
     try:
-        await bot.update_voice_state(guild_id, None)
-    except Exception:
-        lavalink_glue.clear_intentional_disconnect(guild_id)
-        raise
+        if await ensure_same_voice(ctx) is None:
+            return
 
-    await now_playing.teardown(bot, guild_id)
-    await ctx.respond(t("leave.success.left", locale=locale_for_public(ctx)))
+        player = lavalink_glue.get_player(guild_id)
+        if player is None or not player.is_connected:
+            await ctx.respond(
+                t("voice.error.bot_not_in_voice", locale=locale_for_ephemeral(ctx)),
+                ephemeral=True,
+            )
+            return
+
+        await player.stop()
+
+        bot = cast(hikari.GatewayBot, ctx.client.app)
+        # Mark as intentional so on_websocket_closed skips voice_lost broadcast.
+        lavalink_glue.mark_intentional_disconnect(guild_id)
+        try:
+            await bot.update_voice_state(guild_id, None)
+        except Exception:
+            lavalink_glue.clear_intentional_disconnect(guild_id)
+            raise
+
+        await lavalink_glue._teardown_player_session(bot, guild_id, player)
+        await ctx.respond(t("leave.success.left", locale=locale_for_public(ctx)))
+    finally:
+        lavalink_glue.end_explicit_leave(guild_id)

--- a/src/ryzic/lavalink_glue.py
+++ b/src/ryzic/lavalink_glue.py
@@ -94,6 +94,11 @@ last_play_channel: dict[int, int] = {}
 auto_leave_tasks: dict[int, asyncio.Task[None]] = {}
 _voice_ready_events: dict[int, asyncio.Event] = {}
 
+# Guilds where an explicit /leave owns teardown. Backstop for the #218
+# dispatch-boundary the dict-keyed _cancel_auto_leave can't reach; see
+# the guard in _auto_leave.
+_explicit_leave_in_progress: set[int] = set()
+
 # Guilds with pending intentional disconnects, keyed by guild_id to the
 # ``time.monotonic()`` stamp recorded when the disconnect was initiated.
 # When the bot initiates a disconnect (Leave button, /leave, auto-leave), we
@@ -203,6 +208,20 @@ def _cancel_auto_leave(guild_id: int) -> None:
         task.cancel()
 
 
+def begin_explicit_leave(guild_id: int) -> None:
+    """Mark ``guild_id`` as mid-explicit-/leave so ``_auto_leave`` defers.
+
+    Cross-module API: ``commands.leave`` calls this before its first await.
+    Pairs with :func:`end_explicit_leave` (clear it in a ``finally``).
+    """
+    _explicit_leave_in_progress.add(guild_id)
+
+
+def end_explicit_leave(guild_id: int) -> None:
+    """Clear the explicit-leave marker (idempotent; safe to call when none set)."""
+    _explicit_leave_in_progress.discard(guild_id)
+
+
 def _start_auto_leave(bot: hikari.GatewayBot, guild_id: int) -> None:
     """Schedule the disconnect timer for ``guild_id``.
 
@@ -242,7 +261,16 @@ async def _auto_leave(bot: hikari.GatewayBot, guild_id: int, seconds: int) -> No
         clear_intentional_disconnect(guild_id)
         _log.exception("auto-leave: failed to disconnect from guild %d", guild_id)
 
-    _reset_voice_ready(guild_id)
+    # An explicit /leave may have taken ownership of teardown while we awaited
+    # update_voice_state — the #218 dispatch boundary, where our sleep
+    # completed and we self-popped before /leave's handler ran (so
+    # _cancel_auto_leave's dict-keyed cancel could not reach us). Bow out
+    # before the teardown + broadcast: /leave runs _teardown_player_session,
+    # and our "idle, disconnecting" message would duplicate its "left" reply.
+    if guild_id in _explicit_leave_in_progress:
+        return
+
+    await _teardown_player_session(bot, guild_id, player)
     await _send_to_last_play_channel(
         bot,
         guild_id,
@@ -785,6 +813,7 @@ def _reset_state_for_test() -> None:
             task.cancel()
     last_play_channel.clear()
     auto_leave_tasks.clear()
+    _explicit_leave_in_progress.clear()
     _auto_leave_seconds = DEFAULT_AUTO_LEAVE_SECONDS
     _voice_ready_events.clear()
     _pending_intentional_disconnects.clear()

--- a/tests/test_lavalink_bridge.py
+++ b/tests/test_lavalink_bridge.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 import hikari
 import lavalink
@@ -1323,6 +1323,7 @@ async def test_auto_leave_broadcast_uses_catalog_template(
 
     class _ConnectedPlayer:
         is_connected = True
+        queue: ClassVar[list[Any]] = []
 
     class _ConnectedPlayerManager:
         def get(self, guild_id: int) -> _ConnectedPlayer:
@@ -1748,6 +1749,118 @@ async def test_teardown_player_session_runs_full_cleanup_sequence() -> None:
         assert guild_id not in lavalink_glue.auto_leave_tasks
         assert guild_id not in lavalink_glue._voice_ready_events
         assert guild_id not in now_playing._controllers
+    finally:
+        audio_cache.set_audio_cache(None)
+
+
+async def test_teardown_player_session_is_idempotent() -> None:
+    """Double-teardown is safe: every step is a no-op on empty state."""
+    from ryzic import audio_cache, now_playing
+
+    fake = RecordingCache()
+    audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
+    try:
+        bot = _FakeApp()
+        guild_id = 111
+        player = _QueuePlayer(queue=[_IdTrack(identifier="/var/cache/ryzic/audio/id/idem1.audio")])
+
+        await lavalink_glue._teardown_player_session(
+            cast(hikari.GatewayBot, bot), guild_id, cast(lavalink.DefaultPlayer, player)
+        )
+        assert fake.released == ["idem1"]
+
+        # Second call: queue empty, no task, no event, no controller.
+        await lavalink_glue._teardown_player_session(
+            cast(hikari.GatewayBot, bot), guild_id, cast(lavalink.DefaultPlayer, player)
+        )
+        assert fake.released == ["idem1"]
+        assert player.queue == []
+        assert guild_id not in lavalink_glue.auto_leave_tasks
+        assert guild_id not in lavalink_glue._voice_ready_events
+        assert guild_id not in now_playing._controllers
+    finally:
+        audio_cache.set_audio_cache(None)
+
+
+async def test_auto_leave_calls_teardown_player_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for #224: ``_auto_leave`` must call ``_teardown_player_session``."""
+    bot = _FakeApp()
+    guild_id = 111
+
+    class _ConnectedPlayer:
+        is_connected = True
+        queue: ClassVar[list[Any]] = []
+
+    class _ConnectedPlayerManager:
+        def get(self, gid: int) -> _ConnectedPlayer:
+            return _ConnectedPlayer()
+
+    class _ConnectedClient:
+        player_manager = _ConnectedPlayerManager()
+
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, _ConnectedClient()))
+
+    teardown_calls: list[int] = []
+
+    async def _spy_sleep(_: float) -> None:
+        return
+
+    real_teardown = lavalink_glue._teardown_player_session
+
+    async def _spy_teardown(b: Any, gid: int, p: Any) -> None:
+        teardown_calls.append(gid)
+        await real_teardown(b, gid, p)
+
+    monkeypatch.setattr(asyncio, "sleep", _spy_sleep)
+    monkeypatch.setattr(lavalink_glue, "_teardown_player_session", _spy_teardown)
+
+    await lavalink_glue._auto_leave(cast(hikari.GatewayBot, bot), guild_id, 45)
+
+    assert teardown_calls == [guild_id]
+
+
+async def test_4014_after_auto_leave_is_noop_teardown() -> None:
+    """A 4014 arriving after ``_auto_leave`` ran hits empty state (no double-release).
+
+    Regression for #224: ``_auto_leave`` now tears down eagerly, so the
+    late 4014 close event must not double-release or re-broadcast.
+    """
+    from ryzic import audio_cache
+
+    @dataclass
+    class _WsClosedEvent:
+        player: _QueuePlayer
+        code: int = 4014
+        reason: str = "Disconnected"
+        by_remote: bool = True
+
+    fake = RecordingCache()
+    audio_cache.set_audio_cache(cast(audio_cache.AudioCache, fake))
+    try:
+        bot = _FakeApp()
+        lavalink_glue.last_play_channel[111] = 999
+        handler = lavalink_glue.EventHandler(cast(hikari.GatewayBot, bot))
+        player = _QueuePlayer(
+            queue=[_IdTrack(identifier="/var/cache/ryzic/audio/al/autolv1.audio")]
+        )
+
+        # Simulate auto-leave having already torn down + marked intentional.
+        lavalink_glue.mark_intentional_disconnect(111)
+        await lavalink_glue._teardown_player_session(
+            cast(hikari.GatewayBot, bot), 111, cast(lavalink.DefaultPlayer, player)
+        )
+        assert fake.released == ["autolv1"]
+
+        # Now the 4014 close arrives; the intentional marker suppresses
+        # voice_lost and the teardown hits empty state.
+        await handler.on_websocket_closed(
+            cast(lavalink.WebSocketClosedEvent, _WsClosedEvent(player=player)),
+        )
+
+        assert fake.released == ["autolv1"]
+        assert bot.created_messages == []
     finally:
         audio_cache.set_audio_cache(None)
 

--- a/tests/test_leave_command.py
+++ b/tests/test_leave_command.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Iterator
 from typing import Any, cast
 
@@ -105,6 +106,183 @@ async def test_leave_stops_clears_disconnects_and_responds() -> None:
     assert fake.responses[0][0] == t("leave.success.left", locale="en_US")
     assert fake.responses[0][0] == "Left voice channel. Queue cleared."
     assert "ephemeral" not in fake.responses[0][1]
+
+
+async def test_leave_calls_teardown_player_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """/leave must go through ``_teardown_player_session`` (not duplicate steps)."""
+    bot = both_in_voice()
+    ctx = context_for(bot)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = True
+
+    calls: list[tuple[int, int]] = []
+    real_teardown = lavalink_glue._teardown_player_session
+
+    async def _spy_teardown(b: Any, guild_id: int, p: Any) -> None:
+        calls.append((guild_id, id(p)))
+        await real_teardown(b, guild_id, p)
+
+    monkeypatch.setattr(lavalink_glue, "_teardown_player_session", _spy_teardown)
+    await leave_module._handle_leave(ctx)
+
+    assert len(calls) == 1
+    assert calls[0][0] == 111
+    assert calls[0][1] == id(cast(Any, player))
+
+
+async def test_leave_cancels_pending_auto_leave_timer() -> None:
+    """Regression for #218: /leave must cancel a pending auto-leave task."""
+    bot = both_in_voice()
+    ctx = context_for(bot)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = True
+
+    lavalink_glue._start_auto_leave(cast(Any, bot), 111)
+    task = lavalink_glue.auto_leave_tasks[111]
+    assert not task.done()
+
+    await leave_module._handle_leave(ctx)
+
+    assert 111 not in lavalink_glue.auto_leave_tasks
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert task.cancelled()
+
+
+async def test_leave_cancels_auto_leave_task_past_its_sleep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for #218: a timer whose sleep completes during /leave's
+    first await must not emit its "idle, disconnecting" broadcast.
+
+    The cancel bundled inside ``_teardown_player_session`` runs only after
+    ``player.stop()`` and ``update_voice_state``; a timer that wakes during
+    one of those awaits self-pops before that late cancel and runs its body
+    to completion. Cancelling up front — before the first await — closes the
+    window. This test rigs the timer to wake at the first event-loop yield
+    (inside ``player.stop()``) so the race is deterministic: without the
+    up-front cancel the spurious broadcast fires and a second
+    ``update_voice_state`` is recorded.
+    """
+    bot = both_in_voice()
+    ctx = context_for(bot)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = True
+
+    lavalink_glue._set_auto_leave_seconds_for_test(300)
+
+    real_sleep = asyncio.sleep
+
+    async def _noop_sleep(_: float) -> None:
+        return
+
+    # Yield once inside player.stop() so the auto-leave task — whose sleep
+    # is a no-op — gets loop time and can run its post-sleep body during
+    # /leave's first await (the window the up-front cancel must close).
+    async def _yielding_stop(self: Any) -> None:
+        await real_sleep(0)
+        self.stop_calls += 1
+        self.current = None
+
+    broadcasts: list[int] = []
+    real_send = lavalink_glue._send_to_last_play_channel
+
+    async def _spy_send(b: Any, guild_id: int, content: str) -> None:
+        broadcasts.append(guild_id)
+        await real_send(b, guild_id, content)
+
+    monkeypatch.setattr(asyncio, "sleep", _noop_sleep)
+    monkeypatch.setattr(type(player), "stop", _yielding_stop)
+    monkeypatch.setattr(lavalink_glue, "_send_to_last_play_channel", _spy_send)
+
+    lavalink_glue._start_auto_leave(cast(Any, bot), 111)
+    task = lavalink_glue.auto_leave_tasks[111]
+    assert not task.done()
+
+    await leave_module._handle_leave(ctx)
+
+    # Timer cancelled before its body ran: no spurious broadcast, no second
+    # update_voice_state from _auto_leave, task ended cancelled.
+    assert broadcasts == []
+    assert 111 not in lavalink_glue.auto_leave_tasks
+    assert task.cancelled()
+    assert bot.update_voice_state_calls == [(111, None)]
+
+
+async def test_leave_suppresses_auto_leave_broadcast_when_timer_already_past_sleep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for the #218 dispatch-boundary edge: the timer's sleep
+    completed in the same loop tick as /leave and the loop ran _auto_leave
+    first, so it self-popped before /leave's handler ran — the dict-keyed
+    _cancel_auto_leave cannot reach it. begin_explicit_leave is the backstop:
+    _auto_leave bows out after its update_voice_state await instead of
+    broadcasting "idle, disconnecting" alongside /leave's "left".
+
+    The rig parks _auto_leave mid-body at update_voice_state (past its sleep,
+    self-popped) before /leave runs, which is the exact state the up-front
+    cancel alone cannot handle.
+    """
+    bot = both_in_voice()
+    ctx = context_for(bot)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = True
+
+    lavalink_glue._set_auto_leave_seconds_for_test(300)
+
+    real_sleep = asyncio.sleep
+
+    async def _noop_sleep(_: float) -> None:
+        return
+
+    # Yield once inside update_voice_state so _auto_leave parks there (past
+    # its no-op sleep, self-popped) and resumes only when /leave yields.
+    async def _yielding_update_voice_state(
+        self: Any, guild_id: int, channel_id: int | None, *, self_deaf: bool = False
+    ) -> None:
+        await real_sleep(0)
+        self.update_voice_state_calls.append((guild_id, channel_id))
+
+    broadcasts: list[int] = []
+    real_send = lavalink_glue._send_to_last_play_channel
+
+    async def _spy_send(b: Any, guild_id: int, content: str) -> None:
+        broadcasts.append(guild_id)
+        await real_send(b, guild_id, content)
+
+    monkeypatch.setattr(asyncio, "sleep", _noop_sleep)
+    monkeypatch.setattr(type(bot), "update_voice_state", _yielding_update_voice_state)
+    monkeypatch.setattr(lavalink_glue, "_send_to_last_play_channel", _spy_send)
+
+    lavalink_glue._start_auto_leave(cast(Any, bot), 111)
+    task = lavalink_glue.auto_leave_tasks[111]
+    # Run _auto_leave to its update_voice_state await: past its (no-op) sleep,
+    # self-popped, parked mid-body. This is the state the up-front cancel
+    # alone cannot reach (the dict entry is already gone).
+    await real_sleep(0)
+    assert 111 not in lavalink_glue.auto_leave_tasks
+    assert not task.done()
+
+    await leave_module._handle_leave(ctx)
+
+    # _auto_leave bowed out via the explicit-leave marker: no spurious
+    # broadcast. /leave still owns the response.
+    assert broadcasts == []
+    assert not task.cancelled()
+    assert task.done()
+    fake = cast(Any, ctx)
+    assert fake.responses[0][0] == t("leave.success.left", locale="en_US")
+    assert lavalink_glue._explicit_leave_in_progress == set()
 
 
 async def test_leave_releases_audio_cache_pins_for_queued_tracks() -> None:


### PR DESCRIPTION
## Summary

Unify the two remaining teardown paths (`/leave` and `_auto_leave`) through the shared `_teardown_player_session` helper extracted by #209, so every teardown route releases the same set of resources. `/leave` was duplicating cleanup steps and missing `_cancel_auto_leave` (a pending auto-leave timer could fire after explicit `/leave`). `_auto_leave` relied on the 4014 WebSocket close event to trigger cleanup — if the close was lost, audio-cache pins leaked and the now-playing controller was orphaned.

`/leave` now also takes ownership of teardown *before its first await* — cancelling the auto-leave timer outright and setting an explicit-leave marker that `_auto_leave` re-checks after its `update_voice_state` await. The cancel alone handles a timer whose sleep is still pending during `/leave`'s awaits; the marker is the backstop for the dispatch-boundary edge where the timer's sleep completes in the same event-loop tick as the `/leave` interaction and the loop runs `_auto_leave` first (it self-pops before `/leave` runs, so the dict-keyed cancel cannot reach it). Together they close #218 without relying on the late cancel bundled inside `_teardown_player_session`.

## What's in / what's out

**In:**
- `/leave` calls `_teardown_player_session` instead of duplicating `clear_queue_releasing` + `now_playing.teardown` (picks up `_cancel_auto_leave` and `_reset_voice_ready` for free)
- `_auto_leave` calls `_teardown_player_session` after `update_voice_state(None)`, replacing the bare `_reset_voice_ready` call
- `/leave` cancels the auto-leave timer and calls `begin_explicit_leave` before its first await (in a `try/finally` that clears the marker); `_auto_leave` bows out via that marker instead of broadcasting after an explicit leave (#218)
- 7 new regression tests: teardown helper call verification, auto-leave timer cancellation, idempotency, 4014-after-auto-leave no-op, plus two deterministic #218 race tests — one for a timer that wakes during `/leave`'s first yield (fails without the up-front cancel), one for a timer already past its sleep and self-popped (fails without the explicit-leave guard)

**Out (deferred):**
- Renaming `_teardown_player_session` to public (drop underscore) — cross-module internal calls are already established (`clear_queue_releasing` is also internal)
- Latent double-broadcast if `update_voice_state` raises in `_auto_leave` (pre-existing behavior, not introduced by this diff)
- 4014 paths in `on_websocket_closed` — already call `_teardown_player_session`, no change needed
- `_on_guild_leave` — intentionally distinct (no REST teardown; releases the same set inline), not changed
- `now_playing_buttons.py` — dispatches through `_handle_leave`, fixed transitively

## Test plan

- [x] `uv run pytest -q` — 609 passed, 1 deselected
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run ty check` — clean
- [x] CI on this PR — green

## Closes / refs

Closes #218, Closes #224. Refs #209, #225.
