### PR TITLE
fix(now_playing): disable controller buttons while player is disconnected

### DIFF
--- a/src/ryzic/now_playing.py
+++ b/src/ryzic/now_playing.py
@@ -212,14 +212,29 @@ async def refresh_all(bot: hikari.GatewayBot) -> None:
     """Refresh all active controllers whose progress is actually moving.
 
     Used by the bot's background loop to advance progress bars. Skips
-    paused / idle / disconnected players so we don't issue byte-identical
-    edits every cycle (their state only changes via an event, which
-    already routes through :func:`refresh`). Staggers updates to spread
-    concurrent in-flight REST requests.
+    idle players and paused players that are connected — their render is
+    byte-identical between cycles, so re-editing would waste the Discord
+    per-message edit budget (state only changes via an event, which
+    already routes through :func:`refresh`). A disconnected player (the
+    #215 resync window — ``is_connected=False`` with a held track) is NOT
+    skipped: re-rendering it keeps the controller's buttons disabled via
+    :func:`_render_for_player`, closing the #222 gap where the controller
+    advertised live buttons the command side rejects. A playing player
+    auto-recovers to enabled buttons on the next cycle once
+    ``is_connected`` returns True. A paused player is skipped again once it
+    reconnects (paused+connected), so its controller stays disabled until
+    the next user-initiated ``/resume`` *after reconnection* — a bounded
+    transient, strictly safer than the #222 defect (disabled-when-should-
+    be-enabled beats enabled-when-should-be-disabled). No separate
+    recovery hook is needed. Staggers updates to spread concurrent
+    in-flight REST requests.
     """
     for guild_id in list(_controllers.keys()):
         player = lavalink_glue.get_player(guild_id)
-        if player is None or player.paused or player.current is None:
+        # Skip paused only when connected: a paused controller is static
+        # (byte-identical re-render), but a disconnected+paused player must
+        # still be re-rendered so its buttons flip to disabled (#222).
+        if player is None or player.current is None or (player.paused and player.is_connected):
             continue
         try:
             await refresh(bot, guild_id)
@@ -253,7 +268,25 @@ async def _render_for_player(bot: hikari.GatewayBot, guild_id: int, channel_id: 
         queue_length=len(player.queue),
         locale="en_US",
     )
-    components = _build_components_paused() if player.paused else _build_components()
+    # Disconnected takes precedence over paused: a player in the #215
+    # resync window (``is_connected=False`` but ``current`` held) must not
+    # advertise a clickable Resume even when paused. The command-side
+    # guard (``voice_check.check_player_or_respond``) rejects
+    # /pause /resume /seek /skip with "Reconnecting to voice" in this
+    # state, so the controller reuses the held-track embed (the idle
+    # embed's "No tracks playing" copy is factually wrong — ``current`` is
+    # still held) paired with all-disabled buttons. ``refresh_all`` does
+    # NOT skip a disconnected player (the paused-skip is narrowed to the
+    # connected case), so a playing player auto-recovers to enabled
+    # buttons once ``is_connected`` returns True; a paused player is
+    # skipped again once reconnected, so its controller stays disabled
+    # until the next user-initiated ``/resume`` after reconnection.
+    if not player.is_connected:
+        components = _build_idle_components()
+    elif player.paused:
+        components = _build_components_paused()
+    else:
+        components = _build_components()
     await _post_or_edit(bot, guild_id, channel_id, embed=embed, components=components)
 
 

--- a/tests/test_now_playing.py
+++ b/tests/test_now_playing.py
@@ -225,6 +225,248 @@ async def test_refresh_recovers_from_deleted_message_by_reposting() -> None:
 
 
 # ---------------------------------------------------------------------------
+# #222 — disconnected render path (is_connected=False with current held)
+# ---------------------------------------------------------------------------
+
+
+async def test_refresh_renders_disabled_buttons_when_disconnected() -> None:
+    """#215/#222: a held track with ``is_connected=False`` is the resync window.
+
+    The command-side guard rejects /pause /resume /seek /skip with
+    "Reconnecting to voice"; the controller must not advertise live buttons
+    either. The held-track embed is reused (NOT the idle embed — ``current``
+    is still held), and every button is disabled.
+    """
+    rest = _FakeRest(create_returns=9700)
+    bot = _bot_with_rest(rest)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = True
+    player.current = make_track_with_info(title="Held Track")
+    lavalink_glue.last_play_channel[111] = 555
+    await now_playing.upsert_for_track_start(bot, 111)
+    rest.edit_calls.clear()
+
+    # Lavalink reports disconnected while still holding the track.
+    player.is_connected = False
+    await now_playing.refresh(bot, 111)
+
+    assert len(rest.edit_calls) == 1
+    edit = rest.edit_calls[0]
+    embed: hikari.Embed = edit["embed"]
+    # Held-track embed, not the idle embed (whose "No tracks playing" copy
+    # would be factually wrong — current is retained per #215).
+    assert embed.title == t("ux.np.title.playing", locale="en_US")
+    [row] = edit["components"]
+    assert _disabled_in_row(row) == [True, True, True]
+
+
+async def test_refresh_all_does_not_skip_disconnected_player() -> None:
+    """#222: ``refresh_all`` deliberately re-renders disconnected players.
+
+    The skip predicate does not skip a disconnected player (the paused
+    term is narrowed to the connected case): re-rendering keeps the
+    disabled-buttons visual during the resync window and is what
+    auto-recovers to enabled buttons once ``is_connected`` returns True.
+    Pins the decision so a future "optimization" adding ``is_connected``
+    to the predicate doesn't silently drop the visual.
+    """
+    rest = _FakeRest(create_returns=9800)
+    bot = _bot_with_rest(rest)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+
+    # Guild 111: PLAYING (control). Guild 222: disconnected but current held.
+    for guild_id, connected in [(111, True), (222, False)]:
+        player = ll.player_manager.create(guild_id=guild_id)
+        player.is_connected = connected
+        player.current = make_track_with_info()
+        lavalink_glue.last_play_channel[guild_id] = guild_id * 10
+        await now_playing.upsert_for_track_start(bot, guild_id)
+    rest.edit_calls.clear()
+
+    await now_playing.refresh_all(bot)
+
+    edited_channels = {call["channel_id"] for call in rest.edit_calls}
+    # Both re-rendered: the connected one advances progress, the
+    # disconnected one re-renders disabled buttons.
+    assert edited_channels == {111 * 10, 222 * 10}
+    disconnected_edit = next(c for c in rest.edit_calls if c["channel_id"] == 222 * 10)
+    [row] = disconnected_edit["components"]
+    assert _disabled_in_row(row) == [True, True, True]
+
+
+async def test_refresh_all_renders_disabled_for_disconnected_paused() -> None:
+    """#222 regression: ``refresh_all`` must re-render a disconnected+PAUSED player.
+
+    The paused-skip is narrowed to the connected case, so a paused player
+    that enters the resync window (``is_connected=False``) is still
+    re-rendered with disabled buttons. With the pre-fix predicate
+    (``player.paused`` short-circuits before ``is_connected``) this player
+    is skipped every cycle and its controller keeps an enabled Resume
+    button — the exact #222 defect. Fails on the pre-fix predicate; passes
+    after. (The 4014 teardown path bounds this window in practice; the
+    non-4014 resync window leaves the record intact.)
+    """
+    rest = _FakeRest(create_returns=9810)
+    bot = _bot_with_rest(rest)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = True
+    player.paused = True
+    player.current = make_track_with_info(title="Paused & Disconnected")
+    lavalink_glue.last_play_channel[111] = 555
+    await now_playing.upsert_for_track_start(bot, 111)
+    rest.edit_calls.clear()
+
+    player.is_connected = False  # disconnected while paused
+    await now_playing.refresh_all(bot)
+
+    assert len(rest.edit_calls) == 1
+    edit = rest.edit_calls[0]
+    [row] = edit["components"]
+    assert _disabled_in_row(row) == [True, True, True]
+    # Held-track embed keeps the Paused title; only the buttons change.
+    assert edit["embed"].title == t("ux.np.title.paused", locale="en_US")
+
+
+async def test_refresh_re_enables_buttons_after_reconnect() -> None:
+    """#222: a playing player's buttons auto-recover on reconnect.
+
+    ``refresh_all`` re-renders a disconnected player with disabled buttons,
+    and once ``is_connected`` returns True the next cycle renders enabled
+    buttons again — no separate recovery hook. Pins the auto-recovery
+    transition so a future regression making the disabled state sticky
+    (cached components, or skipping disconnected players) is caught.
+    """
+    rest = _FakeRest(create_returns=9820)
+    bot = _bot_with_rest(rest)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = True
+    player.current = make_track_with_info(title="Recovering")
+    lavalink_glue.last_play_channel[111] = 555
+    await now_playing.upsert_for_track_start(bot, 111)
+    rest.edit_calls.clear()
+
+    # Disconnect: the controller flips to disabled buttons.
+    player.is_connected = False
+    await now_playing.refresh_all(bot)
+    [row] = rest.edit_calls[-1]["components"]
+    assert _disabled_in_row(row) == [True, True, True]
+
+    # Reconnect: the next refresh_all cycle re-enables the buttons.
+    rest.edit_calls.clear()
+    player.is_connected = True
+    await now_playing.refresh_all(bot)
+    assert len(rest.edit_calls) == 1
+    [row] = rest.edit_calls[-1]["components"]
+    assert _disabled_in_row(row) == [False, False, False]
+
+
+async def test_refresh_all_leaves_paused_controller_disabled_until_resume_after_reconnect() -> None:
+    """Pins the documented paused-reconnect residual (#222 follow-up review).
+
+    A paused player that disconnects is re-rendered with disabled buttons
+    (the fix). Once it reconnects while STILL paused, ``refresh_all`` skips
+    it again (paused+connected => byte-identical), so the controller stays
+    on the disabled render until the next user-initiated ``/resume`` after
+    reconnection. This is a bounded transient and strictly safer than the
+    #222 defect (disabled-when-should-be-enabled, vs the original
+    enabled-when-should-be-disabled). A future fix that re-enables the
+    paused row on reconnect should update this test.
+    """
+    rest = _FakeRest(create_returns=9821)
+    bot = _bot_with_rest(rest)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = True
+    player.paused = True
+    player.current = make_track_with_info(title="Paused Reconnect")
+    lavalink_glue.last_play_channel[111] = 555
+    await now_playing.upsert_for_track_start(bot, 111)
+    rest.edit_calls.clear()
+
+    # Disconnect while paused: the controller flips to disabled buttons.
+    player.is_connected = False
+    await now_playing.refresh_all(bot)
+    [row] = rest.edit_calls[-1]["components"]
+    assert _disabled_in_row(row) == [True, True, True]
+
+    # Reconnect while still paused: refresh_all skips it (paused+connected),
+    # so no edit lands and the controller stays on the disabled render.
+    rest.edit_calls.clear()
+    player.is_connected = True
+    await now_playing.refresh_all(bot)
+    assert rest.edit_calls == []
+
+
+async def test_upsert_renders_disabled_buttons_when_disconnected() -> None:
+    """#222: the create path also renders disabled buttons when disconnected.
+
+    ``upsert_for_track_start`` -> ``_render_for_player`` shares the
+    disconnected branch, so a track that starts during the resync window
+    renders with disabled buttons (not the enabled row). TrackStart
+    normally implies a voice connection, but the branch is shared and the
+    case is cheap to pin.
+    """
+    rest = _FakeRest(create_returns=9830)
+    bot = _bot_with_rest(rest)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = False
+    player.current = make_track_with_info(title="Started While Disconnected")
+    lavalink_glue.last_play_channel[111] = 555
+
+    await now_playing.upsert_for_track_start(bot, 111)
+
+    assert len(rest.create_calls) == 1
+    call = rest.create_calls[0]
+    [row] = call["components"]
+    assert _disabled_in_row(row) == [True, True, True]
+    embed: hikari.Embed = call["embed"]
+    assert embed.title == t("ux.np.title.playing", locale="en_US")
+
+
+async def test_render_disconnected_takes_precedence_over_paused() -> None:
+    """#222: a disconnected+paused player shows disabled buttons, not Resume.
+
+    Disconnected must win over paused in the component selection — a
+    disconnected player must not advertise a clickable Resume even when the
+    held track is also paused.
+    """
+    rest = _FakeRest(create_returns=9900)
+    bot = _bot_with_rest(rest)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = True
+    player.paused = True
+    player.current = make_track_with_info(title="Paused & Disconnected")
+    lavalink_glue.last_play_channel[111] = 555
+    await now_playing.upsert_for_track_start(bot, 111)
+    rest.edit_calls.clear()
+
+    player.is_connected = False  # disconnected while paused
+    await now_playing.refresh(bot, 111)
+
+    assert len(rest.edit_calls) == 1
+    edit = rest.edit_calls[0]
+    [row] = edit["components"]
+    # All disabled — no enabled Resume button from the paused row.
+    assert _disabled_in_row(row) == [True, True, True]
+    # The held-track embed keeps the Paused title (paused=player.paused is
+    # passed through); only the buttons change. Pins the body so a future
+    # "Reconnecting" title variant doesn't silently change visible copy.
+    assert edit["embed"].title == t("ux.np.title.paused", locale="en_US")
+
+
+# ---------------------------------------------------------------------------
 # refresh_all — per-guild skip filter + exception isolation (#200)
 # ---------------------------------------------------------------------------
 
@@ -449,6 +691,13 @@ def _labels_in_row(row: hikari.api.MessageActionRowBuilder) -> list[str]:
     payload, _ = row.build()
     components = payload["components"]
     return [comp["label"] for comp in components]
+
+
+def _disabled_in_row(row: hikari.api.MessageActionRowBuilder) -> list[bool]:
+    """Extract per-button ``disabled`` flags from an action-row builder."""
+    payload, _ = row.build()
+    components = payload["components"]
+    return [bool(comp["disabled"]) for comp in components]
 
 
 def test_active_row_renders_expected_button_labels() -> None:


### PR DESCRIPTION
## Summary

`_render_for_player` ignored `is_connected`, so during the #215 resync window (`is_connected=False` with a held track) the now-playing controller rendered live buttons while `/pause` `/resume` `/seek` `/skip` reject with "Reconnecting to voice" — a user-facing inconsistency within the ~30s resync window. The render path now disables all buttons when the player is disconnected, and `refresh_all`'s paused-skip is narrowed to the connected case so the disabled render applies to both playing and paused players.

## What's in / what's out

**In:**
- `_render_for_player` reuses the held-track embed (`build_now_playing_embed`) — not the idle embed, whose "No tracks playing" copy is factually wrong because `current` is still retained per #215 — paired with `_build_idle_components()` (all buttons disabled), with **disconnected → paused → playing** precedence.
- `refresh_all`'s skip predicate narrowed to `player is None or player.current is None or (player.paused and player.is_connected)`, so a disconnected player (playing *or* paused) is re-rendered with disabled buttons; a playing player auto-recovers to enabled on the next cycle once `is_connected` returns True.

**Out (deferred):**
- A paused player that reconnects while still paused is skipped again by `refresh_all`, so its controller stays disabled until the next `/resume` *after reconnection* — a bounded, safer transient than the #222 defect (disabled-when-should-be-enabled vs the original enabled-when-should-be-disabled). No recovery hook is added (the design uses the periodic loop); pinned by a test as an intentional limitation.
- A dedicated "Reconnecting" embed variant (frozen progress bar) — rejected per KISS for a transient window.
- `FakePlayer.is_connected` fidelity vs lavalink's read-only `channel_id`-derived property — non-blocking, no current test trips it.

No new ux builder, no new i18n strings.

## Test plan

- [x] `uv run pytest -q` — 616 passed, 1 deselected
- [x] `uv run ruff check . && uv run ruff format --check .` — pass
- [x] `uv run ty check` — pass
- [ ] (if integration-relevant) `uv run pytest -q -m integration` — N/A (render-path logic, fully unit-tested)
- [ ] CI on this PR — green — `lint-and-test`/`workflow-edits`/`label` green; `docker-build`/`integration`/`Analyze` pending

New tests: `test_refresh_renders_disabled_buttons_when_disconnected`, `test_refresh_all_does_not_skip_disconnected_player`, `test_refresh_all_renders_disabled_for_disconnected_paused` (regression guard — verified to **fail** on the pre-fix predicate and pass after), `test_render_disconnected_takes_precedence_over_paused`, `test_refresh_re_enables_buttons_after_reconnect`, `test_refresh_all_leaves_paused_controller_disabled_until_resume_after_reconnect`, `test_upsert_renders_disabled_buttons_when_disconnected`, plus a `_disabled_in_row` introspection helper. Two rounds of adversarial multi-dimension review (correctness / race / coverage / precedence) drove the predicate-narrowing follow-up.

## Closes / refs

Closes #222.
Refs #215, #172, #200.