### PR TITLE
fix(seek): refresh now-playing controller after seek

### DIFF
--- a/src/ryzic/commands/seek.py
+++ b/src/ryzic/commands/seek.py
@@ -7,7 +7,7 @@ from typing import cast
 import hikari
 import lightbulb
 
-from .. import lavalink_glue
+from .. import lavalink_glue, now_playing
 from ..i18n import locale_for_ephemeral, locale_for_public, t
 from ..ux import format_duration, parse_seek_position
 from ..voice_check import check_player_or_respond, ensure_same_voice
@@ -75,4 +75,10 @@ async def _handle_seek(ctx: lightbulb.Context, raw_position: str) -> None:
             locale=locale_for_public(ctx),
             position=format_duration(target_ms),
         )
+    )
+    # The lavalink client's seek PATCHes the server but does not update
+    # player.position locally until the next playerUpdate frame, so refresh
+    # with the known target rather than the stale player.position.
+    await now_playing.refresh_with_position(
+        cast(hikari.GatewayBot, ctx.client.app), guild_id, target_ms
     )

--- a/src/ryzic/now_playing.py
+++ b/src/ryzic/now_playing.py
@@ -208,6 +208,22 @@ async def refresh(bot: hikari.GatewayBot, guild_id: int) -> None:
     await _render_for_player(bot, guild_id, channel_id)
 
 
+async def refresh_with_position(bot: hikari.GatewayBot, guild_id: int, position_ms: int) -> None:
+    """Re-render the existing controller with ``position_ms`` as the progress
+    position; no-op if none has been posted.
+
+    Like :func:`refresh` but the progress bar shows ``position_ms`` instead of
+    ``player.position``. Only the position is overridden — paused/connected
+    state and queue depth still come from the live player, so the button row
+    and title match a plain refresh.
+    """
+    record = _controllers.get(guild_id)
+    if record is None:
+        return
+    channel_id = record[0]
+    await _render_for_player(bot, guild_id, channel_id, position_ms=position_ms)
+
+
 async def refresh_all(bot: hikari.GatewayBot) -> None:
     """Refresh all active controllers whose progress is actually moving.
 
@@ -246,8 +262,19 @@ async def refresh_all(bot: hikari.GatewayBot) -> None:
             _log.debug("periodic refresh failed for guild %d", guild_id, exc_info=True)
 
 
-async def _render_for_player(bot: hikari.GatewayBot, guild_id: int, channel_id: int) -> None:
-    """Pull current player state and render the controller into ``channel_id``."""
+async def _render_for_player(
+    bot: hikari.GatewayBot,
+    guild_id: int,
+    channel_id: int,
+    *,
+    position_ms: int | None = None,
+) -> None:
+    """Pull current player state and render the controller into ``channel_id``.
+
+    ``position_ms`` overrides the progress-bar position without touching any
+    other rendered state (paused/connected title + button row, queue depth
+    still come from the live player).
+    """
     player = lavalink_glue.get_player(guild_id)
     if player is None or player.current is None:
         await _render_idle(bot, guild_id, channel_id)
@@ -261,9 +288,10 @@ async def _render_for_player(bot: hikari.GatewayBot, guild_id: int, channel_id: 
         await _render_idle(bot, guild_id, channel_id)
         return
 
+    render_position = player.position if position_ms is None else position_ms
     embed = ux.build_now_playing_embed(
         info,
-        position_ms=player.position,
+        position_ms=render_position,
         paused=player.paused,
         queue_length=len(player.queue),
         locale="en_US",

--- a/tests/_command_helpers.py
+++ b/tests/_command_helpers.py
@@ -183,8 +183,10 @@ class FakePlayer:
         self.current = None
 
     async def seek(self, position_ms: int) -> None:
+        # Mirrors real ``lavalink.DefaultPlayer.seek``: records the call but
+        # does not update ``position``. Tests that need a specific rendered
+        # position set ``player.position`` directly.
         self.seek_calls.append(position_ms)
-        self.position = position_ms
 
 
 class FakePlayerManager:

--- a/tests/test_seek_command.py
+++ b/tests/test_seek_command.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
 
-from ryzic import lavalink_glue
+from ryzic import lavalink_glue, now_playing, ux
 from ryzic.commands import seek as seek_module
 from ryzic.i18n import t
 from tests._command_helpers import (
@@ -16,6 +17,7 @@ from tests._command_helpers import (
     both_in_voice,
     context_for,
     install_lavalink_client,
+    make_track_info,
 )
 
 
@@ -175,6 +177,64 @@ async def test_bare_seconds_treated_as_absolute() -> None:
 
     # Bare 45 → 45s absolute, NOT a relative jump from current position.
     assert player.seek_calls == [45_000]
+
+
+async def test_seek_success_refreshes_now_playing_controller(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#223: /seek re-renders the controller with the seek target, not the
+    stale ``player.position`` a plain refresh would show.
+
+    Registers a controller + ``bot.rest`` recorder and captures the
+    ``position_ms`` handed to :func:`ux.build_now_playing_embed`; the spy
+    pattern (instead of asserting on the formatted embed field) keeps the
+    assertion robust against i18n template changes.
+    """
+    bot = both_in_voice()
+
+    edit_calls: list[dict[str, Any]] = []
+
+    async def _edit_message(channel_id: int, message_id: int, **kwargs: Any) -> Any:
+        edit_calls.append({"channel_id": channel_id, "message_id": message_id, **kwargs})
+
+    cast(Any, bot).rest = SimpleNamespace(edit_message=_edit_message)
+
+    ctx = context_for(bot)
+    _, player = _player_with_track(duration_ms=213_000, position_ms=10_000)
+    ux.attach_track_info(player.current, make_track_info())
+    now_playing._controllers[111] = (555, 9000)
+
+    captured_positions: list[int] = []
+    real_build = ux.build_now_playing_embed
+
+    def _capture_build(
+        track: Any,
+        *,
+        position_ms: int,
+        paused: bool,
+        queue_length: int,
+        locale: str,
+    ) -> Any:
+        captured_positions.append(position_ms)
+        return real_build(
+            track,
+            position_ms=position_ms,
+            paused=paused,
+            queue_length=queue_length,
+            locale=locale,
+        )
+
+    monkeypatch.setattr(ux, "build_now_playing_embed", _capture_build)
+
+    await seek_module._handle_seek(ctx, "1:30")
+
+    assert player.seek_calls == [90_000]
+    # FakePlayer.seek mirrors the real client: it does not set position, so
+    # player.position stays at the pre-seek value — the override is the
+    # only source of the rendered target.
+    assert player.position == 10_000
+    assert captured_positions == [90_000]
+    assert len(edit_calls) == 1
 
 
 async def test_seek_disconnected_but_current_responds_reconnecting() -> None:


### PR DESCRIPTION
## Summary

`/seek` jumped the track position but left the now-playing controller's progress bar stale. Unlike `/skip` (whose `player.skip()` advances the track and fires a Lavalink `TrackStartEvent`, wired to `on_track_start` → `now_playing.upsert_for_track_start` to re-render the controller) and unlike `/pause` / `/resume` (which explicitly call `now_playing.refresh(...)` after their success response), `/seek` calls `player.seek(target_ms)` and returned without refreshing the controller at all.

A naive "just call `refresh()`" would still be stale: the lavalink client's `seek` only PATCHes the new position to the server — it does **not** update `player.position` locally until the next `playerUpdate` WebSocket frame. So an immediate `refresh()` (which reads `player.position`) would render the **pre-seek** position for up to the periodic-refresh interval (~15s), and for a **paused** track it stayed stale indefinitely because the periodic `refresh_all` loop skips paused+connected players (`now_playing.py:237`) and paused players receive no `playerUpdate`.

The fix adds `now_playing.refresh_with_position(bot, guild_id, position_ms)`: like `refresh()` but it renders the controller with an explicit position override. `/seek` calls it with the `target_ms` it just sent, so the controller shows the correct progress immediately. Only the progress position is overridden — paused/connected state and queue depth still come from the live player, so the button row and title match a plain refresh. `refresh_with_position` is edit-only by construction (short-circuits to a no-op when no controller record exists, and always edits in place when one does), so it cannot create a duplicate controller; concurrent execution with the periodic loop collapses to redundant edits of the same `message_id` (last-write-wins) — no lock needed, and this race surface is pre-existing and identical to what `/pause`/`/resume` already exercise.

## What's in / what's out

In: `now_playing.refresh_with_position` (+ a `position_ms` override on the internal `_render_for_player`), the call from `src/ryzic/commands/seek.py` with `target_ms`, a regression test that asserts the rendered controller position equals the seek target, and a `FakePlayer.seek` fix to mirror the real lavalink client (it no longer sets `position` locally — which had been masking the bug).
Out: no change to `/skip` (already refreshes for free via `TrackStartEvent`), no new lock/mutex, no `FakeBot.rest` extension in the shared test helpers (the test attaches a local rest recorder). A pre-existing duplicate-controller race in `_post_or_edit` (affecting all callers, not just `/seek`) is tracked separately rather than folded in here.

## Test plan

- [x] `uv run pytest -q`
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run ty check`
- [ ] (if integration-relevant) `uv run pytest -q -m integration` — N/A: pure command-handler logic, mocked at module boundaries; no Lavalink/Docker dependency.
- [ ] CI on this PR — green

## Closes / refs

Closes #223