### PR TITLE
test(glue): pin #198 error-path intentional-disconnect marker clearing

### DIFF
--- a/tests/_command_helpers.py
+++ b/tests/_command_helpers.py
@@ -55,6 +55,11 @@ class FakeBot:
         self._me = FakeUser(bot_user_id)
         self.cache = FakeCache(states or {})
         self.update_voice_state_calls: list[tuple[int, int | None]] = []
+        # When set, update_voice_state raises this after recording the call.
+        # Repeatable — fires on every call until the test clears it — so a
+        # multi-call regression never silently turns a second failure into a
+        # no-op success. Default None keeps the historical no-op recorder.
+        self.update_voice_state_exc: BaseException | None = None
 
     def get_me(self) -> FakeUser:
         return self._me
@@ -66,7 +71,12 @@ class FakeBot:
         *,
         self_deaf: bool = False,
     ) -> None:
+        # Record before raising so tests can still assert the disconnect was
+        # attempted (matches real bot semantics: the call was made, then it
+        # failed).
         self.update_voice_state_calls.append((guild_id, channel_id))
+        if self.update_voice_state_exc is not None:
+            raise self.update_voice_state_exc
 
 
 class FakeLightbulbClient:

--- a/tests/test_lavalink_bridge.py
+++ b/tests/test_lavalink_bridge.py
@@ -45,6 +45,11 @@ class _FakeApp:
         self.created_messages: list[tuple[int, str]] = []
         self.voice_state_calls: list[tuple[int, int | None]] = []
         self._create_message_error = create_message_error
+        # When set, update_voice_state raises this after recording the call.
+        # Repeatable — fires on every call until the test clears it. Mirrors
+        # FakeBot (tests/_command_helpers.py); default None keeps the no-op
+        # recorder every existing bridge test relies on.
+        self.update_voice_state_exc: BaseException | None = None
 
     def get_me(self) -> _FakeOwnUser | None:
         return self._me
@@ -63,7 +68,12 @@ class _FakeApp:
         return None
 
     async def update_voice_state(self, guild_id: int, channel_id: int | None) -> None:
+        # Record before raising so tests can assert the disconnect was
+        # attempted (matches real bot semantics: the call was made, then
+        # it failed).
         self.voice_state_calls.append((guild_id, channel_id))
+        if self.update_voice_state_exc is not None:
+            raise self.update_voice_state_exc
 
 
 def _make_voice_server_event(
@@ -559,6 +569,25 @@ async def test_guild_leave_clears_per_guild_state() -> None:
     # The cancelled timer should settle.
     with pytest.raises(asyncio.CancelledError):
         await timer
+
+
+async def test_guild_leave_clears_intentional_disconnect_marker() -> None:
+    """_on_guild_leave drops any lingering intentional-disconnect marker.
+
+    This clear is NOT an except/error branch — it is unconditional per-guild
+    state cleanup, distinct from the try/except which wraps ``player_manager.destroy``.
+    Pinned regardless: a guild-leave
+    must not leak a marker that would suppress a later genuine voice_lost
+    broadcast if the bot re-joins. The existing
+    test_guild_leave_clears_per_guild_state never pre-sets the marker, so
+    this clear site was previously unpinned.
+    """
+    lavalink_glue.mark_intentional_disconnect(111)
+    assert 111 in lavalink_glue._pending_intentional_disconnects
+
+    await lavalink_glue._on_guild_leave(_make_guild_leave_event(111))
+
+    assert 111 not in lavalink_glue._pending_intentional_disconnects
 
 
 async def test_track_exception_strips_markdown_and_caps_length() -> None:
@@ -1819,6 +1848,47 @@ async def test_auto_leave_calls_teardown_player_session(
     await lavalink_glue._auto_leave(cast(hikari.GatewayBot, bot), guild_id, 45)
 
     assert teardown_calls == [guild_id]
+
+
+async def test_auto_leave_clears_intentional_disconnect_when_update_voice_state_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#198: a failed auto-leave disconnect clears the intentional-disconnect marker.
+
+    The except branch in _auto_leave clears the marker and logs; unlike
+    _handle_leave it does NOT re-raise. Without this
+    clear, a failed disconnect would leave a stale marker that suppresses a
+    later genuine voice_lost broadcast. _FakeApp.update_voice_state is a no-op
+    by default, so this path is unreachable without a raisable bot.
+    """
+    bot = _FakeApp()
+    guild_id = 111
+
+    class _ConnectedPlayer:
+        is_connected = True
+        queue: ClassVar[list[Any]] = []
+
+    class _ConnectedPlayerManager:
+        def get(self, gid: int) -> _ConnectedPlayer:
+            return _ConnectedPlayer()
+
+    class _ConnectedClient:
+        player_manager = _ConnectedPlayerManager()
+
+    lavalink_glue._set_lavalink_client_for_test(cast(lavalink.Client, _ConnectedClient()))
+
+    async def _spy_sleep(_: float) -> None:
+        return
+
+    monkeypatch.setattr(asyncio, "sleep", _spy_sleep)
+    bot.update_voice_state_exc = RuntimeError("auto-leave disconnect failed")
+
+    await lavalink_glue._auto_leave(cast(hikari.GatewayBot, bot), guild_id, 45)
+
+    # The disconnect attempt was recorded before the raise.
+    assert bot.voice_state_calls == [(guild_id, None)]
+    # #198 error-path: marker cleared by the except branch despite the raise.
+    assert guild_id not in lavalink_glue._pending_intentional_disconnects
 
 
 async def test_4014_after_auto_leave_is_noop_teardown() -> None:

--- a/tests/test_leave_command.py
+++ b/tests/test_leave_command.py
@@ -108,6 +108,37 @@ async def test_leave_stops_clears_disconnects_and_responds() -> None:
     assert "ephemeral" not in fake.responses[0][1]
 
 
+async def test_leave_clears_intentional_disconnect_when_update_voice_state_raises() -> None:
+    """#198: a failed /leave disconnect clears the intentional-disconnect marker.
+
+    The except branch in _handle_leave clears the marker then re-raises, so
+    a failed disconnect does not leave a stale
+    marker that would suppress a later genuine voice_lost broadcast. The
+    finally block still releases the explicit-leave guard on re-raise.
+    FakeBot.update_voice_state is a no-op by default, so this path is
+    unreachable without a raisable bot.
+    """
+    bot = both_in_voice()
+    ctx = context_for(bot)
+    ll = FakeLavalinkClient()
+    install_lavalink_client(ll)
+    player = ll.player_manager.create(guild_id=111)
+    player.is_connected = True
+    player.current = FakeAudioTrack(title="Now Playing")
+
+    bot.update_voice_state_exc = RuntimeError("voice-state update failed")
+
+    with pytest.raises(RuntimeError, match="voice-state update failed"):
+        await leave_module._handle_leave(ctx)
+
+    # The disconnect attempt was recorded before the raise.
+    assert bot.update_voice_state_calls == [(111, None)]
+    # #198 error-path: marker cleared by the except branch.
+    assert 111 not in lavalink_glue._pending_intentional_disconnects
+    # The finally block still released the explicit-leave guard on re-raise.
+    assert 111 not in lavalink_glue._explicit_leave_in_progress
+
+
 async def test_leave_calls_teardown_player_session(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

The #198 error-path `clear_intentional_disconnect` calls had no regression tests. The except branches around `update_voice_state` in `_handle_leave` (`commands/leave.py:67-69`) and `_auto_leave` (`lavalink_glue.py:260-262`), plus the `_on_guild_leave` clear (`lavalink_glue.py:725`), were unexercised because `FakeBot.update_voice_state` (and the parallel `_FakeApp` in `test_lavalink_bridge.py`) is a no-op that never raises — so a future refactor dropping one of these clears would pass silently.

This makes both bot fakes raisable via an injectable, repeatable exception attribute (`update_voice_state_exc`; default `None` preserves the no-op recorder every existing test relies on, and the call is recorded before raising so disconnect-attempt assertions still hold), then adds three regression tests — one per clear site. No production changes; coverage gap only.

## What's in / what's out

- **In:** raisable `FakeBot` + `_FakeApp` (injectable exception attribute, repeatable, record-before-raise) and three named regression tests pinning the three #198-region clear sites.
- **Out:** production/code changes — the clearing code was verified correct during the v0.6.0 review; this PR is coverage-only. Also out: caplog pinning of the `_auto_leave` `_log.exception` line (the marker-cleared assertion is load-bearing; caplog would couple to log format).
- **Note:** the `_on_guild_leave` clear at `lavalink_glue.py:725` is NOT an except/error branch — it is unconditional per-guild-state cleanup, distinct from the `try/except` at 734-740 which wraps `player.destroy`. Its test is happy-path pre-set/fire/assert; no raisable bot is involved. It was previously unpinned (the existing `test_guild_leave_clears_per_guild_state` never pre-sets the marker), so it is included here as cheap belt-and-suspenders.

## Test plan

- [x] `uv run pytest -q` — 620 passed (was 617; +3 new tests), 1 deselected
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] `uv run ty check` — clean
- [x] coverage: `commands/leave.py` 67-69 and `lavalink_glue.py` 260-262 now covered (were in the missing list)
- [ ] CI on this PR — green

## Closes / refs

Closes #217
